### PR TITLE
fix: mypy ignore statement

### DIFF
--- a/common/birdxplorer_common/settings.py
+++ b/common/birdxplorer_common/settings.py
@@ -18,7 +18,7 @@ class PostgresStorageSettings(BaseSettings):
     port: int = 5432
     database: str = "postgres"
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def sqlalchemy_database_url(self) -> str:
         return PostgresDsn(


### PR DESCRIPTION
## やりたいこと

closes #83 

mypy v1.11 のリリースに伴って型エラーが出るようになったので治す

## やったこと
- 4cce8c8a22d0030bb2cf3be1f8bbef350aa1384d `type:ignore` の修正