### PR TITLE
feat(models): implement TwitterTimestamp class

### DIFF
--- a/birdxplorer/models.py
+++ b/birdxplorer/models.py
@@ -1,6 +1,7 @@
+from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Type, TypeAlias, TypeVar
+from typing import Any, Literal, Type, TypeAlias, TypeVar, Union
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, Field, GetCoreSchemaHandler, TypeAdapter
@@ -9,6 +10,7 @@ from pydantic_core import core_schema
 
 IncEx: TypeAlias = "set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None"
 StrT = TypeVar("StrT", bound="BaseString")
+IntT = TypeVar("IntT", bound="BaseInt")
 
 
 class BaseString(str):
@@ -92,6 +94,130 @@ class UpperCased64DigitsHexadecimalString(BaseString):
         return dict(super().__get_extra_constraint_dict__(), pattern=r"^[0-9A-F]{64}$")
 
 
+class BaseInt(int):
+    """
+    >>> BaseInt(1)
+    BaseInt(1)
+    >>> int(BaseInt(1))
+    1
+    >>> ta = TypeAdapter(BaseInt)
+    >>> ta.validate_python(1)
+    BaseInt(1)
+    >>> ta.validate_python("1")
+    BaseInt(1)
+    >>> ta.dump_json(BaseInt(1))
+    b'1'
+    >>> BaseInt.from_int(1)
+    BaseInt(1)
+    >>> ta.validate_python(BaseInt.from_int(1))
+    BaseInt(1)
+    >>> hash(BaseInt(1)) == hash(1)
+    True
+    """
+
+    @classmethod
+    def _proc_int(cls, i: int) -> int:
+        return i
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({super().__repr__()})"
+
+    def __int__(self) -> int:
+        return super(BaseInt, self).__int__()
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls.validate,
+            core_schema.int_schema(**cls.__get_extra_constraint_dict__()),
+            serialization=core_schema.plain_serializer_function_ser_schema(cls.serialize, when_used="json"),
+        )
+
+    @classmethod
+    def validate(cls: Type[IntT], v: Any) -> IntT:
+        return cls(cls._proc_int(v))
+
+    def serialize(self) -> int:
+        return int(self)
+
+    @classmethod
+    def __get_extra_constraint_dict__(cls) -> dict[str, Any]:
+        return {}
+
+    def __hash__(self) -> int:
+        return super(BaseInt, self).__hash__()
+
+    @classmethod
+    def from_int(cls: Type[IntT], v: int) -> IntT:
+        return TypeAdapter(cls).validate_python(v)
+
+
+class BaseBoundedInt(BaseInt, ABC):
+    """
+    >>> class Under10NaturalNumber(BaseBoundedInt):
+    ...   @classmethod
+    ...   def max_value(cls) -> int:
+    ...     return 9
+    ...   @classmethod
+    ...   def min_value(cls) -> int:
+    ...     return 1
+    >>> Under10NaturalNumber.from_int(1)
+    Under10NaturalNumber(1)
+    >>> Under10NaturalNumber.from_int(0)
+    Traceback (most recent call last):
+     ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[validate(), constrained-int]
+      Input should be greater than or equal to 1 [type=greater_than_equal, input_value=0, input_type=int]
+     ...
+    >>> Under10NaturalNumber.from_int(10)
+    Traceback (most recent call last):
+     ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[validate(), constrained-int]
+      Input should be less than or equal to 9 [type=less_than_equal, input_value=10, input_type=int]
+     ...
+    """
+
+    @classmethod
+    @abstractmethod
+    def max_value(cls) -> int:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def min_value(cls) -> int:
+        raise NotImplementedError
+
+    @classmethod
+    def __get_extra_constraint_dict__(cls) -> dict[str, Any]:
+        return dict(super().__get_extra_constraint_dict__(), ge=cls.min_value(), le=cls.max_value())
+
+
+class TwitterTimestamp(BaseBoundedInt):
+    """
+    >>> TwitterTimestamp.from_int(1)
+    Traceback (most recent call last):
+     ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[validate(), constrained-int]
+      Input should be greater than or equal to 1152921600000 [type=greater_than_equal, input_value=1, input_type=int]
+     ...
+    >>> TwitterTimestamp.from_int(1288834974657)
+    TwitterTimestamp(1288834974657)
+    >>> TwitterTimestamp.from_int(int(datetime.now().timestamp() * 1000 + 24 * 60 * 60 * 1000))
+    Traceback (most recent call last):
+     ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[validate(), constrained-int]
+     ...
+    """
+
+    @classmethod
+    def max_value(cls) -> int:
+        return int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+    @classmethod
+    def min_value(cls) -> int:
+        return int(datetime(2006, 7, 15, 0, 0, 0, 0, timezone.utc).timestamp() * 1000)
+
+
 class BaseModel(PydanticBaseModel):
     """
     >>> from unittest.mock import patch
@@ -160,11 +286,14 @@ class EnrollmentState(str, Enum):
     earned_out_no_acknowledge = "earnedOutNoAcknowledge"
 
 
+UserEnrollmentLastStateChangeTimeStamp = Union[TwitterTimestamp, Literal["0"], Literal["103308100"]]
+
+
 class UserEnrollment(BaseModel):
     participant_id: ParticipantId
     enrollment_state: EnrollmentState
     successful_rating_needed_to_earn_in: str
-    timestamp_of_last_state_change: str
+    timestamp_of_last_state_change: UserEnrollmentLastStateChangeTimeStamp
     timestamp_of_last_earn_out: str
     modeling_population: str
     modeling_group: str
@@ -196,9 +325,6 @@ class NotesBelievable(str, Enum):
 class Note(BaseModel):
     note_id: NoteId
     note_author_participant_id: str = Field(pattern=r"^[0-9A-F]{64}$")
-    created_at_millis: int = Field(
-        gt=(int(datetime(2006, 7, 15, 0, 0, 0, 0, timezone.utc).timestamp() * 1000)),
-        lt=(int(datetime.now().timestamp() * 1000)),
-    )
+    created_at_millis: TwitterTimestamp
     tweet_id: str = Field(pattern=r"^[0-9]{9,19}$")
     believable: NotesBelievable


### PR DESCRIPTION
closes #8 
closes #20

制約を付けやすくした `int` 型である `BaseInt` クラスから、上限下限を付けやすくした型である `BaseBoundedInt` クラス (抽象クラスであり、classmethod の `max_value`, `min_value` を実装する必要があるため `Base` がついている) を派生させ、そこから `Twitter` サービス開始のタイムスタンプから現在までのタイムスタンプをそれぞれ下限上限に持つ `TwitterTimestamp` 型を派生させました。これが #8 の実装。
ついでに #20 も実装してしまったが、userEnrollment データに 2 レコードほど変なタイムスタンプ (0 と 103308100) が入っていたので、ヴァリデーションをバイパスするためユニオン型を作り部分的に許可する形にした。これが良かったかどうかは、出力側を作り込むまで不明なので、出力しようとして不都合発生したら直しましょう