### PR TITLE
fix: validate_timestamp_rangeをカレンダー日数ベースの比較に修正

### DIFF
--- a/api/birdxplorer_api/routers/graphs.py
+++ b/api/birdxplorer_api/routers/graphs.py
@@ -64,14 +64,12 @@ def validate_timestamp_range(
          ...
         fastapi.exceptions.HTTPException: 400...
     """
-    from datetime import datetime, timezone
+    import math
 
     if start_date > end_date:
         raise HTTPException(status_code=400, detail="start_date must be before or equal to end_date")
 
-    start_dt = datetime.fromtimestamp(start_date / 1000, tz=timezone.utc).date()
-    end_dt = datetime.fromtimestamp(end_date / 1000, tz=timezone.utc).date()
-    days_diff = (end_dt - start_dt).days
+    days_diff = math.floor((end_date - start_date) / (1000 * 60 * 60 * 24))
     if days_diff > max_days:
         raise HTTPException(status_code=400, detail=f"Date range cannot exceed {max_days} days")
 

--- a/api/birdxplorer_api/routers/graphs.py
+++ b/api/birdxplorer_api/routers/graphs.py
@@ -64,10 +64,14 @@ def validate_timestamp_range(
          ...
         fastapi.exceptions.HTTPException: 400...
     """
+    from datetime import datetime, timezone
+
     if start_date > end_date:
         raise HTTPException(status_code=400, detail="start_date must be before or equal to end_date")
 
-    days_diff = (end_date - start_date) / (1000 * 60 * 60 * 24)
+    start_dt = datetime.fromtimestamp(start_date / 1000, tz=timezone.utc).date()
+    end_dt = datetime.fromtimestamp(end_date / 1000, tz=timezone.utc).date()
+    days_diff = (end_dt - start_dt).days
     if days_diff > max_days:
         raise HTTPException(status_code=400, detail=f"Date range cannot exceed {max_days} days")
 


### PR DESCRIPTION
## Summary
- グラフAPIの日付範囲バリデーション(`validate_timestamp_range`)をミリ秒差ベースからカレンダー日数ベースに修正
- フロントエンドが`endOf("day")`でタイムスタンプを送信するため、30日分の日付範囲選択が約31日と判定されて400エラーになっていた

## Test plan
- [x] 既存の日付範囲バリデーションテスト5件がパス
- [x] doctest 2件がパス
- [ ] ローカルで30日ぴったりの日付範囲でAPI呼び出しが200を返すことを確認