### PR TITLE
/v1/data/posts に NoteId による絞り込みを追加する

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -92,11 +92,14 @@ def gen_router(storage: Storage) -> APIRouter:
     @router.get("/posts", response_model=PostListResponse)
     def get_posts(
         post_id: Union[List[PostId], None] = Query(default=None),
+        note_id: Union[List[NoteId], None] = Query(default=None),
         created_at_start: Union[None, TwitterTimestamp, str] = Query(default=None),
         created_at_end: Union[None, TwitterTimestamp, str] = Query(default=None),
     ) -> PostListResponse:
         if post_id is not None:
             return PostListResponse(data=list(storage.get_posts_by_ids(post_ids=post_id)))
+        if note_id is not None:
+            return PostListResponse(data=list(storage.get_posts_by_note_ids(note_ids=note_id)))
         if created_at_start is not None:
             if created_at_end is not None:
                 return PostListResponse(

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -262,6 +262,15 @@ def mock_storage(
 
     mock.get_posts_by_ids.side_effect = _get_posts_by_ids
 
+    def _get_posts_by_note_ids(note_ids: List[NoteId]) -> Generator[Post, None, None]:
+        for post in post_samples:
+            for note in note_samples:
+                if note.note_id in note_ids and post.post_id == note.post_id:
+                    yield post
+                    break
+
+    mock.get_posts_by_note_ids.side_effect = _get_posts_by_note_ids
+
     def _get_posts_by_created_at_range(start: TwitterTimestamp, end: TwitterTimestamp) -> Generator[Post, None, None]:
         for post in post_samples:
             if start <= post.created_at < end:

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -39,6 +39,13 @@ def test_posts_get_has_post_id_filter(client: TestClient, post_samples: List[Pos
     }
 
 
+def test_posts_get_has_note_id_filter(client: TestClient, post_samples: List[Post], note_samples: List[Note]) -> None:
+    response = client.get(f"/api/v1/data/posts/?noteId={','.join([n.note_id for n in note_samples])}")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert res_json == {"data": [json.loads(post_samples[0].model_dump_json())]}
+
+
 def test_posts_get_has_created_at_filter_start_and_end(client: TestClient, post_samples: List[Post]) -> None:
     response = client.get("/api/v1/data/posts/?createdAtStart=2006-7-25 00:00:00&createdAtEnd=2006-7-30 23:59:59")
     assert response.status_code == 200

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -296,6 +296,16 @@ class Storage:
             for post_record in sess.query(PostRecord).filter(PostRecord.created_at < end).all():
                 yield self._post_record_to_model(post_record)
 
+    def get_posts_by_note_ids(self, note_ids: List[NoteId]) -> Generator[PostModel, None, None]:
+        query = (
+            select(PostRecord)
+            .join(NoteRecord, NoteRecord.post_id == PostRecord.post_id)
+            .where(NoteRecord.note_id.in_(note_ids))
+        )
+        with Session(self.engine) as sess:
+            for post_record in sess.execute(query).scalars().all():
+                yield self._post_record_to_model(post_record)
+
 
 def gen_storage(settings: GlobalSettings) -> Storage:
     engine = create_engine(settings.storage_settings.sqlalchemy_database_url)


### PR DESCRIPTION
## やりたいこと
`GET /v1/data/posts` に `note_id` を渡す(複数可)ことで、
コミュニティノートに関連するポストを逆引きできるようにする

closes #51

## やったこと
- dd8fa2fbbd675574488d1dbe5da46e856958846b NoteIdによる絞り込みの追加
- 776d0d1b27609245480fa812a3ae5506af83a7f0 テストの追加

## やらなかったこと
[conftest.py](https://github.com/codeforjapan/BirdXplorer/blob/776d0d1b27609245480fa812a3ae5506af83a7f0/api/tests/conftest.py#L268)で mypy の error が出ているのを治す

```
tests/conftest.py:268: error: Non-overlapping equality check (left operand type: "PostId", right operand type: "TweetId")  [comparison-overlap]
Found 1 error in 1 file (checked 7 source files)
py310: exit 1 (0.88 seconds) /Users/sushi/cfj/BirdXplorer/api> mypy tests --strict pid=82134
  py310: FAIL code 1 (4.06=setup[0.04]+cmd[0.22,0.08,1.79,0.25,0.80,0.88] seconds)
  evaluation failed :( (4.24 seconds)
```

これは `post.post_id`が`PostId`、`note.post_id`が`TweetId`であり異なるクラス間で等価比較をしているのが原因
`TweetId`に統一してしまいたい
→ 起票済み #84