### PR TITLE
fix: 明示的に全オリジンからのリクエストを許可する

### DIFF
--- a/common/birdxplorer_common/settings.py
+++ b/common/birdxplorer_common/settings.py
@@ -32,7 +32,7 @@ class CORSSettings(BaseSettings):
     allow_methods: list[str] = ["GET"]
     allow_headers: list[str] = ["*"]
 
-    allow_origins: list[str] = []
+    allow_origins: list[str] = ["*"]
 
 
 class GlobalSettings(BaseSettings):


### PR DESCRIPTION
CORS Middleware の origin の指定が漏れていたので指定する