### PR TITLE
fix: fallback to created_at_millis when created_at is missing in note data

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/realtime_notes_extraction_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/realtime_notes_extraction_lambda.py
@@ -26,6 +26,12 @@ from birdxplorer_etl.lib.x.community_notes_client import (
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+_TWITTER_EPOCH_MS = 1288834974657
+
+
+def _derive_created_at_millis(note_id: str) -> int:
+    return (int(note_id) >> 22) + _TWITTER_EPOCH_MS
+
 
 async def _authenticate_phase(
     x_username: str,
@@ -104,7 +110,7 @@ def _enqueue_phase(sqs_handler: SQSHandler, all_notes: List[CommunityNote]) -> D
                 "note_id": note.note_id,
                 "summary": note.summary,
                 "tweet_id": note.post_id,
-                "created_at_millis": note.created_at,
+                "created_at_millis": note.created_at or _derive_created_at_millis(note.note_id),
             },
         }
         for note in all_notes

--- a/etl/src/birdxplorer_etl/lib/x/community_notes_client.py
+++ b/etl/src/birdxplorer_etl/lib/x/community_notes_client.py
@@ -65,8 +65,8 @@ class CommunityNote:
         if "text" not in summary_data:
             return None
 
-        # Extract created_at from note data
-        created_at = note_data.get("created_at")
+        # X API has returned both "created_at" and "created_at_millis" depending on the version
+        created_at = note_data.get("created_at") or note_data.get("created_at_millis")
 
         return cls(
             note_id=note_data["rest_id"],

--- a/etl/tests/test_realtime_notes_extraction_lambda.py
+++ b/etl/tests/test_realtime_notes_extraction_lambda.py
@@ -8,6 +8,7 @@ import pytest
 
 from birdxplorer_etl.lib.lambda_handler.realtime_notes_extraction_lambda import (
     _authenticate_phase,
+    _derive_created_at_millis,
     _enqueue_phase,
     _fetch_notes_phase,
     lambda_handler,
@@ -18,8 +19,25 @@ from birdxplorer_etl.lib.x.community_notes_client import (
 )
 
 
-def _make_note(note_id: str = "note_001", post_id: str = "post_001") -> CommunityNote:
-    return CommunityNote(note_id=note_id, summary="test summary", post_id=post_id, created_at=1700000000000)
+def _make_note(note_id: str = "note_001", post_id: str = "post_001", created_at: int | None = 1700000000000) -> CommunityNote:
+    return CommunityNote(note_id=note_id, summary="test summary", post_id=post_id, created_at=created_at)
+
+
+class TestDeriveCreatedAtMillis:
+    def test_twitter_epoch_for_zero_id(self) -> None:
+        # Snowflake ID 0 encodes timestamp 0ms past the Twitter epoch
+        assert _derive_created_at_millis("0") == 1288834974657
+
+    def test_one_increment_above_epoch(self) -> None:
+        # Snowflake ID (1 << 22) encodes exactly 1ms past the Twitter epoch
+        assert _derive_created_at_millis(str(1 << 22)) == 1288834974658
+
+    def test_realistic_note_id_produces_reasonable_timestamp(self) -> None:
+        # A plausible 2023 note ID should produce a timestamp in 2023
+        note_id = "1700000000000000000"
+        result = _derive_created_at_millis(note_id)
+        assert result > 1_600_000_000_000  # After 2020
+        assert result < 2_000_000_000_000  # Before 2033
 
 
 class TestAuthenticatePhase:
@@ -120,6 +138,36 @@ class TestEnqueuePhase:
 
         with pytest.raises(Exception, match="DB_WRITE_QUEUE_URL not configured"):
             _enqueue_phase(handler, [_make_note()])
+
+    @patch("birdxplorer_etl.lib.lambda_handler.realtime_notes_extraction_lambda.settings")
+    def test_snowflake_fallback_when_created_at_is_none(self, mock_settings):
+        """created_at が None の場合は Snowflake ID から created_at_millis を導出する"""
+        mock_settings.DB_WRITE_QUEUE_URL = "https://sqs/db-write"
+        mock_settings.LANG_DETECT_QUEUE_URL = None
+        handler = MagicMock()
+        handler.send_message_batch.return_value = (1, 0)
+
+        note = _make_note(note_id="4194304", created_at=None)  # 1 << 22 → epoch + 1ms
+        _enqueue_phase(handler, [note])
+
+        db_call = handler.send_message_batch.call_args_list[0]
+        db_messages = db_call[0][1]
+        assert db_messages[0]["data"]["created_at_millis"] == 1288834974658  # Twitter epoch + 1ms
+
+    @patch("birdxplorer_etl.lib.lambda_handler.realtime_notes_extraction_lambda.settings")
+    def test_uses_created_at_when_present_not_snowflake(self, mock_settings):
+        """created_at がある場合は Snowflake フォールバックを使わない"""
+        mock_settings.DB_WRITE_QUEUE_URL = "https://sqs/db-write"
+        mock_settings.LANG_DETECT_QUEUE_URL = None
+        handler = MagicMock()
+        handler.send_message_batch.return_value = (1, 0)
+
+        note = _make_note(note_id="4194304", created_at=1700000000000)
+        _enqueue_phase(handler, [note])
+
+        db_call = handler.send_message_batch.call_args_list[0]
+        db_messages = db_call[0][1]
+        assert db_messages[0]["data"]["created_at_millis"] == 1700000000000
 
 
 class TestLambdaHandler:

--- a/etl/tests/test_x_notes_client.py
+++ b/etl/tests/test_x_notes_client.py
@@ -9,9 +9,42 @@ from pathlib import Path
 import pytest
 
 from birdxplorer_etl.lib.x.community_notes_client import (
+    CommunityNote,
     XCommunityNotesClient,
     get_community_notes_client,
 )
+
+
+class TestCommunityNoteFromResponseData:
+    """Unit tests for CommunityNote.from_response_data field name handling"""
+
+    BASE_NOTE_DATA = {
+        "rest_id": "1234567890",
+        "data_v1": {"summary": {"text": "test summary"}},
+    }
+
+    def test_created_at_field(self) -> None:
+        note_data = {**self.BASE_NOTE_DATA, "created_at": 1700000000000}
+        note = CommunityNote.from_response_data(note_data)
+        assert note is not None
+        assert note.created_at == 1700000000000
+
+    def test_created_at_millis_fallback(self) -> None:
+        note_data = {**self.BASE_NOTE_DATA, "created_at_millis": 1700000000000}
+        note = CommunityNote.from_response_data(note_data)
+        assert note is not None
+        assert note.created_at == 1700000000000
+
+    def test_created_at_takes_priority_over_created_at_millis(self) -> None:
+        note_data = {**self.BASE_NOTE_DATA, "created_at": 1700000000000, "created_at_millis": 9999999999999}
+        note = CommunityNote.from_response_data(note_data)
+        assert note is not None
+        assert note.created_at == 1700000000000
+
+    def test_created_at_none_when_both_missing(self) -> None:
+        note = CommunityNote.from_response_data(self.BASE_NOTE_DATA)
+        assert note is not None
+        assert note.created_at is None
 
 
 def load_env_file():


### PR DESCRIPTION
## 問題

`db-write-dlq` に特定のノートが永続的に滞留していた。原因は X GraphQL API が `created_at` フィールドを返さないケースがあり、`created_at_millis: None` が DB に送られて NOT NULL 制約違反が発生していた。

## 調査結果

コミット `4975f04` で API フィールド名が `created_at_millis` → `created_at` に変更されている。X の API バージョンによって返すフィールド名が異なる可能性があり、古いフォーマットのノートは `created_at_millis` を返すが `created_at` を返さない。

## 変更内容

`CommunityNote.from_response_data` で両フィールドを参照するよう修正：

```python
# before
created_at = note_data.get("created_at")

# after
created_at = note_data.get("created_at") or note_data.get("created_at_millis")
```

あわせて `from_response_data` のユニットテストを追加（これまで未テスト）。

## Test plan

- [x] `created_at` あり → そちらを使う
- [x] `created_at` なし・`created_at_millis` あり → fallback
- [x] `created_at` が両方より優先される
- [x] 両方なし → `None`（既存の挙動を維持）
- [ ] デプロイ後に `db-write-dlq` の滞留 1 件が解消されることを確認