### PR TITLE
Feat/#237 csv export

### DIFF
--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -48,6 +48,6 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
     app.add_middleware(QueryStringFlatteningMiddleware)
     app.add_middleware(TimingMiddleware)
     app.include_router(gen_system_router(), prefix="/api/v1/system")
-    app.include_router(gen_data_router(storage=storage), prefix="/api/v1/data")
+    app.include_router(gen_data_router(storage=storage, export_api_key=settings.export_api_key), prefix="/api/v1/data")
     app.include_router(gen_graphs_router(storage=storage), prefix="/api/v1/graphs")
     return app

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -45,7 +45,7 @@ _CSV_EXPORT_THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
 _CSV_EXPORT_MAX_KEYWORDS = 50
 _CSV_EXPORT_MAX_ROWS = 5000
 _CSV_EXPORT_COLUMNS = [
-    "ポスト(投稿)日時",
+    "ポスト（投稿）日時",
     "ポスト",
     "コミュニティノート作成日時",
     "コミュニティノート",
@@ -744,7 +744,12 @@ def gen_router(storage: Storage) -> APIRouter:
         note_created_at_from: int = Query(..., description="ノート作成期間の開始(ミリ秒)"),
         note_created_at_to: int = Query(..., description="ノート作成期間の終了(ミリ秒)"),
     ) -> Response:
-        parsed_keywords = [kw.strip() for kw in keywords if kw.strip()]
+        parsed_keywords = [
+            token.strip()
+            for keyword in keywords
+            for token in keyword.split(",")
+            if token.strip()
+        ]
         if not parsed_keywords:
             return _csv_export_error("invalid_keywords", "キーワードは1個以上指定してください")
         if len(parsed_keywords) > _CSV_EXPORT_MAX_KEYWORDS:

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -1,10 +1,14 @@
-from datetime import timezone
-from typing import Any, Dict, List, Optional, TypeAlias, Union
+import csv
+from datetime import datetime, timezone
+from io import StringIO
+from typing import Any, Dict, Generator, List, Optional, TypeAlias, Union
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
 
 from dateutil.parser import parse as dateutil_parse
-from fastapi import APIRouter, HTTPException, Path, Query, Request
+from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import Field as PydanticField
 from pydantic import HttpUrl
 from typing_extensions import Annotated
@@ -34,7 +38,73 @@ from birdxplorer_common.models import (
     UserEnrollment,
     UserId,
 )
-from birdxplorer_common.storage import Storage
+from birdxplorer_common.storage import CsvExportRow, Storage
+
+_CSV_EXPORT_JST = ZoneInfo("Asia/Tokyo")
+_CSV_EXPORT_THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+_CSV_EXPORT_MAX_KEYWORDS = 50
+_CSV_EXPORT_MAX_ROWS = 5000
+_CSV_EXPORT_COLUMNS = [
+    "ポスト(投稿)日時",
+    "ポスト",
+    "コミュニティノート作成日時",
+    "コミュニティノート",
+    "ステータス",
+    "ポストURL",
+    "インプレッション数",
+    "Like数",
+    "リポスト数",
+    "評価数",
+    "役に立った",
+    "少し役に立った",
+    "役に立たなかった",
+    "コミュニティノートID",
+    "コミュニティノート作成者ID",
+    "投稿者ID",
+    "投稿者アカウント名",
+    "ポスト取得日時",
+]
+
+
+def _csv_export_format_jst(ts_ms: Union[int, None]) -> str:
+    if ts_ms is None:
+        return ""
+    return (
+        datetime.fromtimestamp(int(ts_ms) / 1000, tz=timezone.utc)
+        .astimezone(_CSV_EXPORT_JST)
+        .strftime("%Y/%m/%d %H:%M:%S")
+    )
+
+
+def _csv_export_row_values(row: CsvExportRow) -> List[str]:
+    note = row.note
+    post = row.post
+    user_name = post.user.name if post.user is not None else ""
+    return [
+        _csv_export_format_jst(post.created_at),
+        post.text,
+        _csv_export_format_jst(note.created_at),
+        note.summary,
+        row.status,
+        f"https://twitter.com/i/web/status/{post.post_id}",
+        str(post.impression_count),
+        str(post.like_count),
+        str(post.repost_count),
+        str(note.rate_count if note.rate_count is not None else 0),
+        str(note.helpful_count if note.helpful_count is not None else 0),
+        str(note.somewhat_helpful_count if note.somewhat_helpful_count is not None else 0),
+        str(note.not_helpful_count if note.not_helpful_count is not None else 0),
+        str(note.note_id),
+        str(note.note_author_participant_id) if note.note_author_participant_id is not None else "",
+        str(post.user_id),
+        user_name,
+        _csv_export_format_jst(post.aggregated_at),
+    ]
+
+
+def _csv_export_error(error: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=400, content={"error": error, "message": message})
+
 
 PostsPaginationMetaWithExamples: TypeAlias = Annotated[
     PaginationMeta,
@@ -661,5 +731,65 @@ def gen_router(storage: Storage) -> APIRouter:
             prev_url = f"{base_url}?{urlencode(query_params, doseq=True)}"
 
         return SearchResponse(data=results, meta=PaginationMeta(next=next_url, prev=prev_url, total=total_count))
+
+    @router.get(
+        "/export/csv",
+        description=(
+            "キーワード(カンマ区切り、OR検索、最大50個)と作成期間(ミリ秒、最大30日)を指定して、"
+            "コミュニティノート + ポストを CSV(UTF-8 BOM 付き)でダウンロードする。"
+        ),
+    )
+    def export_csv(
+        keywords: List[str] = Query(..., description="カンマ区切りのキーワード(OR検索)。最大50個、最低1個"),
+        note_created_at_from: int = Query(..., description="ノート作成期間の開始(ミリ秒)"),
+        note_created_at_to: int = Query(..., description="ノート作成期間の終了(ミリ秒)"),
+    ) -> Response:
+        parsed_keywords = [kw.strip() for kw in keywords if kw.strip()]
+        if not parsed_keywords:
+            return _csv_export_error("invalid_keywords", "キーワードは1個以上指定してください")
+        if len(parsed_keywords) > _CSV_EXPORT_MAX_KEYWORDS:
+            return _csv_export_error("too_many_keywords", "キーワードは最大50個です")
+
+        if note_created_at_from > note_created_at_to:
+            return _csv_export_error("invalid_period", "開始日時は終了日時より前である必要があります")
+        if note_created_at_to - note_created_at_from > _CSV_EXPORT_THIRTY_DAYS_MS:
+            return _csv_export_error("invalid_period", "期間は最大30日です")
+
+        try:
+            ts_from = TwitterTimestamp.from_int(note_created_at_from)
+            ts_to = TwitterTimestamp.from_int(note_created_at_to)
+        except (OverflowError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        rows = storage.search_notes_with_posts_for_csv(
+            keywords=parsed_keywords,
+            note_created_at_from=ts_from,
+            note_created_at_to=ts_to,
+            limit=_CSV_EXPORT_MAX_ROWS,
+        )
+
+        def _stream() -> Generator[bytes, None, None]:
+            buf = StringIO()
+            writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
+            yield "﻿".encode("utf-8")
+            writer.writerow(_CSV_EXPORT_COLUMNS)
+            yield buf.getvalue().encode("utf-8")
+            buf.seek(0)
+            buf.truncate(0)
+            for row in rows:
+                writer.writerow(_csv_export_row_values(row))
+                yield buf.getvalue().encode("utf-8")
+                buf.seek(0)
+                buf.truncate(0)
+
+        filename = f"community_notes_{datetime.now(_CSV_EXPORT_JST).strftime('%Y%m%d_%H%M%S')}.csv"
+        return StreamingResponse(
+            _stream(),
+            media_type="text/csv; charset=utf-8",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Cache-Control": "no-store",
+            },
+        )
 
     return router

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -397,7 +397,7 @@ def ensure_twitter_timestamp(t: Union[str, TwitterTimestamp]) -> TwitterTimestam
         raise OverflowError("Timestamp out of range")
 
 
-def gen_router(storage: Storage) -> APIRouter:
+def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRouter:
     router = APIRouter()
 
     @router.get(
@@ -740,16 +740,17 @@ def gen_router(storage: Storage) -> APIRouter:
         ),
     )
     def export_csv(
+        request: Request,
         keywords: List[str] = Query(..., description="カンマ区切りのキーワード(OR検索)。最大50個、最低1個"),
         note_created_at_from: int = Query(..., description="ノート作成期間の開始(ミリ秒)"),
         note_created_at_to: int = Query(..., description="ノート作成期間の終了(ミリ秒)"),
     ) -> Response:
-        parsed_keywords = [
-            token.strip()
-            for keyword in keywords
-            for token in keyword.split(",")
-            if token.strip()
-        ]
+        if export_api_key and request.headers.get("X-API-Key") != export_api_key:
+            return JSONResponse(
+                status_code=401, content={"error": "unauthorized", "message": "Invalid or missing X-API-Key"}
+            )
+
+        parsed_keywords = [token.strip() for keyword in keywords for token in keyword.split(",") if token.strip()]
         if not parsed_keywords:
             return _csv_export_error("invalid_keywords", "キーワードは1個以上指定してください")
         if len(parsed_keywords) > _CSV_EXPORT_MAX_KEYWORDS:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -71,6 +71,7 @@ testpaths = ["tests", "birdxplorer_api"]
 filterwarnings = [
     "error",
     "ignore:The \\'app\\' shortcut is now deprecated. Use the explicit style \\'transport=WSGITransport\\(app=\\.\\.\\.\\)\\' instead\\.",
+    "ignore::starlette.exceptions.StarletteDeprecationWarning",
 ]
 
 [tool.black]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -657,6 +657,7 @@ def global_settings_factory(
 
         cors_settings = cors_settings_factory.build()
         storage_settings = postgres_storage_settings_factory.build()
+        export_api_key = None
 
     return GlobalSettingsFactory
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import random
 from collections.abc import Generator
 from datetime import datetime, timezone
-from typing import List, Type, Union
+from typing import Any, List, Type, Union
 from unittest.mock import MagicMock, patch
 
 from dotenv import load_dotenv
@@ -592,6 +592,17 @@ def mock_storage(
         return "2025-01-15"
 
     mock.get_graph_updated_at.side_effect = _get_graph_updated_at
+
+    def _search_notes_with_posts_for_csv(
+        keywords: List[str],
+        note_created_at_from: int,
+        note_created_at_to: int,
+        limit: int = 5000,
+    ) -> List[Any]:
+        # Default: return empty. Tests override via mock.search_notes_with_posts_for_csv.return_value.
+        return []
+
+    mock.search_notes_with_posts_for_csv.side_effect = _search_notes_with_posts_for_csv
 
     yield mock
 

--- a/api/tests/routers/test_data_csv_export.py
+++ b/api/tests/routers/test_data_csv_export.py
@@ -108,7 +108,7 @@ def test_header_row_lists_all_columns(client: TestClient, mock_storage: MagicMoc
     reader = csv.reader(io.StringIO(text))
     header = next(reader)
     assert header == [
-        "ポスト(投稿)日時",
+        "ポスト（投稿）日時",
         "ポスト",
         "コミュニティノート作成日時",
         "コミュニティノート",

--- a/api/tests/routers/test_data_csv_export.py
+++ b/api/tests/routers/test_data_csv_export.py
@@ -1,0 +1,276 @@
+"""Tests for GET /api/v1/data/export/csv.
+
+See specs/002-csv-export-api/ for the design.
+"""
+
+import csv
+import io
+import re
+from types import SimpleNamespace
+from typing import Any, List, cast
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from birdxplorer_common.storage import CsvExportRow, NoteRecord, PostRecord
+
+# 30日 = 2592000000 ms
+_VALID_FROM = 1700000000000
+_VALID_TO = 1700100000000  # ~ 27.7 hours later
+
+
+def _build_row(
+    *,
+    note_id: str = "4000000000000000001",
+    note_summary: str = "医療にかんしては〜の見解です",
+    note_created_at: int = 1700000050000,
+    note_author_participant_id: str = "A" * 64,
+    note_rate_count: int = 10,
+    note_helpful_count: int = 5,
+    note_somewhat_helpful_count: int = 2,
+    note_not_helpful_count: int = 1,
+    post_id: str = "3000000000000000001",
+    post_text: str = "ポスト本文1",
+    post_created_at: int = 1700000000000,
+    post_aggregated_at: int = 1700000900000,
+    post_like_count: int = 1,
+    post_repost_count: int = 2,
+    post_impression_count: int = 100,
+    user_id: str = "9999999999999999991",
+    user_name: str = "csv_test_user",
+    status: str = "NEEDS_MORE_RATINGS",
+) -> CsvExportRow:
+    user = SimpleNamespace(name=user_name)
+    note = SimpleNamespace(
+        note_id=note_id,
+        summary=note_summary,
+        created_at=note_created_at,
+        note_author_participant_id=note_author_participant_id,
+        rate_count=note_rate_count,
+        helpful_count=note_helpful_count,
+        somewhat_helpful_count=note_somewhat_helpful_count,
+        not_helpful_count=note_not_helpful_count,
+    )
+    post = SimpleNamespace(
+        post_id=post_id,
+        text=post_text,
+        created_at=post_created_at,
+        aggregated_at=post_aggregated_at,
+        like_count=post_like_count,
+        repost_count=post_repost_count,
+        impression_count=post_impression_count,
+        user_id=user_id,
+        user=user,
+    )
+    return CsvExportRow(note=cast(NoteRecord, note), post=cast(PostRecord, post), status=status)
+
+
+def _set_storage_rows(mock_storage: MagicMock, rows: List[CsvExportRow]) -> None:
+    def _impl(**_kwargs: Any) -> List[CsvExportRow]:
+        return rows
+
+    mock_storage.search_notes_with_posts_for_csv.side_effect = _impl
+
+
+# --- Tests ------------------------------------------------------------------
+
+
+def test_returns_200_with_correct_headers(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(mock_storage, [_build_row()])
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "charset=utf-8" in response.headers["content-type"]
+    assert "attachment;" in response.headers["content-disposition"]
+    assert re.search(r'filename="community_notes_\d{8}_\d{6}\.csv"', response.headers["content-disposition"])
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_body_starts_with_utf8_bom(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(mock_storage, [_build_row()])
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    assert response.content[:3] == b"\xef\xbb\xbf"
+
+
+def test_header_row_lists_all_columns(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(mock_storage, [])
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    text = response.content.decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    header = next(reader)
+    assert header == [
+        "ポスト(投稿)日時",
+        "ポスト",
+        "コミュニティノート作成日時",
+        "コミュニティノート",
+        "ステータス",
+        "ポストURL",
+        "インプレッション数",
+        "Like数",
+        "リポスト数",
+        "評価数",
+        "役に立った",
+        "少し役に立った",
+        "役に立たなかった",
+        "コミュニティノートID",
+        "コミュニティノート作成者ID",
+        "投稿者ID",
+        "投稿者アカウント名",
+        "ポスト取得日時",
+    ]
+    assert next(reader, None) is None
+
+
+def test_data_row_format(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(mock_storage, [_build_row()])
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    text = response.content.decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    next(reader)  # skip header
+    row = next(reader)
+    # post.created_at=1700000000000 ms = 2023-11-14 22:13:20 UTC = 2023-11-15 07:13:20 JST
+    assert row[0] == "2023/11/15 07:13:20"
+    assert row[1] == "ポスト本文1"
+    assert row[2] == "2023/11/15 07:14:10"
+    assert row[3] == "医療にかんしては〜の見解です"
+    assert row[4] == "NEEDS_MORE_RATINGS"
+    assert row[5] == "https://twitter.com/i/web/status/3000000000000000001"
+    assert row[6] == "100"
+    assert row[7] == "1"
+    assert row[8] == "2"
+    assert row[9] == "10"
+    assert row[10] == "5"
+    assert row[11] == "2"
+    assert row[12] == "1"
+    assert row[13] == "4000000000000000001"
+    assert row[14] == "A" * 64
+    assert row[15] == "9999999999999999991"
+    assert row[16] == "csv_test_user"
+    assert row[17] == "2023/11/15 07:28:20"
+
+
+def test_quoting_for_special_characters(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(
+        mock_storage,
+        [
+            _build_row(
+                post_text='quoted "post", with, comma\nand newline',
+                note_summary='note has "double quotes"',
+            )
+        ],
+    )
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    text = response.content.decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    next(reader)  # header
+    row = next(reader)
+    # csv module で読み戻すと、エスケープ後の生値が復元される
+    assert row[1] == 'quoted "post", with, comma\nand newline'
+    assert row[3] == 'note has "double quotes"'
+
+
+def test_empty_result_returns_header_only(client: TestClient, mock_storage: MagicMock) -> None:
+    _set_storage_rows(mock_storage, [])
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    assert response.status_code == 200
+    text = response.content.decode("utf-8-sig")
+    rows = list(csv.reader(io.StringIO(text)))
+    assert len(rows) == 1  # header only
+
+
+def test_keywords_are_split_and_passed_to_storage(client: TestClient, mock_storage: MagicMock) -> None:
+    captured: dict[str, Any] = {}
+
+    def _impl(**kwargs: Any) -> List[CsvExportRow]:
+        captured.update(kwargs)
+        return []
+
+    mock_storage.search_notes_with_posts_for_csv.side_effect = _impl
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={
+            "keywords": "医療, 政治 ,,  ",  # trim & filter empty
+            "note_created_at_from": _VALID_FROM,
+            "note_created_at_to": _VALID_TO,
+        },
+    )
+    assert response.status_code == 200
+    assert captured["keywords"] == ["医療", "政治"]
+
+
+def test_400_when_period_exceeds_30_days(client: TestClient, mock_storage: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={
+            "keywords": "医療",
+            "note_created_at_from": _VALID_FROM,
+            "note_created_at_to": _VALID_FROM + 30 * 24 * 60 * 60 * 1000 + 1,
+        },
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body == {"error": "invalid_period", "message": "期間は最大30日です"}
+
+
+def test_400_when_from_greater_than_to(client: TestClient, mock_storage: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={
+            "keywords": "医療",
+            "note_created_at_from": _VALID_TO,
+            "note_created_at_to": _VALID_FROM,
+        },
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "invalid_period"
+
+
+def test_400_when_empty_keywords(client: TestClient, mock_storage: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "  , ,, ", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body == {"error": "invalid_keywords", "message": "キーワードは1個以上指定してください"}
+
+
+def test_400_when_too_many_keywords(client: TestClient, mock_storage: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={
+            "keywords": ",".join(f"kw{i}" for i in range(51)),
+            "note_created_at_from": _VALID_FROM,
+            "note_created_at_to": _VALID_TO,
+        },
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body == {"error": "too_many_keywords", "message": "キーワードは最大50個です"}
+
+
+def test_422_when_timestamp_not_integer(client: TestClient, mock_storage: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": "abc", "note_created_at_to": _VALID_TO},
+    )
+    assert response.status_code == 422

--- a/specs/002-csv-export-api/data-model.md
+++ b/specs/002-csv-export-api/data-model.md
@@ -77,19 +77,14 @@ CSV エクスポート API が使用するデータモデル、JOIN 戦略、ス
 | `note_created_at_from` (ms) | `NoteRecord.created_at` | `created_at >= :from_ms` |
 | `note_created_at_to` (ms) | `NoteRecord.created_at` | `created_at <= :to_ms` |
 
-`_apply_filters` への追加パラメータ:
+CSV 専用メソッド `search_notes_with_posts_for_csv` の中で直接適用（_apply_filters は変更しない）:
 ```python
-note_includes_texts: Union[List[str], None] = None  # OR 検索用
-```
-適用ロジック:
-```python
-if note_includes_texts:
-    query = query.filter(
-        or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in note_includes_texts])
-    )
+query = query.filter(
+    or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in keywords])
+)
 ```
 
-既存の単数 `note_includes_text` と併用された場合は AND として両方適用（破壊的変更を避ける）。
+> **Note**: 当初は `_apply_filters` 拡張を予定していたが、副作用ゼロのため独立クエリ方式を採用（[plan.md](./plan.md) D-1 参照）。
 
 ## Status resolution
 

--- a/specs/002-csv-export-api/plan.md
+++ b/specs/002-csv-export-api/plan.md
@@ -8,9 +8,10 @@
 `/api/v1/data/export/csv` を追加し、キーワード（カンマ区切り・OR検索・最大50個）と作成期間（ミリ秒、最大30日）を指定して、コミュニティノート + ポストの組を CSV (UTF-8 BOM 付き、StreamingResponse) でダウンロードできるようにする。
 
 **Technical Approach**:
-- 既存 `_apply_filters` ([common/birdxplorer_common/storage.py:1530](../../common/birdxplorer_common/storage.py#L1530)) に複数キーワード OR 検索パラメータを追加
-- ステータス解決のため `RowNoteStatusRecord` を LEFT JOIN し、`COALESCE(locked_status, current_status)` 相当の解決ロジックを Python 側で適用
-- `api/birdxplorer_api/routers/data.py` に新エンドポイントを追加し、`StreamingResponse` で 1 行ずつ CSV を yield
+- `common/birdxplorer_common/storage.py` に CSV 専用の `search_notes_with_posts_for_csv` メソッドと戻り値型 `CsvExportRow` を追加（独立クエリ。`_apply_filters` には触らない）
+- ステータス解決のため `RowNoteStatusRecord` を LEFT JOIN し、Python 側で `locked_status or current_status or ""` の優先順位で解決
+- `api/birdxplorer_api/routers/data.py` に新エンドポイントを追加し、`StreamingResponse` で BOM → ヘッダ → 1 行ずつ CSV を yield
+- カンマ分割は既存 `QueryStringFlatteningMiddleware` ([api/birdxplorer_api/app.py:20-39](../../api/birdxplorer_api/app.py#L20-L39)) に委ね、エンドポイント側は `keywords: List[str]` で受け取る
 - 日時整形は `zoneinfo.ZoneInfo("Asia/Tokyo")` を利用
 
 ## Technical Context
@@ -84,16 +85,16 @@ common/
 
 ## Design Decisions
 
-### D-1: OR 検索の実装方針 — 既存 `_apply_filters` を拡張
+### D-1: OR 検索の実装方針 — CSV 専用の独立クエリ（実装時更新）
 
-`_apply_filters` に新パラメータ `note_includes_texts: Union[List[str], None] = None` を追加し、`or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in keywords])` を AND として合流させる。
+当初は既存 `_apply_filters` の拡張を予定していたが、実装着手時に CSV 専用メソッド内で独立 SQL を構築する形に変更した。`search_notes_with_posts_for_csv` の中で `or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in keywords])` を直接 query にチェインする。
 
-**Why**:
-- 既存の `note_includes_text`（単数）と互換性を維持（両指定時は AND）
-- 将来 `/api/v1/data/search` でも OR 検索に対応できる拡張ポイント
-- 単一機能のための新メソッド分岐を作らず、テスト面でも統一できる
+**Why（変更理由）**:
+- 既存 `search_notes_with_posts` / `/api/v1/data/search` への副作用ゼロ（シグネチャと挙動を保てる）
+- CSV 専用パスは INNER JOIN / LEFT JOIN / 安定ソート / LIMIT 5000 など制約が固定なので、汎用ヘルパに合流させる動機が薄い
+- テストが独立メソッド単位で完結する
 
-**Trade-off**: `_apply_filters` のシグネチャが 1 つ増える。許容範囲。
+**Trade-off**: 将来 search エンドポイントにも OR 検索が必要になった場合は `_apply_filters` を別途拡張する。本タスクのスコープ外として後送り。
 
 ### D-2: ステータス解決 — `RowNoteStatusRecord` を LEFT JOIN
 

--- a/specs/002-csv-export-api/tasks.md
+++ b/specs/002-csv-export-api/tasks.md
@@ -15,10 +15,10 @@
 
 ## Phase 1: Foundation（既存資産の調査と前提整備）
 
-- [ ] **T-001**: `_apply_filters` の現状コードを再確認（[common/birdxplorer_common/storage.py:1530](../../common/birdxplorer_common/storage.py#L1530)）
-- [ ] **T-002**: `search_notes_with_posts` のシグネチャを確認、新パラメータ追加箇所を特定
-- [ ] **T-003**: `RowNoteStatusRecord` の SQLAlchemy 定義を確認、JOIN 条件を確定
-- [ ] **T-004**: `api/tests/conftest.py` の `mock_storage` フィクスチャ構造を確認
+- [X] **T-001**: `_apply_filters` の現状コードを再確認（[common/birdxplorer_common/storage.py:1510](../../common/birdxplorer_common/storage.py#L1510)）
+- [X] **T-002**: `search_notes_with_posts` のシグネチャを確認 → 独立メソッド方式に決定（plan.md D-1 更新）
+- [X] **T-003**: `RowNoteStatusRecord` の SQLAlchemy 定義を確認、JOIN 条件を確定
+- [X] **T-004**: `api/tests/conftest.py` の `mock_storage` フィクスチャ構造を確認
 
 ---
 
@@ -26,30 +26,30 @@
 
 ### Tests first
 
-- [ ] **T-010**: `common/tests/test_storage_csv_export.py` を新規作成し、以下のテストケースを記述（red 状態を確認）:
-  - `test_search_notes_or_match_single_keyword` — 1キーワードで OR 検索（既存単数フィルタとの差分を確認）
-  - `test_search_notes_or_match_multiple_keywords` — 2 キーワードで両方マッチする結果が含まれる
-  - `test_search_notes_or_no_match` — 期間内に該当ノートなし
-  - `test_status_resolution_prefers_locked_status` — `locked_status` がある場合にそちらが採用される
-  - `test_status_resolution_falls_back_to_current_status` — `locked_status` が None なら `current_status`
-  - `test_status_resolution_empty_when_no_row` — `row_note_status` 自体が None なら空文字
-  - `test_inner_join_excludes_orphan_notes` — `post_id` が None のノートは結果から除外
-  - `test_orders_by_created_at_then_id` — 安定ソート
-  - `test_limit_5000` — 5,001 件あるケースで 5,000 件で打ち切られる
+- [X] **T-010**: `common/tests/test_storage_csv_export.py` を新規作成し、以下のテストケースを記述（red 状態を確認）:
+  - `test_or_search_matches_single_keyword`
+  - `test_or_search_matches_multiple_keywords`
+  - `test_or_search_no_match_returns_empty`
+  - `test_inner_join_excludes_orphan_notes`
+  - `test_status_resolution_prefers_locked_status`
+  - `test_status_resolution_falls_back_to_current_status`
+  - `test_status_resolution_empty_when_no_row`
+  - `test_date_range_filter`
+  - `test_orders_by_created_at_then_id`
+  - `test_limit_caps_result_set`
 
 ### Implementation
 
-- [ ] **T-020**: `_apply_filters` に `note_includes_texts: Union[List[str], None] = None` を追加し、`or_(*[...])` でフィルタ適用
-- [ ] **T-021**: `search_notes_with_posts_for_csv()` メソッドを `Storage` クラスに追加
-  - パラメータ: `keywords: List[str]`, `note_created_at_from: TwitterTimestamp`, `note_created_at_to: TwitterTimestamp`
-  - 戻り値: `Iterator[Tuple[NoteRecord, PostRecord, Optional[str]]]`（`status` は解決済み文字列）
-  - INNER JOIN posts、LEFT JOIN row_note_status、ORDER BY、LIMIT 5000
-  - メモリ効率のため `yield_per(...)` または stream_results を検討（実装時に評価）
+- [X] ~~**T-020**: `_apply_filters` 拡張~~ → 取消（独立クエリ方式を採用、plan.md D-1）
+- [X] **T-021**: `search_notes_with_posts_for_csv()` メソッドと `CsvExportRow` NamedTuple を追加
+  - パラメータ: `keywords: List[str]`, `note_created_at_from/to: TwitterTimestamp`, `limit: int = 5000`
+  - 戻り値: `List[CsvExportRow]` (note: NoteRecord, post: PostRecord, status: str)
+  - INNER JOIN posts、LEFT JOIN row_note_status、ORDER BY note.created_at ASC, note_id ASC、LIMIT
 
 ### Verify
 
-- [ ] **T-030**: T-010 のテストを green に
-- [ ] **T-031**: `cd common && tox` で全 PASS（"congratulations :)" 確認）
+- [X] **T-030**: T-010 のテスト 10 件 すべて green
+- [X] **T-031**: `cd common && tox` で全 PASS（101 件 "congratulations :)"）
 
 ---
 
@@ -57,51 +57,37 @@
 
 ### Tests first
 
-- [ ] **T-040**: `api/tests/conftest.py` の `mock_storage` に `search_notes_with_posts_for_csv` の `side_effect` を追加
-- [ ] **T-041**: `api/tests/routers/test_data_csv_export.py` を新規作成、以下のテストケースを記述（red 確認）:
-  - `test_csv_export_returns_200_with_correct_headers` — Content-Type, Content-Disposition の検証
-  - `test_csv_export_body_starts_with_bom` — レスポンスボディの先頭が `﻿` (UTF-8 で `b'\xef\xbb\xbf'`)
-  - `test_csv_export_header_row` — ヘッダ行が 18 カラム、日本語名で出力
-  - `test_csv_export_data_row_format` — 日時が JST `YYYY/MM/DD HH:MM:SS` 形式
-  - `test_csv_export_status_locked_priority` — `locked_status` 優先で出力
-  - `test_csv_export_status_fallback_current` — `current_status` フォールバック
-  - `test_csv_export_post_url_format` — `https://twitter.com/i/web/status/{post_id}`
-  - `test_csv_export_csv_quoting_for_special_chars` — 改行・カンマ・`"` のエスケープ
-  - `test_csv_export_filename_pattern` — `community_notes_YYYYMMDD_HHMMSS.csv` パターン
-  - `test_csv_export_400_when_period_exceeds_30_days`
-  - `test_csv_export_400_when_too_many_keywords` — 51 個指定
-  - `test_csv_export_400_when_empty_keywords` — 空 / 全空白
-  - `test_csv_export_400_when_from_greater_than_to`
-  - `test_csv_export_422_when_invalid_timestamp` — `from=abc`
-  - `test_csv_export_empty_result_returns_header_only_csv`
+- [X] **T-040**: `api/tests/conftest.py` の `mock_storage` に `search_notes_with_posts_for_csv` の `side_effect` を追加（Any 型を `typing` から import）
+- [X] **T-041**: `api/tests/routers/test_data_csv_export.py` を新規作成、12 テストケースを記述
 
 ### Implementation
 
-- [ ] **T-050**: `api/birdxplorer_api/routers/data.py` に `GET /export/csv` を追加
-  - 関数: `async def export_csv(...)` または同期版
-  - Query パラメータ受け取り（`keywords: str`, `note_created_at_from: int`, `note_created_at_to: int`）
-  - バリデーション (期間、キーワード数、from≤to) → 400 with `{"error": "...", "message": "..."}`
-  - キーワードを `,` で split → trim → empty filter
-  - storage.search_notes_with_posts_for_csv(...) を呼び出し
-  - generator で 1 行ずつ CSV 化、StreamingResponse でラップ
-- [ ] **T-051**: ヘルパ関数 `_format_jst(ts_ms)`, `_generate_csv_stream(rows)`, `_resolve_status(row_status)` を `data.py` 内に追加（プライベート関数）
-- [ ] **T-052**: BOM 付与とヘッダ行 yield を generator の最初に組み込む
-- [ ] **T-053**: `Content-Disposition` ヘッダにファイル名（JST 現在時刻）を埋め込む
+- [X] **T-050**: `api/birdxplorer_api/routers/data.py` に `GET /export/csv` を追加
+  - `keywords: List[str]` で受け取り（カンマ分割は `QueryStringFlatteningMiddleware` に委任）
+  - バリデーション (期間≤30日、from≤to、1≤kw数≤50) → 400 with `JSONResponse({"error":..., "message":...})`
+  - storage.search_notes_with_posts_for_csv(...) を呼び出し、generator で 1 行ずつ CSV 化、StreamingResponse でラップ
+- [X] **T-051**: ヘルパ `_csv_export_format_jst(ts_ms)`, `_csv_export_row_values(row)`, `_csv_export_error(error, msg)` を `data.py` モジュールトップに配置
+- [X] **T-052**: BOM 付与とヘッダ行 yield を generator の最初に組み込む
+- [X] **T-053**: `Content-Disposition` ヘッダにファイル名（JST 現在時刻）を埋め込む
 
 ### Verify
 
-- [ ] **T-060**: T-041 のテストを green に
-- [ ] **T-061**: `cd api && tox` で全 PASS
+- [X] **T-060**: T-041 のテスト 12 件すべて green
+- [X] **T-061**: `cd api && tox` で全 PASS（105 件 "congratulations :)"）
+  - 副次変更: `api/pyproject.toml` の `filterwarnings` に `ignore::starlette.exceptions.StarletteDeprecationWarning` を追加（最新 starlette が出す `httpx2` 推奨の Deprecation を抑制）
 
 ---
 
 ## Phase 4: Polish
 
-- [ ] **T-070**: `quickstart.md` の手順に従い、ローカルで curl 検証
-- [ ] **T-071**: Excel (macOS or Windows) で開いて文字化けしないことを確認
-- [ ] **T-072**: 5,000 行のモック（または実 DB）で初回バイト送信 < 2s をストップウォッチで確認（best effort）
-- [ ] **T-073**: OpenAPI 自動生成ドキュメント（`/docs`）で新エンドポイントが表示されることを確認
-- [ ] **T-074**: 必要に応じて `api/birdxplorer_api/openapi_doc.py` に description を追加
+- [X] **T-070**: `quickstart.md` の手順に従い、ローカルで curl 検証
+  - 正常系（200, BOM ok, ヘッダ正常, データ 2 行, ステータス解決 locked 優先 ok）
+  - 400: 期間超過, from > to, 51 キーワード, 全空白キーワード
+  - 422: timestamp 非整数（middleware で空クエリ展開ケースも 422 で結果的にバリデーション）
+- [ ] **T-071**: Excel (macOS or Windows) で開いて文字化けしないことを確認（ローカル CLI 環境では未実施。BOM `EF BB BF` 付与は CLI で確認済み）
+- [ ] **T-072**: 5,000 行の実 DB で初回バイト送信 < 2s を測定（実データ未投入のため未実施）
+- [ ] **T-073**: OpenAPI 自動生成ドキュメント（`/docs`）で新エンドポイントが表示されることを確認（description は付与済み）
+- [ ] **T-074**: 必要に応じて `api/birdxplorer_api/openapi_doc.py` に description を追加（現状はエンドポイント側 description で十分と判断）
 - [ ] **T-075**: README 等で外部公開ドキュメントの更新が必要か確認（必要なければスキップ）
 
 ---


### PR DESCRIPTION
# feat(api): CSV エクスポート API エンドポイントの追加

Closes #237

## 概要

キーワード（OR 検索、最大 50 個）とノート作成期間（ミリ秒、最大 30 日）を指定して、コミュニティノート + 紐づくポスト情報を **UTF-8 BOM 付き CSV** でダウンロードできる API エンドポイントを追加した。

- エンドポイント: `GET /api/v1/data/export/csv`
- レスポンス: `StreamingResponse`（1 行ずつ生成）、`Content-Type: text/csv; charset=utf-8`、`Content-Disposition: attachment`
- 想定上限: 5,000 レコード

仕様の出典は [specs/002-csv-export-api/](specs/002-csv-export-api/) を参照。

## 変更ファイル

### API レイヤー

- [api/birdxplorer_api/routers/data.py](api/birdxplorer_api/routers/data.py): エンドポイント、CSV カラム定義、JST 整形ヘルパ、エラーヘルパ
- [api/tests/routers/test_data_csv_export.py](api/tests/routers/test_data_csv_export.py): 12 件の endpoint テスト
- [api/tests/conftest.py](api/tests/conftest.py): `mock_storage.search_notes_with_posts_for_csv` の `side_effect` 追加
- [api/pyproject.toml](api/pyproject.toml): `filterwarnings` に `StarletteDeprecationWarning` ignore を追加（最新 starlette が出す httpx2 推奨警告がテストを失敗させないため）

### Common テスト

- [common/tests/test_storage_csv_export.py](common/tests/test_storage_csv_export.py): fixture の Session に `expire_on_commit=False` を追加

### ドキュメント

- [specs/002-csv-export-api/plan.md](specs/002-csv-export-api/plan.md)
- [specs/002-csv-export-api/data-model.md](specs/002-csv-export-api/data-model.md)
- [specs/002-csv-export-api/tasks.md](specs/002-csv-export-api/tasks.md)

## 設計判断（plan.md より抜粋）

| ID | 決定 | 理由 |
|---|---|---|
| **D-1** | OR 検索は `_apply_filters` の拡張ではなく、CSV 専用の独立クエリで実装 | 既存 `/api/v1/data/search` への副作用ゼロ。CSV パスは制約（INNER JOIN/LIMIT 5000/固定ソート）が独自なので合流させる動機が薄い |
| **D-2** | ステータス値は `RowNoteStatusRecord` を LEFT JOIN で取得 | Issue 仕様で `RowNoteStatusRecord.locked_status > current_status` の優先順位が明記されており、ETL 生データに近い `row_note_status` を一次情報として尊重 |
| **D-3** | StreamingResponse の generator で BOM → ヘッダ → 1 行ずつ yield、`csv.QUOTE_MINIMAL` | RFC 4180 準拠のエスケープを自動化、メモリ効率と初回バイト送信時間を両立 |
| **D-4** | 日時整形は `zoneinfo.ZoneInfo("Asia/Tokyo")` で JST 固定 | クライアント側のタイムゾーン変換不要、Excel での日本語ユーザ体験優先 |
| **D-5** | 行数上限 5,000 をハードコード | Issue 本文の「想定 5,000 程度」を安全側で上限化 |
| **(追記)** | カンマ分割は既存 `QueryStringFlatteningMiddleware` に委任し、endpoint は `keywords: List[str]` で受ける | 既存パターン踏襲。さらに `8b33769` で二重 split による防御を追加 |

## API 仕様

### Request

```
GET /api/v1/data/export/csv
  ?keywords=医療,政治                     # 必須。カンマ区切り OR 検索、1〜50 個
  &note_created_at_from=1700000000000    # 必須。エポックミリ秒
  &note_created_at_to=1700100000000      # 必須。エポックミリ秒、from から最大 30 日
```

### Response

- **200 OK**: BOM 付き UTF-8 CSV、18 カラム（日本語ヘッダ）

```csv
﻿ポスト（投稿）日時,ポスト,コミュニティノート作成日時,コミュニティノート,ステータス,ポストURL,インプレッション数,Like数,リポスト数,評価数,役に立った,少し役に立った,役に立たなかった,コミュニティノートID,コミュニティノート作成者ID,投稿者ID,投稿者アカウント名,ポスト取得日時
```

- **400 Bad Request**: `{"error": "...", "message": "..."}`
  - `invalid_period` — 30 日超 / `from > to`
  - `invalid_keywords` — 0 個
  - `too_many_keywords` — 51 個以上
- **422 Unprocessable Entity**: 型が int でない timestamp 等（FastAPI デフォルト）

詳細は [specs/002-csv-export-api/contracts/csv-export-api.md](specs/002-csv-export-api/contracts/csv-export-api.md) を参照。

## テスト結果

| モジュール | tox 結果 |
|---|---|
| `common` | 101 件 PASS（`congratulations :)`） |
| `api` | 105 件 PASS（うち本 PR 追加分 12 件、`congratulations :)`） |

ゲート: `black` / `isort` / `pytest` / `pflake8` / `mypy --strict` 全 PASS。

### 追加されたテスト観点（api/tests/routers/test_data_csv_export.py、12 件）

- HTTP 200 とレスポンスヘッダ（Content-Type, Content-Disposition, Cache-Control, filename パターン）
- ボディ先頭の UTF-8 BOM（`\xef\xbb\xbf`）
- 18 カラムの日本語ヘッダ完全一致
- データ行の整形（JST 日時、ポスト URL、ステータス解決、各種カウント）
- RFC 4180 引用符エスケープ（カンマ・改行・ダブルクォート）
- 0 件マッチ時はヘッダ行のみ返却
- キーワード分割（middleware × endpoint の二重保険、trim、空要素除外）
- バリデーション 400: 期間 30 日超 / `from > to` / 空キーワード / 51 個以上
- バリデーション 422: timestamp 非整数

## 手動検証（ローカル）

ローカル PostgreSQL に検証データ 2 行を投入し、`curl` で実 DB 経由のレスポンスを確認:

- 200 OK、Content-Disposition の filename に JST タイムスタンプ
- ボディ先頭 3 バイト = `EF BB BF`（UTF-8 BOM）
- ステータス解決: `locked_status="LOCKED_HELPFUL"` がある行ではそちらが、無い行では `current_status` が出力
- 引用符・カンマ・改行を含むポスト本文が RFC 4180 で正しくエスケープ
- 400/422 バリデーションは各エラーケースで仕様通り

> Excel での文字化け非確認は CLI 環境制約のため未実施。BOM 付与は CLI で確認済み。

## 未対応 / Out of Scope

- ページネーション API（5,000 上限の単発ダウンロードのみ）
- 認証・レート制限
- 他フォーマット（XLSX, JSON）対応
- フロントエンド UI
- `pg_trgm` 等の検索インデックス追加（パフォーマンス問題が顕在化してから検討）
