### PR TITLE
fix: クエリパラメータ名称を他エンドポイントとそろえる

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -126,8 +126,8 @@ def gen_router(storage: Storage) -> APIRouter:
     @router.get("/posts", response_model=PostListResponse)
     def get_posts(
         request: Request,
-        post_id: Union[List[PostId], None] = Query(default=None),
-        note_id: Union[List[NoteId], None] = Query(default=None),
+        post_ids: Union[List[PostId], None] = Query(default=None),
+        note_ids: Union[List[NoteId], None] = Query(default=None),
         created_at_from: Union[None, TwitterTimestamp, str] = Query(default=None),
         created_at_to: Union[None, TwitterTimestamp, str] = Query(default=None),
         offset: int = Query(default=0, ge=0),
@@ -142,8 +142,8 @@ def gen_router(storage: Storage) -> APIRouter:
             created_at_to = ensure_twitter_timestamp(created_at_to)
         posts = list(
             storage.get_posts(
-                post_ids=post_id,
-                note_ids=note_id,
+                post_ids=post_ids,
+                note_ids=note_ids,
                 start=created_at_from,
                 end=created_at_to,
                 search_text=search_text,
@@ -154,8 +154,8 @@ def gen_router(storage: Storage) -> APIRouter:
             )
         )
         total_count = storage.get_number_of_posts(
-            post_ids=post_id,
-            note_ids=note_id,
+            post_ids=post_ids,
+            note_ids=note_ids,
             start=created_at_from,
             end=created_at_to,
             search_text=search_text,

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -44,7 +44,7 @@ def test_posts_get_limit_and_offset(client: TestClient, post_samples: List[Post]
 
 
 def test_posts_get_has_post_id_filter(client: TestClient, post_samples: List[Post]) -> None:
-    response = client.get(f"/api/v1/data/posts/?postId={post_samples[0].post_id},{post_samples[2].post_id}")
+    response = client.get(f"/api/v1/data/posts/?postIds={post_samples[0].post_id},{post_samples[2].post_id}")
     assert response.status_code == 200
     res_json = response.json()
     assert res_json == {
@@ -57,7 +57,7 @@ def test_posts_get_has_post_id_filter(client: TestClient, post_samples: List[Pos
 
 
 def test_posts_get_has_note_id_filter(client: TestClient, post_samples: List[Post], note_samples: List[Note]) -> None:
-    response = client.get(f"/api/v1/data/posts/?noteId={','.join([n.note_id for n in note_samples])}")
+    response = client.get(f"/api/v1/data/posts/?noteIds={','.join([n.note_id for n in note_samples])}")
     assert response.status_code == 200
     res_json = response.json()
     assert res_json == {"data": [json.loads(post_samples[0].model_dump_json())], "meta": {"next": None, "prev": None}}
@@ -123,7 +123,7 @@ def test_posts_get_timestamp_out_of_range(client: TestClient, post_samples: List
 
 
 def test_posts_get_with_media_by_default(client: TestClient, post_samples: List[Post]) -> None:
-    response = client.get("/api/v1/data/posts/?postId=2234567890123456791")
+    response = client.get("/api/v1/data/posts/?postIds=2234567890123456791")
 
     assert response.status_code == 200
     res_json_default = response.json()
@@ -134,7 +134,7 @@ def test_posts_get_with_media_by_default(client: TestClient, post_samples: List[
 
 
 def test_posts_get_with_media_true(client: TestClient, post_samples: List[Post]) -> None:
-    response = client.get("/api/v1/data/posts/?postId=2234567890123456791&media=true")
+    response = client.get("/api/v1/data/posts/?postIds=2234567890123456791&media=true")
 
     assert response.status_code == 200
     res_json_default = response.json()
@@ -146,7 +146,7 @@ def test_posts_get_with_media_true(client: TestClient, post_samples: List[Post])
 
 def test_posts_get_with_media_false(client: TestClient, post_samples: List[Post]) -> None:
     expected_post = post_samples[1].model_copy(update={"media_details": []})
-    response = client.get("/api/v1/data/posts/?postId=2234567890123456791&media=false")
+    response = client.get("/api/v1/data/posts/?postIds=2234567890123456791&media=false")
 
     assert response.status_code == 200
     res_json_default = response.json()


### PR DESCRIPTION
## Outline
`/notes` では id 系のクエリパラメータの名称が複数形になっているが、 `/posts` では単数形になっている。
`/posts` においても複数指定できる実態を考慮すると複数形に揃えたほうが良いと判断したためそろえる。