### PR TITLE
feat(api): 言語コードフィルタでISO 639-1全コードを許可する

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -18,7 +18,7 @@ from birdxplorer_api.openapi_doc import (
 )
 from birdxplorer_common.models import (
     BaseModel,
-    LanguageIdentifier,
+    LanguageCode,
     Note,
     NoteId,
     PaginationMeta,
@@ -184,7 +184,7 @@ class SearchedNote(BaseModel):
         Optional[ParticipantId], PydanticField(description="コミュニティノートの作成者のユーザーID")
     ]
     summary: Annotated[SummaryString, PydanticField(description="コミュニティノートの本文")]
-    language: Annotated[LanguageIdentifier, PydanticField(description="コミュニティノートの言語")]
+    language: Annotated[LanguageCode, PydanticField(description="コミュニティノートの言語")]
     topics: Annotated[List[Topic], PydanticField(description="コミュニティノートに関連付けられたトピックのリスト")]
     postId: Annotated[PostId, PydanticField(description="関連するPostのID")]
     current_status: Annotated[
@@ -360,7 +360,7 @@ def gen_router(storage: Storage) -> APIRouter:
         topic_ids: Union[List[TopicId], None] = Query(default=None, **V1DataNotesDocs.params["topic_ids"]),
         post_ids: Union[List[PostId], None] = Query(default=None, **V1DataNotesDocs.params["post_ids"]),
         current_status: Union[None, List[str]] = Query(default=None, **V1DataNotesDocs.params["current_status"]),
-        language: Union[LanguageIdentifier, None] = Query(default=None, **V1DataNotesDocs.params["language"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataNotesDocs.params["language"]),
         search_text: Union[None, str] = Query(default=None, **V1DataNotesDocs.params["search_text"]),
     ) -> NoteListResponse:
         try:
@@ -477,7 +477,7 @@ def gen_router(storage: Storage) -> APIRouter:
         note_excludes_text: Union[None, str] = Query(default=None),
         post_includes_text: Union[None, str] = Query(default=None),
         post_excludes_text: Union[None, str] = Query(default=None),
-        language: Union[LanguageIdentifier, None] = Query(default=None),
+        language: Union[LanguageCode, None] = Query(default=None),
         topic_ids: Union[List[TopicId], None] = Query(default=None),
         note_status: Union[None, List[str]] = Query(default=None),
         note_created_at_from: Union[None, TwitterTimestamp, str] = Query(default=None),
@@ -526,7 +526,7 @@ def gen_router(storage: Storage) -> APIRouter:
         note_excludes_text: Union[None, str] = Query(default=None, **V1DataSearchDocs.params["note_excludes_text"]),
         post_includes_text: Union[None, str] = Query(default=None, **V1DataSearchDocs.params["post_includes_text"]),
         post_excludes_text: Union[None, str] = Query(default=None, **V1DataSearchDocs.params["post_excludes_text"]),
-        language: Union[LanguageIdentifier, None] = Query(default=None, **V1DataSearchDocs.params["language"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchDocs.params["language"]),
         topic_ids: Union[List[TopicId], None] = Query(default=None, **V1DataSearchDocs.params["topic_ids"]),
         note_status: Union[None, List[str]] = Query(default=None, **V1DataSearchDocs.params["note_status"]),
         note_created_at_from: Union[None, TwitterTimestamp, str] = Query(

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -15,7 +15,7 @@ from pytest import fixture
 
 from birdxplorer_common.exceptions import UserEnrollmentNotFoundError
 from birdxplorer_common.models import (
-    LanguageIdentifier,
+    LanguageCode,
     Link,
     LinkId,
     Media,
@@ -379,7 +379,7 @@ def mock_storage(
         topic_ids: Union[List[TopicId], None] = None,
         post_ids: Union[List[PostId], None] = None,
         current_status: Union[None, List[str]] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         search_text: Union[str, None] = None,
         offset: Union[int, None] = None,
         limit: Union[int, None] = None,
@@ -397,7 +397,7 @@ def mock_storage(
                 continue
             if current_status is not None and note.current_status not in current_status:
                 continue
-            if language is not None and note.language != language.value:
+            if language is not None and note.language != language:
                 continue
             if search_text is not None and search_text not in note.summary:
                 continue
@@ -412,7 +412,7 @@ def mock_storage(
         topic_ids: Union[List[TopicId], None] = None,
         post_ids: Union[List[PostId], None] = None,
         current_status: Union[None, List[str]] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         search_text: Union[str, None] = None,
     ) -> int:
         return len(

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -248,3 +248,22 @@ def test_notes_get_has_topic_id_filter(client: TestClient, note_samples: List[No
         "data": [json.loads(correct_notes[i].model_dump_json()) for i in range(correct_notes.__len__())],
         "meta": {"next": None, "prev": None, "total": len(correct_notes)},
     }
+
+
+def test_notes_get_has_language_filter(client: TestClient, note_samples: List[Note]) -> None:
+    correct_notes = [note for note in note_samples if note.language == "en"]
+    response = client.get("/api/v1/data/notes/?language=en")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert res_json == {
+        "data": [json.loads(note.model_dump_json()) for note in correct_notes],
+        "meta": {"next": None, "prev": None, "total": len(correct_notes)},
+    }
+
+
+def test_notes_get_accepts_non_enum_language(client: TestClient, note_samples: List[Note]) -> None:
+    # "zh" is a valid ISO 639-1 code but is not a member of the LanguageIdentifier enum.
+    # The endpoint must accept it (200) instead of rejecting it (422).
+    response = client.get("/api/v1/data/notes/?language=zh")
+    assert response.status_code == 200
+    assert response.json()["meta"]["total"] == 0

--- a/api/tests/routers/test_search.py
+++ b/api/tests/routers/test_search.py
@@ -434,3 +434,63 @@ def test_search_include_total_false(client: TestClient, mock_storage: MagicMock)
     data = response.json()
     assert data["meta"].get("total") is None
     mock_storage.count_search_results.assert_not_called()
+
+
+def test_search_count_accepts_non_enum_language(client: TestClient, mock_storage: MagicMock) -> None:
+    """LanguageIdentifier enum に無いが有効な ISO 639-1 コード(zh)でも絞り込める。"""
+    mock_storage.count_search_results.return_value = 7
+
+    response = client.get("/api/v1/data/search/count?language=zh")
+    assert response.status_code == 200
+    assert response.json()["total"] == 7
+
+    call_kwargs = mock_storage.count_search_results.call_args
+    assert call_kwargs.kwargs["language"] == "zh"
+
+
+def test_search_returns_non_enum_language(client: TestClient, mock_storage: MagicMock) -> None:
+    """検索結果に enum 外の言語コード(zh)が含まれていてもシリアライズできる。"""
+    timestamp = TwitterTimestamp.from_int(int(datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp() * 1000))
+    note = Note(
+        note_id="1234567890123456789",
+        note_author_participant_id="".join(random.choices("0123456789ABCDEF", k=64)),
+        post_id="2234567890123456789",
+        language="zh",
+        topics=[],
+        summary="Test summary",
+        current_status="NEEDS_MORE_RATINGS",
+        created_at=timestamp,
+        has_been_helpfuled=False,
+        helpful_count=0,
+        not_helpful_count=0,
+        somewhat_helpful_count=0,
+        current_status_history=[],
+    )
+    post = Post(
+        post_id="2234567890123456789",
+        x_user_id="9876543210123456789",
+        x_user=XUser(
+            user_id="9876543210123456789",
+            name="test_user",
+            profile_image="http://example.com/image.jpg",
+            followers_count=100,
+            following_count=50,
+        ),
+        text="Test post",
+        media_details=[],
+        created_at=timestamp,
+        aggregated_at=timestamp,
+        like_count=10,
+        repost_count=5,
+        impression_count=100,
+        links=[],
+        link="http://x.com/test_user/status/2234567890123456789",
+    )
+
+    mock_storage.search_notes_with_posts.return_value = SearchResultPage(items=[(note, post)], has_next=False)
+    mock_storage.count_search_results.return_value = 1
+
+    response = client.get("/api/v1/data/search?language=zh")
+    assert response.status_code == 200
+    result = response.json()["data"][0]
+    assert result["language"] == "zh"

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -22,7 +22,6 @@ from .logger import get_logger
 from .models import (
     BinaryBool,
     LanguageCode,
-    LanguageIdentifier,
 )
 from .models import Link as LinkModel
 from .models import (
@@ -1309,7 +1308,7 @@ class Storage:
         topic_ids: Union[List[TopicId], None] = None,
         post_ids: Union[List[PostId], None] = None,
         current_status: Union[None, List[str]] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         search_text: Union[str, None] = None,
         offset: Union[int, None] = None,
         limit: int = 100,
@@ -1394,7 +1393,7 @@ class Storage:
         topic_ids: Union[List[TopicId], None] = None,
         post_ids: Union[List[PostId], None] = None,
         current_status: Union[None, List[str]] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         search_text: Union[str, None] = None,
     ) -> int:
         with Session(self.engine) as sess:
@@ -1513,7 +1512,7 @@ class Storage:
         note_excludes_text: Union[str, None] = None,
         post_includes_text: Union[str, None] = None,
         post_excludes_text: Union[str, None] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         topic_ids: Union[List[TopicId], None] = None,
         note_status: Union[List[str], None] = None,
         note_created_at_from: Union[TwitterTimestamp, None] = None,
@@ -1608,7 +1607,7 @@ class Storage:
         query: RowReturningQuery[Tuple[Any, ...]],
         note_includes_text: Union[str, None] = None,
         note_excludes_text: Union[str, None] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         topic_ids: Union[List[TopicId], None] = None,
         note_status: Union[List[str], None] = None,
         note_created_at_from: Union[TwitterTimestamp, None] = None,
@@ -1642,7 +1641,7 @@ class Storage:
         note_excludes_text: Union[str, None] = None,
         post_includes_text: Union[str, None] = None,
         post_excludes_text: Union[str, None] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         topic_ids: Union[List[TopicId], None] = None,
         note_status: Union[List[str], None] = None,
         note_created_at_from: Union[TwitterTimestamp, None] = None,
@@ -1813,7 +1812,7 @@ class Storage:
         note_excludes_text: Union[str, None] = None,
         post_includes_text: Union[str, None] = None,
         post_excludes_text: Union[str, None] = None,
-        language: Union[LanguageIdentifier, None] = None,
+        language: Union[LanguageCode, None] = None,
         topic_ids: Union[List[TopicId], None] = None,
         note_status: Union[List[str], None] = None,
         note_created_at_from: Union[TwitterTimestamp, None] = None,
@@ -1862,7 +1861,7 @@ class Storage:
         post_id: Optional[PostId] = None,
         created_at: Optional[TwitterTimestamp] = None,
         note_author_participant_id: Optional[ParticipantId] = None,
-        language: Optional[LanguageIdentifier] = None,
+        language: Optional[LanguageCode] = None,
         current_status: Optional[str] = None,
     ) -> None:
         """

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -5,7 +5,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
-from birdxplorer_common.models import LanguageIdentifier, Note, Post, TopicId
+from birdxplorer_common.models import LanguageCode, Note, Post, TopicId
 from birdxplorer_common.storage import (
     NoteRecord,
     PostRecord,
@@ -64,13 +64,13 @@ def test_search_by_language(
     storage = Storage(engine=engine_for_test)
 
     # Test searching for English notes
-    results = storage.search_notes_with_posts(language=LanguageIdentifier("en")).items
+    results = storage.search_notes_with_posts(language=LanguageCode("en")).items
     assert len(results) > 0
     for note, _ in results:
         assert note.language == "en"
 
     # Test searching for Japanese notes
-    results = storage.search_notes_with_posts(language=LanguageIdentifier("ja")).items
+    results = storage.search_notes_with_posts(language=LanguageCode("ja")).items
     assert len(results) > 0
     for note, _ in results:
         assert note.language == "ja"
@@ -130,9 +130,7 @@ def test_combined_search(
     """Test combining multiple search criteria"""
     storage = Storage(engine=engine_for_test)
 
-    results = storage.search_notes_with_posts(
-        note_includes_text="summary", language=LanguageIdentifier("en"), limit=2
-    ).items
+    results = storage.search_notes_with_posts(note_includes_text="summary", language=LanguageCode("en"), limit=2).items
 
     assert len(results) <= 2
     for note, _ in results:
@@ -180,12 +178,12 @@ def test_count_search_results(
     assert total_count > 0
 
     # Get filtered count
-    filtered_count = storage.count_search_results(note_includes_text="summary", language=LanguageIdentifier("en"))
+    filtered_count = storage.count_search_results(note_includes_text="summary", language=LanguageCode("en"))
     assert filtered_count > 0
     assert filtered_count <= total_count
 
     # Verify count matches actual results
-    results = storage.search_notes_with_posts(note_includes_text="summary", language=LanguageIdentifier("en")).items
+    results = storage.search_notes_with_posts(note_includes_text="summary", language=LanguageCode("en")).items
     assert len(results) == filtered_count
 
 

--- a/common/tests/test_storage.py
+++ b/common/tests/test_storage.py
@@ -5,7 +5,7 @@ from pydantic import HttpUrl
 from sqlalchemy.engine import Engine
 
 from birdxplorer_common.models import (
-    LanguageIdentifier,
+    LanguageCode,
     Note,
     NoteId,
     Post,
@@ -228,7 +228,7 @@ def test_get_notes_by_language(
     note_records_sample: List[NoteRecord],
 ) -> None:
     storage = Storage(engine=engine_for_test)
-    language = LanguageIdentifier("en")
-    expected = [note for note in note_samples if note.language == language.value]
+    language = LanguageCode("en")
+    expected = [note for note in note_samples if note.language == language]
     actual = list(storage.get_notes(language=language))
     assert expected == actual


### PR DESCRIPTION
## 概要

ノート/検索エンドポイントの `language` フィルタが固定 enum (`LanguageIdentifier`、約20言語) で制限されており、ISO 639-1 として有効でも enum 外のコード (例: `zh`, `ko`, `ar`, `hi`) は **422 で拒否** されていました。データ層は #244 で既に ISO 639-1 検証 (`LanguageCode`) に対応済みだったため、API 層の型だけがギャップとして残っていました。

本PRで API 層を `LanguageCode` に揃え、**標準化された全 ISO 639-1 言語コードを受理** できるようにします。

## 変更内容

- **`api/birdxplorer_api/routers/data.py`**
  - `/notes`・`/search`・`/search/count` の `language` クエリパラメータを `LanguageIdentifier` → `LanguageCode` へ
  - `SearchedNote.language` レスポンスフィールドも `LanguageCode` へ (enum 外コードを含む検索結果が正しくシリアライズされるよう修正)
- **`common/birdxplorer_common/storage.py`**
  - `get_notes` / `get_number_of_notes` / `search_notes_with_posts` / `count_search_results` / `_apply_note_only_filters` のシグネチャ型注釈を `LanguageCode` へ統一 (未使用になった `LanguageIdentifier` import を削除)
- **テスト**
  - enum 外コード (`zh`) が 200 で受理され結果に保持されることを検証するテストを追加 (`test_data.py` / `test_search.py`)
  - モック (`conftest.py`) と common 側既存テストを `LanguageCode` に追従

## 挙動

- 有効な ISO 639-1 コード (`zh`, `ko`, `ar`, `hi` 等) → そのまま絞り込み
- 無効/幻覚コード (`Japanese`, `xyz123` 等) → `other` に正規化 (取り込み時の挙動と一貫)

なお enum `LanguageIdentifier` 自体は ETL の正規化処理と `TopicLabel` 型エイリアスで使用しているため残しています。

## テスト

両モジュールで `tox` が `congratulations :)` (common: 100 passed、api: 101 passed、black / isort / pflake8 / mypy --strict すべてパス)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)