### PR TITLE
fix: replace httpx with httpx2 to resolve starlette deprecation

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -57,7 +57,7 @@ dev=[
     "psycopg2-binary",
     "factory_boy",
     "polyfactory",
-    "httpx",
+    "httpx2",
 ]
 prod=[
     "birdxplorer_common @ git+https://github.com/codeforjapan/BirdXplorer.git@main#subdirectory=common",


### PR DESCRIPTION
## Summary
- `starlette.testclient` が `httpx` を deprecated にして `httpx2` への移行を要求するようになり、`filterwarnings = ["error"]` でテストが落ちていた
- `api/pyproject.toml` の dev 依存を `httpx` → `httpx2` に置き換えて修正

## Test plan
- [ ] `api-test-check` CI が green になること