### PR TITLE
Feat/issue 105 posts url search

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -101,6 +101,7 @@ def gen_router(storage: Storage) -> APIRouter:
         offset: int = Query(default=0, ge=0),
         limit: int = Query(default=100, gt=0, le=1000),
         search_text: Union[None, str] = Query(default=None),
+        search_url: Union[None, HttpUrl] = Query(default=None),
     ) -> PostListResponse:
         if created_at_from is not None and isinstance(created_at_from, str):
             created_at_from = ensure_twitter_timestamp(created_at_from)
@@ -113,6 +114,7 @@ def gen_router(storage: Storage) -> APIRouter:
                 start=created_at_from,
                 end=created_at_to,
                 search_text=search_text,
+                search_url=search_url,
                 offset=offset,
                 limit=limit,
             )
@@ -123,6 +125,7 @@ def gen_router(storage: Storage) -> APIRouter:
             start=created_at_from,
             end=created_at_to,
             search_text=search_text,
+            search_url=search_url,
         )
 
         for post in posts:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -14,6 +14,7 @@ from pytest import fixture
 from birdxplorer_common.exceptions import UserEnrollmentNotFoundError
 from birdxplorer_common.models import (
     LanguageIdentifier,
+    Link,
     Note,
     NoteId,
     ParticipantId,
@@ -66,6 +67,11 @@ class PostFactory(ModelFactory[Post]):
     __model__ = Post
 
 
+@register_fixture(name="link_factory")
+class LinkFactory(ModelFactory[Link]):
+    __model__ = Link
+
+
 @fixture
 def user_enrollment_samples(
     user_enrollment_factory: UserEnrollmentFactory,
@@ -82,6 +88,17 @@ def topic_samples(topic_factory: TopicFactory) -> Generator[List[Topic], None, N
         topic_factory.build(topic_id=3, label={"en": "topic3", "ja": "トピック3"}, reference_count=0),
     ]
     yield topics
+
+
+@fixture
+def link_samples(link_factory: LinkFactory) -> Generator[List[Link], None, None]:
+    links = [
+        link_factory.build(link_id="9f56ee4a-6b36-b79c-d6ca-67865e54bbd5", url="https://example.com/sh0"),
+        link_factory.build(link_id="f5b0ac79-20fe-9718-4a40-6030bb62d156", url="https://example.com/sh1"),
+        link_factory.build(link_id="76a0ac4a-a20c-b1f4-1906-d00e2e8f8bf8", url="https://example.com/sh2"),
+        link_factory.build(link_id="6c352be8-eca3-0d96-55bf-a9bbef1c0fc2", url="https://example.com/sh3"),
+    ]
+    yield links
 
 
 @fixture
@@ -160,10 +177,13 @@ def x_user_samples(x_user_factory: XUserFactory) -> Generator[List[XUser], None,
 
 
 @fixture
-def post_samples(post_factory: PostFactory, x_user_samples: List[XUser]) -> Generator[List[Post], None, None]:
+def post_samples(
+    post_factory: PostFactory, x_user_samples: List[XUser], link_samples: List[Link]
+) -> Generator[List[Post], None, None]:
     posts = [
         post_factory.build(
             post_id="2234567890123456781",
+            link=None,
             x_user_id="1234567890123456781",
             x_user=x_user_samples[0],
             text="""\
@@ -175,9 +195,11 @@ https://t.co/xxxxxxxxxxx/ #プロジェクト #新発売 #Tech""",
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[0]],
         ),
         post_factory.build(
             post_id="2234567890123456791",
+            link=None,
             x_user_id="1234567890123456781",
             x_user=x_user_samples[0],
             text="""\
@@ -189,18 +211,47 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[1]],
         ),
         post_factory.build(
             post_id="2234567890123456801",
+            link=None,
             x_user_id="1234567890123456782",
             x_user=x_user_samples[1],
             text="""\
-次の休暇はここに決めた！🌴🏖️ 見てみて～ https://t.co/xxxxxxxxxxx/ #旅行 #バケーション""",
+次の休暇はここに決めた！🌴🏖️ 見てみて～ https://t.co/xxxxxxxxxxx/ https://t.co/wwwwwwwwwww/ #旅行 #バケーション""",
             media_details=None,
             created_at=1154921800000,
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[0], link_samples[3]],
+        ),
+        post_factory.build(
+            post_id="2234567890123456811",
+            link=None,
+            x_user_id="1234567890123456782",
+            x_user=x_user_samples[1],
+            text="https://t.co/zzzzzzzzzzz/ https://t.co/wwwwwwwwwww/",
+            media_details=None,
+            created_at=1154922900000,
+            like_count=10,
+            repost_count=20,
+            impression_count=30,
+            links=[link_samples[2], link_samples[3]],
+        ),
+        post_factory.build(
+            post_id="2234567890123456821",
+            link=None,
+            x_user_id="1234567890123456783",
+            x_user=x_user_samples[2],
+            text="empty",
+            media_details=None,
+            created_at=1154923900000,
+            like_count=10,
+            repost_count=20,
+            impression_count=30,
+            links=[],
         ),
     ]
     yield posts

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -356,7 +356,7 @@ def mock_storage(
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
-        search_url: Union[str, None] = None,
+        search_url: Union[HttpUrl, None] = None,
     ) -> int:
         return len(list(_get_posts(post_ids, note_ids, start, end, search_text, search_url)))
 

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -132,6 +132,16 @@ def test_posts_search_by_text(client: TestClient, post_samples: List[Post]) -> N
     }
 
 
+def test_posts_search_by_url(client: TestClient, post_samples: List[Post]) -> None:
+    response = client.get("/api/v1/data/posts/?searchUrl=https%3A%2F%2Fexample.com%2Fsh3")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert res_json == {
+        "data": [json.loads(post_samples[i].model_dump_json()) for i in (2, 3)],
+        "meta": {"next": None, "prev": None},
+    }
+
+
 def test_notes_get(client: TestClient, note_samples: List[Note]) -> None:
     response = client.get("/api/v1/data/notes")
     assert response.status_code == 200

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -36,7 +36,10 @@ def test_posts_get_limit_and_offset(client: TestClient, post_samples: List[Post]
     res_json = response.json()
     assert res_json == {
         "data": [json.loads(d.model_dump_json()) for d in post_samples[1:3]],
-        "meta": {"next": None, "prev": "http://testserver/api/v1/data/posts?offset=0&limit=2"},
+        "meta": {
+            "next": "http://testserver/api/v1/data/posts?offset=3&limit=2",
+            "prev": "http://testserver/api/v1/data/posts?offset=0&limit=2",
+        },
     }
 
 
@@ -72,7 +75,7 @@ def test_posts_get_has_created_at_filter_start(client: TestClient, post_samples:
     assert response.status_code == 200
     res_json = response.json()
     assert res_json == {
-        "data": [json.loads(post_samples[i].model_dump_json()) for i in (1, 2)],
+        "data": [json.loads(post_samples[i].model_dump_json()) for i in (1, 2, 3, 4)],
         "meta": {"next": None, "prev": None},
     }
 
@@ -99,7 +102,7 @@ def test_posts_get_created_at_start_filter_accepts_integer(client: TestClient, p
     assert response.status_code == 200
     res_json = response.json()
     assert res_json == {
-        "data": [json.loads(post_samples[i].model_dump_json()) for i in (1, 2)],
+        "data": [json.loads(post_samples[i].model_dump_json()) for i in (1, 2, 3, 4)],
         "meta": {"next": None, "prev": None},
     }
 

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List, Literal, Optional, Type, TypeAlias, TypeVar,
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, GetCoreSchemaHandler, HttpUrl, TypeAdapter
 from pydantic.alias_generators import to_camel
+from pydantic.main import IncEx
 from pydantic_core import core_schema
 
-IncEx: TypeAlias = "set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None"
 StrT = TypeVar("StrT", bound="BaseString")
 IntT = TypeVar("IntT", bound="BaseInt")
 FloatT = TypeVar("FloatT", bound="BaseFloat")
@@ -467,8 +467,8 @@ class BaseModel(PydanticBaseModel):
         self,
         *,
         indent: int | None = None,
-        include: IncEx = None,
-        exclude: IncEx = None,
+        include: IncEx | None = None,
+        exclude: IncEx | None = None,
         context: Dict[str, Any] | None = None,
         by_alias: bool = True,
         exclude_unset: bool = False,

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -677,6 +677,26 @@ class XUser(BaseModel):
 MediaDetails: TypeAlias = List[HttpUrl] | None
 
 
+class LinkId(NonNegativeInt):
+    """
+    >>> LinkId.from_int(1)
+    LinkId(1)
+    """
+
+    pass
+
+
+class Link(BaseModel):
+    """
+    >>> Link.model_validate_json('{"linkId": 1, "canonicalUrl": "https://example.com", "shortUrl": "https://example.com/short"}')
+    Link(link_id=LinkId(1), canonical_url=Url('https://example.com/'), short_url=Url('https://example.com/short'))
+    """  # noqa: E501
+
+    link_id: LinkId
+    canonical_url: HttpUrl
+    short_url: HttpUrl
+
+
 class Post(BaseModel):
     post_id: PostId
     link: Optional[HttpUrl] = None
@@ -688,6 +708,7 @@ class Post(BaseModel):
     like_count: NonNegativeInt
     repost_count: NonNegativeInt
     impression_count: NonNegativeInt
+    links: List[Link] = []
 
 
 class PaginationMeta(BaseModel):

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -1,10 +1,18 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
+from random import Random
 from typing import Any, Dict, List, Literal, Optional, Type, TypeAlias, TypeVar, Union
+from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ConfigDict, GetCoreSchemaHandler, HttpUrl, TypeAdapter
+from pydantic import (
+    ConfigDict,
+    GetCoreSchemaHandler,
+    HttpUrl,
+    TypeAdapter,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 from pydantic.main import IncEx
 from pydantic_core import core_schema
@@ -677,24 +685,66 @@ class XUser(BaseModel):
 MediaDetails: TypeAlias = List[HttpUrl] | None
 
 
-class LinkId(NonNegativeInt):
+class LinkId(UUID):
     """
-    >>> LinkId.from_int(1)
-    LinkId(1)
+    >>> LinkId("53dc4ed6-fc9b-54ef-1afa-90f1125098c5")
+    LinkId('53dc4ed6-fc9b-54ef-1afa-90f1125098c5')
+    >>> LinkId(UUID("53dc4ed6-fc9b-54ef-1afa-90f1125098c5"))
+    LinkId('53dc4ed6-fc9b-54ef-1afa-90f1125098c5')
     """
 
-    pass
+    def __init__(
+        self,
+        hex: str | None = None,
+        int: int | None = None,
+    ) -> None:
+        if isinstance(hex, UUID):
+            hex = str(hex)
+        super().__init__(hex, int=int)
+
+    @classmethod
+    def from_url(cls, url: HttpUrl) -> "LinkId":
+        """
+        >>> LinkId.from_url("https://example.com/")
+        LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6')
+        """
+        random_number_generator = Random()
+        random_number_generator.seed(str(url).encode("utf-8"))
+        return LinkId(int=random_number_generator.getrandbits(128))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.no_info_plain_validator_function(
+            cls.validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(cls.serialize, when_used="json"),
+        )
+
+    @classmethod
+    def validate(cls, v: Any) -> "LinkId":
+        return cls(v)
+
+    def serialize(self) -> str:
+        return str(self)
 
 
 class Link(BaseModel):
     """
-    >>> Link.model_validate_json('{"linkId": 1, "canonicalUrl": "https://example.com", "shortUrl": "https://example.com/short"}')
-    Link(link_id=LinkId(1), canonical_url=Url('https://example.com/'), short_url=Url('https://example.com/short'))
+    >>> Link.model_validate_json('{"linkId": "d5d15194-6574-0c01-8f6f-15abd72b2cf6", "url": "https://example.com"}')
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=Url('https://example.com/'))
+    >>> Link(url="https://example.com/")
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=Url('https://example.com/'))
+    >>> Link(link_id=UUID("d5d15194-6574-0c01-8f6f-15abd72b2cf6"), url="https://example.com/")
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=Url('https://example.com/'))
     """  # noqa: E501
 
     link_id: LinkId
-    canonical_url: HttpUrl
-    short_url: HttpUrl
+    url: HttpUrl
+
+    @model_validator(mode="before")
+    def validate_link_id(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if "link_id" not in values:
+            values["link_id"] = LinkId.from_url(values["url"])
+        return values
 
 
 class Post(BaseModel):

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -295,6 +295,7 @@ class Storage:
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
+        search_url: Union[HttpUrl, None] = None,
         offset: Union[int, None] = None,
         limit: int = 100,
     ) -> Generator[PostModel, None, None]:
@@ -312,6 +313,12 @@ class Storage:
                 query = query.filter(PostRecord.created_at < end)
             if search_text is not None:
                 query = query.filter(PostRecord.text.like(f"%{search_text}%"))
+            if search_url is not None:
+                query = (
+                    query.join(PostLinkAssociation, PostLinkAssociation.post_id == PostRecord.post_id)
+                    .join(LinkRecord, LinkRecord.link_id == PostLinkAssociation.link_id)
+                    .filter(LinkRecord.url == search_url)
+                )
             if offset is not None:
                 query = query.offset(offset)
             query = query.limit(limit)
@@ -325,6 +332,7 @@ class Storage:
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
+        search_url: Union[HttpUrl, None] = None,
     ) -> int:
         with Session(self.engine) as sess:
             query = sess.query(PostRecord)
@@ -340,6 +348,12 @@ class Storage:
                 query = query.filter(PostRecord.created_at < end)
             if search_text is not None:
                 query = query.filter(PostRecord.text.like(f"%{search_text}%"))
+            if search_url is not None:
+                query = (
+                    query.join(PostLinkAssociation, PostLinkAssociation.post_id == PostRecord.post_id)
+                    .join(LinkRecord, LinkRecord.link_id == PostLinkAssociation.link_id)
+                    .filter(LinkRecord.url == search_url)
+                )
             return query.count()
 
 

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 from sqlalchemy.types import CHAR, DECIMAL, JSON, Integer, String
 
-from .models import BinaryBool, LanguageIdentifier, MediaDetails, NonNegativeInt
+from .models import BinaryBool, LanguageIdentifier, LinkId, MediaDetails, NonNegativeInt
 from .models import Note as NoteModel
 from .models import NoteId, NotesClassification, NotesHarmful, ParticipantId
 from .models import Post as PostModel
@@ -34,6 +34,7 @@ register_adapter(AnyUrl, adapt_pydantic_http_url)
 
 class Base(DeclarativeBase):
     type_annotation_map = {
+        LinkId: Integer,
         TopicId: Integer,
         TopicLabel: JSON,
         NoteId: String,
@@ -88,6 +89,14 @@ class XUserRecord(Base):
     following_count: Mapped[NonNegativeInt] = mapped_column(nullable=False)
 
 
+class LinkRecord(Base):
+    __tablename__ = "links"
+
+    link_id: Mapped[LinkId] = mapped_column(primary_key=True)
+    canonical_url: Mapped[HttpUrl] = mapped_column(nullable=False, index=True)
+    short_url: Mapped[HttpUrl] = mapped_column(nullable=False, index=True)
+
+
 class PostRecord(Base):
     __tablename__ = "posts"
 
@@ -100,6 +109,14 @@ class PostRecord(Base):
     like_count: Mapped[NonNegativeInt] = mapped_column(nullable=False)
     repost_count: Mapped[NonNegativeInt] = mapped_column(nullable=False)
     impression_count: Mapped[NonNegativeInt] = mapped_column(nullable=False)
+
+
+class PostLinkAssociation(Base):
+    __tablename__ = "post_link"
+
+    post_id: Mapped[PostId] = mapped_column(ForeignKey("posts.post_id"), primary_key=True)
+    link_id: Mapped[LinkId] = mapped_column(ForeignKey("links.link_id"), primary_key=True)
+    link: Mapped["LinkRecord"] = relationship()
 
 
 class RowNoteRecord(Base):

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "sqlalchemy",
     "pydantic_settings",
     "JSON-log-formatter",
+    "ulid-py",
 ]
 
 [project.urls]

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from birdxplorer_common.models import (
+    Link,
     Note,
     Post,
     Topic,
@@ -99,6 +100,11 @@ class PostFactory(ModelFactory[Post]):
     __model__ = Post
 
 
+@register_fixture(name="link_factory")
+class LinkFactory(ModelFactory[Link]):
+    __model__ = Link
+
+
 @fixture
 def user_enrollment_samples(
     user_enrollment_factory: UserEnrollmentFactory,
@@ -115,6 +121,17 @@ def topic_samples(topic_factory: TopicFactory) -> Generator[List[Topic], None, N
         topic_factory.build(topic_id=3, label={"en": "topic3", "ja": "トピック3"}, reference_count=0),
     ]
     yield topics
+
+
+@fixture
+def link_samples(link_factory: LinkFactory) -> Generator[List[Link], None, None]:
+    links = [
+        link_factory.build(link_id=0, canonical_url="https://t.co/xxxxxxxxxxx/", short_url="https://example.com/sh0"),
+        link_factory.build(link_id=1, canonical_url="https://t.co/yyyyyyyyyyy/", short_url="https://example.com/sh1"),
+        link_factory.build(link_id=2, canonical_url="https://t.co/zzzzzzzzzzz/", short_url="https://example.com/sh2"),
+        link_factory.build(link_id=3, canonical_url="https://t.co/wwwwwwwwwww/", short_url="https://example.com/sh3"),
+    ]
+    yield links
 
 
 @fixture
@@ -201,7 +218,9 @@ def x_user_samples(x_user_factory: XUserFactory) -> Generator[List[XUser], None,
 
 
 @fixture
-def post_samples(post_factory: PostFactory, x_user_samples: List[XUser]) -> Generator[List[Post], None, None]:
+def post_samples(
+    post_factory: PostFactory, x_user_samples: List[XUser], link_samples: List[Link]
+) -> Generator[List[Post], None, None]:
     posts = [
         post_factory.build(
             post_id="2234567890123456781",
@@ -217,6 +236,7 @@ https://t.co/xxxxxxxxxxx/ #プロジェクト #新発売 #Tech""",
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[0]],
         ),
         post_factory.build(
             post_id="2234567890123456791",
@@ -232,6 +252,7 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[1]],
         ),
         post_factory.build(
             post_id="2234567890123456801",
@@ -239,12 +260,26 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
             x_user_id="1234567890123456782",
             x_user=x_user_samples[1],
             text="""\
-次の休暇はここに決めた！🌴🏖️ 見てみて～ https://t.co/xxxxxxxxxxx/ #旅行 #バケーション""",
+次の休暇はここに決めた！🌴🏖️ 見てみて～ https://t.co/xxxxxxxxxxx/ https://t.co/wwwwwwwwwww/ #旅行 #バケーション""",
             media_details=None,
             created_at=1154921800000,
             like_count=10,
             repost_count=20,
             impression_count=30,
+            links=[link_samples[0], link_samples[3]],
+        ),
+        post_factory.build(
+            post_id="2234567890123456811",
+            link=None,
+            x_user_id="1234567890123456782",
+            x_user=x_user_samples[1],
+            text="https://t.co/zzzzzzzzzzz/ https://t.co/wwwwwwwwwww/",
+            media_details=None,
+            created_at=1154922900000,
+            like_count=10,
+            repost_count=20,
+            impression_count=30,
+            links=[link_samples[2], link_samples[3]],
         ),
     ]
     yield posts

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -128,10 +128,10 @@ def topic_samples(topic_factory: TopicFactory) -> Generator[List[Topic], None, N
 @fixture
 def link_samples(link_factory: LinkFactory) -> Generator[List[Link], None, None]:
     links = [
-        link_factory.build(link_id=0, canonical_url="https://t.co/xxxxxxxxxxx/", short_url="https://example.com/sh0"),
-        link_factory.build(link_id=1, canonical_url="https://t.co/yyyyyyyyyyy/", short_url="https://example.com/sh1"),
-        link_factory.build(link_id=2, canonical_url="https://t.co/zzzzzzzzzzz/", short_url="https://example.com/sh2"),
-        link_factory.build(link_id=3, canonical_url="https://t.co/wwwwwwwwwww/", short_url="https://example.com/sh3"),
+        link_factory.build(link_id="9f56ee4a-6b36-b79c-d6ca-67865e54bbd5", url="https://example.com/sh0"),
+        link_factory.build(link_id="f5b0ac79-20fe-9718-4a40-6030bb62d156", url="https://example.com/sh1"),
+        link_factory.build(link_id="76a0ac4a-a20c-b1f4-1906-d00e2e8f8bf8", url="https://example.com/sh2"),
+        link_factory.build(link_id="6c352be8-eca3-0d96-55bf-a9bbef1c0fc2", url="https://example.com/sh3"),
     ]
     yield links
 
@@ -416,7 +416,7 @@ def link_records_sample(
     link_samples: List[Link],
     engine_for_test: Engine,
 ) -> Generator[List[LinkRecord], None, None]:
-    res = [LinkRecord(link_id=d.link_id, canonical_url=d.canonical_url, short_url=d.short_url) for d in link_samples]
+    res = [LinkRecord(link_id=d.link_id, url=d.url) for d in link_samples]
     with Session(engine_for_test) as sess:
         sess.add_all(res)
         sess.commit()

--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -281,6 +281,19 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
             impression_count=30,
             links=[link_samples[2], link_samples[3]],
         ),
+        post_factory.build(
+            post_id="2234567890123456821",
+            link=None,
+            x_user_id="1234567890123456783",
+            x_user=x_user_samples[2],
+            text="empty",
+            media_details=None,
+            created_at=1154923900000,
+            like_count=10,
+            repost_count=20,
+            impression_count=30,
+            links=[],
+        ),
     ]
     yield posts
 

--- a/common/tests/test_storage.py
+++ b/common/tests/test_storage.py
@@ -31,14 +31,14 @@ def test_get_topic_list(
 @pytest.mark.parametrize(
     ["filter_args", "expected_indices"],
     [
-        [dict(), [0, 1, 2, 3]],
-        [dict(offset=1), [1, 2, 3]],
+        [dict(), [0, 1, 2, 3, 4]],
+        [dict(offset=1), [1, 2, 3, 4]],
         [dict(limit=1), [0]],
         [dict(offset=1, limit=1), [1]],
         [dict(post_ids=[PostId.from_str("2234567890123456781"), PostId.from_str("2234567890123456801")]), [0, 2]],
         [dict(post_ids=[]), []],
         [dict(start=TwitterTimestamp.from_int(1153921700000), end=TwitterTimestamp.from_int(1153921800000)), [1]],
-        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2]],
+        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3, 4]],
         [dict(end=TwitterTimestamp.from_int(1153921700000)), [0]],
         [dict(search_text="https://t.co/xxxxxxxxxxx/"), [0, 2]],
         [dict(note_ids=[NoteId.from_str("1234567890123456781")]), [0]],
@@ -63,11 +63,11 @@ def test_get_post(
 @pytest.mark.parametrize(
     ["filter_args", "expected_indices"],
     [
-        [dict(), [0, 1, 2, 3]],
+        [dict(), [0, 1, 2, 3, 4]],
         [dict(post_ids=[PostId.from_str("2234567890123456781"), PostId.from_str("2234567890123456801")]), [0, 2]],
         [dict(post_ids=[]), []],
         [dict(start=TwitterTimestamp.from_int(1153921700000), end=TwitterTimestamp.from_int(1153921800000)), [1]],
-        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3]],
+        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3, 4]],
         [dict(end=TwitterTimestamp.from_int(1153921700000)), [0]],
         [dict(search_text="https://t.co/xxxxxxxxxxx/"), [0, 2]],
         [dict(note_ids=[NoteId.from_str("1234567890123456781")]), [0]],

--- a/common/tests/test_storage.py
+++ b/common/tests/test_storage.py
@@ -31,8 +31,8 @@ def test_get_topic_list(
 @pytest.mark.parametrize(
     ["filter_args", "expected_indices"],
     [
-        [dict(), [0, 1, 2]],
-        [dict(offset=1), [1, 2]],
+        [dict(), [0, 1, 2, 3]],
+        [dict(offset=1), [1, 2, 3]],
         [dict(limit=1), [0]],
         [dict(offset=1, limit=1), [1]],
         [dict(post_ids=[PostId.from_str("2234567890123456781"), PostId.from_str("2234567890123456801")]), [0, 2]],
@@ -63,11 +63,11 @@ def test_get_post(
 @pytest.mark.parametrize(
     ["filter_args", "expected_indices"],
     [
-        [dict(), [0, 1, 2]],
+        [dict(), [0, 1, 2, 3]],
         [dict(post_ids=[PostId.from_str("2234567890123456781"), PostId.from_str("2234567890123456801")]), [0, 2]],
         [dict(post_ids=[]), []],
         [dict(start=TwitterTimestamp.from_int(1153921700000), end=TwitterTimestamp.from_int(1153921800000)), [1]],
-        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2]],
+        [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3]],
         [dict(end=TwitterTimestamp.from_int(1153921700000)), [0]],
         [dict(search_text="https://t.co/xxxxxxxxxxx/"), [0, 2]],
         [dict(note_ids=[NoteId.from_str("1234567890123456781")]), [0]],

--- a/common/tests/test_storage.py
+++ b/common/tests/test_storage.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 import pytest
+from pydantic import HttpUrl
 from sqlalchemy.engine import Engine
 
 from birdxplorer_common.models import (
@@ -41,6 +42,7 @@ def test_get_topic_list(
         [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3, 4]],
         [dict(end=TwitterTimestamp.from_int(1153921700000)), [0]],
         [dict(search_text="https://t.co/xxxxxxxxxxx/"), [0, 2]],
+        [dict(search_url=HttpUrl("https://example.com/sh3")), [2, 3]],
         [dict(note_ids=[NoteId.from_str("1234567890123456781")]), [0]],
         [dict(offset=1, limit=1, search_text="https://t.co/xxxxxxxxxxx/"), [2]],
     ],
@@ -70,6 +72,7 @@ def test_get_post(
         [dict(start=TwitterTimestamp.from_int(1153921700000)), [1, 2, 3, 4]],
         [dict(end=TwitterTimestamp.from_int(1153921700000)), [0]],
         [dict(search_text="https://t.co/xxxxxxxxxxx/"), [0, 2]],
+        [dict(search_url=HttpUrl("https://example.com/sh3")), [2, 3]],
         [dict(note_ids=[NoteId.from_str("1234567890123456781")]), [0]],
     ],
 )


### PR DESCRIPTION
closes #105

```
client.get("/api/v1/data/posts/?searchUrl=https%3A%2F%2Fexample.com%2Fsh3")
```
こんな感じで、`GET` の `searchUrl` クエリをつけて検索ができます。単一の URL の検索にのみ対応しています。