### PR TITLE
Post.link を computed fieldにする

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -132,9 +132,6 @@ def gen_router(storage: Storage) -> APIRouter:
             search_url=search_url,
         )
 
-        for post in posts:
-            post.link = HttpUrl(f"https://x.com/{post.x_user.name}/status/{post.post_id}")
-
         base_url = str(request.url).split("?")[0]
         next_offset = offset + limit
         prev_offset = max(offset - limit, 0)

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -15,11 +15,14 @@ from typing import (
     Union,
 )
 from uuid import UUID
+from typing import Annotated, Any, Dict, List, Literal, Optional, Type, TypeAlias, TypeVar, Union
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict
 from pydantic import Field as PydanticField
 from pydantic import GetCoreSchemaHandler, HttpUrl, TypeAdapter, model_validator
+from pydantic import BaseModel as PydanticBaseModel, Field as PydanticField
+from pydantic import ConfigDict, GetCoreSchemaHandler, HttpUrl, TypeAdapter
 from pydantic.alias_generators import to_camel
 from pydantic.main import IncEx
 from pydantic_core import core_schema

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict
 from pydantic import Field as PydanticField
-from pydantic import GetCoreSchemaHandler, HttpUrl, TypeAdapter, model_validator
+from pydantic import GetCoreSchemaHandler, HttpUrl, TypeAdapter, model_validator, computed_field
 from pydantic.alias_generators import to_camel
 from pydantic.main import IncEx
 from pydantic_core import core_schema
@@ -770,7 +770,6 @@ class Link(BaseModel):
 
 class Post(BaseModel):
     post_id: PostId
-    link: Optional[HttpUrl] = None
     x_user_id: UserId
     x_user: XUser
     text: str
@@ -780,6 +779,29 @@ class Post(BaseModel):
     repost_count: NonNegativeInt
     impression_count: NonNegativeInt
     links: List[Link] = []
+
+    @property
+    @computed_field
+    def link(self) -> HttpUrl:
+        """
+        PostのX上でのURLを返す。
+
+        Examples
+        --------
+        >>> post = Post(post_id="1234567890123456789",
+                        x_user_id="1234567890123456789",
+                        x_user=XUser(user_id="1234567890123456789",
+                                     name="test",
+                                     profile_image="https://x.com/test"),
+                        text="test",
+                        created_at=1288834974657,
+                        like_count=1,
+                        repost_count=1,
+                        impression_count=1)
+        >>> post.link
+        HttpUrl('https://x.com/test/status/1234567890123456789')
+        """
+        return HttpUrl(f"https://x.com/{self.x_user.name}/status/{self.post_id}")
 
 
 class PaginationMeta(BaseModel):

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -15,14 +15,11 @@ from typing import (
     Union,
 )
 from uuid import UUID
-from typing import Annotated, Any, Dict, List, Literal, Optional, Type, TypeAlias, TypeVar, Union
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict
 from pydantic import Field as PydanticField
 from pydantic import GetCoreSchemaHandler, HttpUrl, TypeAdapter, model_validator
-from pydantic import BaseModel as PydanticBaseModel, Field as PydanticField
-from pydantic import ConfigDict, GetCoreSchemaHandler, HttpUrl, TypeAdapter
 from pydantic.alias_generators import to_camel
 from pydantic.main import IncEx
 from pydantic_core import core_schema

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -7,15 +7,20 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 from sqlalchemy.types import CHAR, DECIMAL, JSON, Integer, String, Uuid
 
-from .models import BinaryBool, LanguageIdentifier
-from .models import Link as LinkModel
-from .models import LinkId, Media, MediaDetails, MediaType, NonNegativeInt
-from .models import Note as NoteModel
-from .models import NoteId, NotesClassification, NotesHarmful, ParticipantId
-from .models import Post as PostModel
-from .models import PostId, SummaryString
-from .models import Topic as TopicModel
 from .models import (
+    BinaryBool,
+    LanguageIdentifier,
+    LinkId,
+    Media,
+    MediaDetails,
+    MediaType,
+    NonNegativeInt,
+    NoteId,
+    NotesClassification,
+    NotesHarmful,
+    ParticipantId,
+    PostId,
+    SummaryString,
     TopicId,
     TopicLabel,
     TwitterTimestamp,
@@ -23,6 +28,10 @@ from .models import (
     UserId,
     UserName,
 )
+from .models import Link as LinkModel
+from .models import Note as NoteModel
+from .models import Post as PostModel
+from .models import Topic as TopicModel
 from .models import XUser as XUserModel
 from .settings import GlobalSettings
 

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -7,20 +7,15 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 from sqlalchemy.types import CHAR, DECIMAL, JSON, Integer, String, Uuid
 
+from .models import BinaryBool, LanguageIdentifier
+from .models import Link as LinkModel
+from .models import LinkId, Media, MediaDetails, MediaType, NonNegativeInt
+from .models import Note as NoteModel
+from .models import NoteId, NotesClassification, NotesHarmful, ParticipantId
+from .models import Post as PostModel
+from .models import PostId, SummaryString
+from .models import Topic as TopicModel
 from .models import (
-    BinaryBool,
-    LanguageIdentifier,
-    LinkId,
-    Media,
-    MediaDetails,
-    MediaType,
-    NonNegativeInt,
-    NoteId,
-    NotesClassification,
-    NotesHarmful,
-    ParticipantId,
-    PostId,
-    SummaryString,
     TopicId,
     TopicLabel,
     TwitterTimestamp,
@@ -28,10 +23,6 @@ from .models import (
     UserId,
     UserName,
 )
-from .models import Link as LinkModel
-from .models import Note as NoteModel
-from .models import Post as PostModel
-from .models import Topic as TopicModel
 from .models import XUser as XUserModel
 from .settings import GlobalSettings
 

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -267,7 +267,6 @@ def post_samples(
     posts = [
         post_factory.build(
             post_id="2234567890123456781",
-            link=None,
             x_user_id="1234567890123456781",
             x_user=x_user_samples[0],
             text="""\
@@ -283,7 +282,6 @@ https://t.co/xxxxxxxxxxx/ #プロジェクト #新発売 #Tech""",
         ),
         post_factory.build(
             post_id="2234567890123456791",
-            link=None,
             x_user_id="1234567890123456781",
             x_user=x_user_samples[0],
             text="""\
@@ -299,7 +297,6 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
         ),
         post_factory.build(
             post_id="2234567890123456801",
-            link=None,
             x_user_id="1234567890123456782",
             x_user=x_user_samples[1],
             text="""\


### PR DESCRIPTION
## Outline
closes #113 
Post.linkは他のプロパティから自明に計算できる値であるため、 手動で設定せず Pydantic に計算させた方が安全

## 実装詳細
- Post.link を computed fieldに変更した
  - あわせて一部既存のテストデータを修正した