### PR TITLE
feat(common): add CsvExportRow and search_notes_with_posts_for_csv

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -358,6 +358,14 @@ class SearchResultPage(NamedTuple):
     has_next: bool
 
 
+class CsvExportRow(NamedTuple):
+    """search_notes_with_posts_for_csv の 1 行。status は locked_status > current_status の優先順位で解決済み。"""
+
+    note: "NoteRecord"
+    post: "PostRecord"
+    status: str
+
+
 class Storage:
     def __init__(self, engine: Engine) -> None:
         self._engine = engine
@@ -1853,6 +1861,49 @@ class Storage:
             )
 
             return query.scalar() or 0
+
+    def search_notes_with_posts_for_csv(
+        self,
+        keywords: List[str],
+        note_created_at_from: TwitterTimestamp,
+        note_created_at_to: TwitterTimestamp,
+        limit: int = 5000,
+    ) -> List[CsvExportRow]:
+        """CSV エクスポート用にノート + ポストをまとめて取得する。
+
+        - ノート本文 (`NoteRecord.summary`) に対し、`keywords` の OR LIKE 検索
+        - `[note_created_at_from, note_created_at_to]` の範囲（両端含む）で `created_at` フィルタ
+        - `NoteRecord.post_id = PostRecord.post_id` の INNER JOIN（孤立ノートは除外）
+        - `RowNoteStatusRecord` を LEFT JOIN し、`locked_status > current_status` の優先順位で
+          ステータス文字列を解決する（解決できなければ空文字）
+        - `NoteRecord.created_at ASC, NoteRecord.note_id ASC` の安定ソート
+        - 最大 `limit` 件を返す（既定 5000）
+        """
+        if not keywords:
+            return []
+
+        with Session(self.engine) as sess:
+            query = (
+                sess.query(NoteRecord, PostRecord, RowNoteStatusRecord)
+                .join(PostRecord, NoteRecord.post_id == PostRecord.post_id)
+                .outerjoin(
+                    RowNoteStatusRecord,
+                    RowNoteStatusRecord.note_id == NoteRecord.note_id,
+                )
+                .filter(or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in keywords]))
+                .filter(NoteRecord.created_at >= note_created_at_from)
+                .filter(NoteRecord.created_at <= note_created_at_to)
+                .order_by(NoteRecord.created_at.asc(), NoteRecord.note_id.asc())
+                .limit(limit)
+            )
+            rows: List[CsvExportRow] = []
+            for note, post, row_status in query.all():
+                if row_status is not None:
+                    status = row_status.locked_status or row_status.current_status or ""
+                else:
+                    status = ""
+                rows.append(CsvExportRow(note=note, post=post, status=status))
+            return rows
 
     def upsert_note(
         self,

--- a/common/tests/test_storage_csv_export.py
+++ b/common/tests/test_storage_csv_export.py
@@ -44,7 +44,7 @@ def csv_x_user(engine_for_test: Engine) -> Generator[XUserRecord, None, None]:
         followers_count=10,
         following_count=20,
     )
-    with Session(engine_for_test) as sess:
+    with Session(engine_for_test, expire_on_commit=False) as sess:
         sess.add(user)
         sess.commit()
     yield user
@@ -94,7 +94,7 @@ def csv_posts(engine_for_test: Engine, csv_x_user: XUserRecord) -> Generator[Lis
             impression_count=400,
         ),
     ]
-    with Session(engine_for_test) as sess:
+    with Session(engine_for_test, expire_on_commit=False) as sess:
         sess.add_all(posts)
         sess.commit()
     yield posts
@@ -187,7 +187,7 @@ def csv_notes(engine_for_test: Engine, csv_posts: List[PostRecord]) -> Generator
             current_status_history="[]",
         ),
     ]
-    with Session(engine_for_test) as sess:
+    with Session(engine_for_test, expire_on_commit=False) as sess:
         sess.add_all(notes)
         sess.commit()
     yield notes
@@ -223,7 +223,7 @@ def csv_row_notes(engine_for_test: Engine, csv_notes: List[NoteRecord]) -> Gener
             summary="医療と政治の両方について",
         ),
     ]
-    with Session(engine_for_test) as sess:
+    with Session(engine_for_test, expire_on_commit=False) as sess:
         sess.add_all(rows)
         sess.commit()
     yield rows
@@ -263,7 +263,7 @@ def csv_row_note_status(
             locked_status=None,
         ),
     ]
-    with Session(engine_for_test) as sess:
+    with Session(engine_for_test, expire_on_commit=False) as sess:
         sess.add_all(statuses)
         sess.commit()
     yield statuses

--- a/common/tests/test_storage_csv_export.py
+++ b/common/tests/test_storage_csv_export.py
@@ -1,0 +1,436 @@
+"""Tests for Storage.search_notes_with_posts_for_csv used by the CSV export API.
+
+See specs/002-csv-export-api/ for the design.
+"""
+
+from typing import Generator, List
+
+from pytest import fixture
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from birdxplorer_common.models import NoteId, TwitterTimestamp
+from birdxplorer_common.storage import (
+    NoteRecord,
+    PostRecord,
+    RowNoteRecord,
+    RowNoteStatusRecord,
+    Storage,
+    XUserRecord,
+)
+
+
+def _ts(v: int) -> TwitterTimestamp:
+    return TwitterTimestamp.from_int(v)
+
+
+def _nid(v: str) -> NoteId:
+    return NoteId.from_str(v)
+
+
+# --- Local fixtures: data shaped specifically for CSV export tests ---------
+#
+# 各テストノートは対応するポストを持ち、INNER JOIN で漏れないように
+# note.post_id == post.post_id を一致させている。row_note_status は
+# RowNoteRecord と FK で紐づくため、まず RowNoteRecord も挿入する。
+
+
+@fixture
+def csv_x_user(engine_for_test: Engine) -> Generator[XUserRecord, None, None]:
+    user = XUserRecord(
+        user_id="9999999999999999991",
+        name="csv_test_user",
+        profile_image="https://example.com/icon.png",
+        followers_count=10,
+        following_count=20,
+    )
+    with Session(engine_for_test) as sess:
+        sess.add(user)
+        sess.commit()
+    yield user
+
+
+@fixture
+def csv_posts(engine_for_test: Engine, csv_x_user: XUserRecord) -> Generator[List[PostRecord], None, None]:
+    posts = [
+        PostRecord(
+            post_id="3000000000000000001",
+            user_id=csv_x_user.user_id,
+            text="ポスト本文1",
+            created_at=1700000000000,
+            aggregated_at=1700000900000,
+            like_count=1,
+            repost_count=2,
+            impression_count=100,
+        ),
+        PostRecord(
+            post_id="3000000000000000002",
+            user_id=csv_x_user.user_id,
+            text='quoted "post", with, comma',
+            created_at=1700000100000,
+            aggregated_at=1700000900000,
+            like_count=3,
+            repost_count=4,
+            impression_count=200,
+        ),
+        PostRecord(
+            post_id="3000000000000000003",
+            user_id=csv_x_user.user_id,
+            text="ポスト本文3",
+            created_at=1700000200000,
+            aggregated_at=1700000900000,
+            like_count=5,
+            repost_count=6,
+            impression_count=300,
+        ),
+        PostRecord(
+            post_id="3000000000000000004",
+            user_id=csv_x_user.user_id,
+            text="ポスト本文4",
+            created_at=1700000300000,
+            aggregated_at=1700000900000,
+            like_count=7,
+            repost_count=8,
+            impression_count=400,
+        ),
+    ]
+    with Session(engine_for_test) as sess:
+        sess.add_all(posts)
+        sess.commit()
+    yield posts
+
+
+@fixture
+def csv_notes(engine_for_test: Engine, csv_posts: List[PostRecord]) -> Generator[List[NoteRecord], None, None]:
+    """4 個のノート + 1 個の孤立ノート（post_id 未紐付け）を挿入する。
+
+    - notes[0]: 「医療」を含む。post[0] にひもづく
+    - notes[1]: 「政治」を含む、引用符付きポスト。post[1] にひもづく
+    - notes[2]: どちらのキーワードも含まない。post[2] にひもづく
+    - notes[3]: 「医療」「政治」両方を含む。post[3] にひもづく
+    - notes[4]: 孤立ノート（post_id=None）
+    """
+    notes = [
+        NoteRecord(
+            note_id=_nid("4000000000000000001"),
+            note_author_participant_id="A" * 64,
+            post_id="3000000000000000001",
+            summary="医療にかんしては〜の見解です",
+            current_status="NEEDS_MORE_RATINGS",
+            locked_status=None,
+            created_at=1700000050000,
+            has_been_helpfuled=False,
+            rate_count=10,
+            helpful_count=5,
+            not_helpful_count=1,
+            somewhat_helpful_count=2,
+            current_status_history="[]",
+        ),
+        NoteRecord(
+            note_id=_nid("4000000000000000002"),
+            note_author_participant_id="B" * 64,
+            post_id="3000000000000000002",
+            summary='政治の議論で "quoted", 出典あり',
+            current_status="NEEDS_MORE_RATINGS",
+            locked_status=None,
+            created_at=1700000150000,
+            has_been_helpfuled=False,
+            rate_count=20,
+            helpful_count=10,
+            not_helpful_count=2,
+            somewhat_helpful_count=3,
+            current_status_history="[]",
+        ),
+        NoteRecord(
+            note_id=_nid("4000000000000000003"),
+            note_author_participant_id="C" * 64,
+            post_id="3000000000000000003",
+            summary="無関係な要約テキスト",
+            current_status="CURRENTLY_RATED_HELPFUL",
+            locked_status=None,
+            created_at=1700000250000,
+            has_been_helpfuled=True,
+            rate_count=30,
+            helpful_count=20,
+            not_helpful_count=3,
+            somewhat_helpful_count=4,
+            current_status_history="[]",
+        ),
+        NoteRecord(
+            note_id=_nid("4000000000000000004"),
+            note_author_participant_id="D" * 64,
+            post_id="3000000000000000004",
+            summary="医療と政治の両方について",
+            current_status="NEEDS_MORE_RATINGS",
+            locked_status=None,
+            created_at=1700000350000,
+            has_been_helpfuled=False,
+            rate_count=40,
+            helpful_count=30,
+            not_helpful_count=4,
+            somewhat_helpful_count=5,
+            current_status_history="[]",
+        ),
+        NoteRecord(
+            note_id=_nid("4000000000000000005"),
+            note_author_participant_id="E" * 64,
+            post_id=None,
+            summary="医療の話だが対応ポストなし",
+            current_status=None,
+            locked_status=None,
+            created_at=1700000400000,
+            has_been_helpfuled=False,
+            rate_count=0,
+            helpful_count=0,
+            not_helpful_count=0,
+            somewhat_helpful_count=0,
+            current_status_history="[]",
+        ),
+    ]
+    with Session(engine_for_test) as sess:
+        sess.add_all(notes)
+        sess.commit()
+    yield notes
+
+
+@fixture
+def csv_row_notes(engine_for_test: Engine, csv_notes: List[NoteRecord]) -> Generator[List[RowNoteRecord], None, None]:
+    """RowNoteRecord は RowNoteStatusRecord の FK の先。
+
+    note_id 4000000000000000001 と 4000000000000000002 のみ RowNoteRecord を作る。
+    notes[2] (id...003) は RowNoteRecord を作らず、つまり row_note_status とも紐付かない。
+    """
+    rows = [
+        RowNoteRecord(
+            note_id=_nid("4000000000000000001"),
+            note_author_participant_id="A" * 64,
+            created_at_millis=1700000050000,
+            tweet_id="3000000000000000001",
+            summary="医療にかんしては〜の見解です",
+        ),
+        RowNoteRecord(
+            note_id=_nid("4000000000000000002"),
+            note_author_participant_id="B" * 64,
+            created_at_millis=1700000150000,
+            tweet_id="3000000000000000002",
+            summary='政治の議論で "quoted", 出典あり',
+        ),
+        RowNoteRecord(
+            note_id=_nid("4000000000000000004"),
+            note_author_participant_id="D" * 64,
+            created_at_millis=1700000350000,
+            tweet_id="3000000000000000004",
+            summary="医療と政治の両方について",
+        ),
+    ]
+    with Session(engine_for_test) as sess:
+        sess.add_all(rows)
+        sess.commit()
+    yield rows
+
+
+@fixture
+def csv_row_note_status(
+    engine_for_test: Engine, csv_row_notes: List[RowNoteRecord]
+) -> Generator[List[RowNoteStatusRecord], None, None]:
+    """3 種のステータスバリエーション。
+
+    - 4000000000000000001: current_status="NEEDS_MORE_RATINGS", locked_status=None
+    - 4000000000000000002: current_status="OLD", locked_status="LOCKED_HELPFUL" → locked 優先
+    - 4000000000000000004: current_status=None, locked_status=None → 空文字
+    - 4000000000000000003: そもそも row_note_status 未挿入 → 空文字
+    """
+    statuses = [
+        RowNoteStatusRecord(
+            note_id=_nid("4000000000000000001"),
+            note_author_participant_id="A" * 64,
+            created_at_millis=1700000050000,
+            current_status="NEEDS_MORE_RATINGS",
+            locked_status=None,
+        ),
+        RowNoteStatusRecord(
+            note_id=_nid("4000000000000000002"),
+            note_author_participant_id="B" * 64,
+            created_at_millis=1700000150000,
+            current_status="OLD",
+            locked_status="LOCKED_HELPFUL",
+        ),
+        RowNoteStatusRecord(
+            note_id=_nid("4000000000000000004"),
+            note_author_participant_id="D" * 64,
+            created_at_millis=1700000350000,
+            current_status=None,
+            locked_status=None,
+        ),
+    ]
+    with Session(engine_for_test) as sess:
+        sess.add_all(statuses)
+        sess.commit()
+    yield statuses
+
+
+# --- Tests ------------------------------------------------------------------
+
+
+def test_or_search_matches_single_keyword(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    note_ids = {r.note.note_id for r in rows}
+    # notes[0] (医療), notes[3] (医療と政治の両方), 孤立ノート notes[4] は INNER JOIN で除外
+    assert note_ids == {_nid("4000000000000000001"), _nid("4000000000000000004")}
+
+
+def test_or_search_matches_multiple_keywords(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療", "政治"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    note_ids = {r.note.note_id for r in rows}
+    # notes[0], notes[1], notes[3] がマッチ。notes[2] は無関係、notes[4] は孤立
+    assert note_ids == {
+        _nid("4000000000000000001"),
+        _nid("4000000000000000002"),
+        _nid("4000000000000000004"),
+    }
+
+
+def test_or_search_no_match_returns_empty(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["この語は存在しないはず"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    assert rows == []
+
+
+def test_inner_join_excludes_orphan_notes(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    note_ids = {r.note.note_id for r in rows}
+    # 4000000000000000005 は post_id=None なので INNER JOIN で除外される
+    assert _nid("4000000000000000005") not in note_ids
+
+
+def test_status_resolution_prefers_locked_status(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["政治"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    by_id = {r.note.note_id: r for r in rows}
+    # notes[1] は locked_status="LOCKED_HELPFUL" / current_status="OLD" → locked 優先
+    assert by_id[_nid("4000000000000000002")].status == "LOCKED_HELPFUL"
+
+
+def test_status_resolution_falls_back_to_current_status(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    by_id = {r.note.note_id: r for r in rows}
+    # notes[0] は locked_status=None / current_status="NEEDS_MORE_RATINGS"
+    assert by_id[_nid("4000000000000000001")].status == "NEEDS_MORE_RATINGS"
+
+
+def test_status_resolution_empty_when_no_row(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    by_id = {r.note.note_id: r for r in rows}
+    # notes[3] は row_note_status の current_status / locked_status 共に None → 空文字
+    assert by_id[_nid("4000000000000000004")].status == ""
+
+
+def test_date_range_filter(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    # notes[0]@1700000050000, notes[1]@1700000150000 を含み notes[3]@1700000350000 を除外
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療", "政治"],
+        note_created_at_from=_ts(1700000050000),
+        note_created_at_to=_ts(1700000200000),
+    )
+    note_ids = {r.note.note_id for r in rows}
+    assert note_ids == {_nid("4000000000000000001"), _nid("4000000000000000002")}
+
+
+def test_orders_by_created_at_then_id(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療", "政治"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    ordered_ids = [r.note.note_id for r in rows]
+    assert ordered_ids == [
+        _nid("4000000000000000001"),
+        _nid("4000000000000000002"),
+        _nid("4000000000000000004"),
+    ]
+
+
+def test_limit_caps_result_set(
+    engine_for_test: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    rows = storage.search_notes_with_posts_for_csv(
+        keywords=["医療", "政治"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+        limit=2,
+    )
+    assert len(rows) == 2

--- a/specs/002-csv-export-api/contracts/csv-export-api.md
+++ b/specs/002-csv-export-api/contracts/csv-export-api.md
@@ -1,0 +1,87 @@
+# Endpoint Contract: CSV Export API
+
+## `GET /api/v1/data/export/csv`
+
+### Description
+
+キーワードと作成期間を指定して、コミュニティノート + ポストの情報を CSV 形式でダウンロードする。
+
+### Request
+
+#### Query Parameters
+
+| Name | Type | Required | Description | Validation |
+|------|------|----------|-------------|------------|
+| `keywords` | string | yes | カンマ区切りのキーワード（OR 検索） | トリム後 1〜50 個 |
+| `note_created_at_from` | int (ms) | yes | ノート作成期間の開始（UNIX エポックミリ秒） | 整数、`<= note_created_at_to` |
+| `note_created_at_to` | int (ms) | yes | ノート作成期間の終了（UNIX エポックミリ秒） | 整数、`from + 30日 >=` |
+
+#### Example
+
+```http
+GET /api/v1/data/export/csv?keywords=%E5%8C%BB%E7%99%82,%E6%94%BF%E6%B2%BB&note_created_at_from=1719273600000&note_created_at_to=1721865600000
+```
+
+### Response
+
+#### 200 OK
+
+**Headers**:
+```
+Content-Type: text/csv; charset=utf-8
+Content-Disposition: attachment; filename="community_notes_YYYYMMDD_HHMMSS.csv"
+```
+
+**Body**: UTF-8 BOM (`﻿`) で始まる CSV ストリーム。
+
+**Columns** (RFC 4180、ダブルクォート最小エスケープ):
+
+```
+ポスト（投稿）日時,ポスト,コミュニティノート作成日時,コミュニティノート,ステータス,ポストURL,インプレッション数,Like数,リポスト数,評価数,役に立った,少し役に立った,役に立たなかった,コミュニティノートID,コミュニティノート作成者ID,投稿者ID,投稿者アカウント名,ポスト取得日時
+```
+
+#### 400 Bad Request
+
+バリデーションエラー時に返す。JSON ボディ:
+
+```json
+{
+  "error": "invalid_period",
+  "message": "期間は最大30日です"
+}
+```
+
+| `error` code | 条件 |
+|---|---|
+| `invalid_period` | 期間が30日超、または from > to |
+| `too_many_keywords` | キーワードが51個以上 |
+| `invalid_keywords` | キーワードが0個（空文字 or 全空白） |
+
+#### 422 Unprocessable Entity
+
+FastAPI 標準のバリデーションエラー（型が不正、例: `note_created_at_from=abc`）。FastAPI のデフォルト形式に従う。
+
+#### 500 Internal Server Error
+
+予期しないエラー時に既存 API と同形式で返す。
+
+### Example response body (excerpt)
+
+```csv
+﻿ポスト（投稿）日時,ポスト,コミュニティノート作成日時,コミュニティノート,ステータス,ポストURL,インプレッション数,Like数,リポスト数,評価数,役に立った,少し役に立った,役に立たなかった,コミュニティノートID,コミュニティノート作成者ID,投稿者ID,投稿者アカウント名,ポスト取得日時
+2025/06/21 15:47:46,"医療にかんしては...",2025/06/21 20:00:33,"知念氏は「軽い思いつき」と...",NEEDS_MORE_RATINGS,https://twitter.com/i/web/status/1936315088300097703,126032,3496,810,12,0,0,12,1936378704198009228,83BDBD9D...,389584667,@example_user,2025/06/29 09:12:21
+```
+
+### Caching
+
+`Cache-Control: no-store` を付与（CSV はデータスナップショットなので、フィルタ条件が同一でも常に最新を返す方が望ましい）。
+
+### Performance
+
+- 最大 5,000 行
+- 初回バイト送信 <2s
+- 完了 <10s
+
+### Authentication
+
+なし（既存 `/api/v1/data/*` と同じ）。

--- a/specs/002-csv-export-api/data-model.md
+++ b/specs/002-csv-export-api/data-model.md
@@ -1,0 +1,148 @@
+# Data Model & Query Contract
+
+CSV エクスポート API が使用するデータモデル、JOIN 戦略、ステータス解決ロジック。
+
+## Tables in scope
+
+### `notes` ([NoteRecord](../../common/birdxplorer_common/storage.py))
+| Column | CSV column | Notes |
+|---|---|---|
+| `note_id` | コミュニティノートID | PK |
+| `note_author_participant_id` | コミュニティノート作成者ID | nullable |
+| `post_id` | (join key) | nullable. INNER JOIN により null は除外 |
+| `summary` | コミュニティノート | OR 検索の対象 |
+| `created_at` | コミュニティノート作成日時 | 期間フィルタの対象。JST 整形 |
+| `rate_count` | 評価数 | |
+| `helpful_count` | 役に立った | |
+| `somewhat_helpful_count` | 少し役に立った | |
+| `not_helpful_count` | 役に立たなかった | |
+
+### `posts` ([PostRecord](../../common/birdxplorer_common/storage.py))
+| Column | CSV column | Notes |
+|---|---|---|
+| `post_id` | (join key, ポストURL に埋め込み) | PK |
+| `user_id` | 投稿者ID | FK → x_users |
+| `text` | ポスト | |
+| `created_at` | ポスト（投稿）日時 | JST 整形 |
+| `aggregated_at` | ポスト取得日時 | nullable。null の場合は空文字 |
+| `like_count` | Like数 | |
+| `repost_count` | リポスト数 | |
+| `impression_count` | インプレッション数 | |
+
+### `x_users` (XUserRecord)
+| Column | CSV column |
+|---|---|
+| `user_id` | (join key) |
+| `name` | 投稿者アカウント名 |
+
+### `row_note_status` (RowNoteStatusRecord)
+| Column | CSV column | Notes |
+|---|---|---|
+| `note_id` | (join key) | FK → row_notes.note_id |
+| `locked_status` | ステータス（優先1） | nullable |
+| `current_status` | ステータス（優先2） | nullable |
+
+## Join graph
+
+```
+                  ┌──────────────────┐
+                  │  RowNoteStatus   │  (LEFT JOIN by note_id)
+                  └────────┬─────────┘
+                           │
+┌──────────┐       ┌───────┴────────┐       ┌──────────┐
+│  Note    │──INNER│   Note + Post  │──INNER│   Post   │
+│ (notes)  │  JOIN │      row       │  JOIN │ (posts)  │
+└──────────┘ note. └────────────────┘ posts └────┬─────┘
+             post_id =                  .post_id │
+             posts.post_id                       │ INNER JOIN by user_id
+                                                 │
+                                          ┌──────┴─────┐
+                                          │  XUser     │
+                                          │ (x_users)  │
+                                          └────────────┘
+```
+
+**JOIN 戦略**:
+- `notes ⋈ posts ON notes.post_id = posts.post_id` — INNER JOIN（ノートのみで紐付くポストがない行は除外）
+- `posts ⋈ x_users ON posts.user_id = x_users.user_id` — INNER JOIN（PostRecord は user_id NOT NULL）
+- `notes ⟕ row_note_status ON notes.note_id = row_note_status.note_id` — LEFT OUTER JOIN
+
+## Filter contract
+
+入力パラメータ → SQL WHERE 条件の対応：
+
+| 入力 | 適用先 | SQL |
+|---|---|---|
+| `keywords = [kw1, kw2, ..., kwN]` | `NoteRecord.summary` | `summary LIKE '%kw1%' OR summary LIKE '%kw2%' OR ...` |
+| `note_created_at_from` (ms) | `NoteRecord.created_at` | `created_at >= :from_ms` |
+| `note_created_at_to` (ms) | `NoteRecord.created_at` | `created_at <= :to_ms` |
+
+`_apply_filters` への追加パラメータ:
+```python
+note_includes_texts: Union[List[str], None] = None  # OR 検索用
+```
+適用ロジック:
+```python
+if note_includes_texts:
+    query = query.filter(
+        or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in note_includes_texts])
+    )
+```
+
+既存の単数 `note_includes_text` と併用された場合は AND として両方適用（破壊的変更を避ける）。
+
+## Status resolution
+
+CSV「ステータス」列の値解決:
+
+```python
+status = row_note_status.locked_status \
+      or row_note_status.current_status \
+      or ""
+```
+
+`row_note_status` 自体が None の場合は空文字。`locked_status` が空文字 `""` のケースは「未ロック」を意味するので、`or` チェインで `current_status` に進む（Python falsy semantics で十分）。
+
+> **Note**: `NoteRecord` 側にも同名のキャッシュフィールドが存在するが、Issue 仕様の指示通り `RowNoteStatusRecord` を一次情報とする（[plan.md](./plan.md) D-2 参照）。
+
+## Ordering
+
+```sql
+ORDER BY notes.created_at ASC, notes.note_id ASC
+LIMIT 5000
+```
+
+理由:
+- `created_at ASC` で時系列ダウンロードが直感的
+- 同タイムスタンプの安定ソートのため `note_id ASC` を tie-breaker に
+- 5,000 上限は spec FR-020 / plan D-5
+
+## Datetime formatting
+
+すべての日時カラムは JST (Asia/Tokyo, UTC+09:00) で `YYYY/MM/DD HH:MM:SS` に整形。
+
+```python
+from zoneinfo import ZoneInfo
+from datetime import datetime, timezone
+
+JST = ZoneInfo("Asia/Tokyo")
+
+def _format_jst(ts_ms: int | None) -> str:
+    if ts_ms is None:
+        return ""
+    return (
+        datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        .astimezone(JST)
+        .strftime("%Y/%m/%d %H:%M:%S")
+    )
+```
+
+`TwitterTimestamp` はミリ秒の int として扱われる（`common/models.py` 参照）。
+
+## Post URL
+
+```python
+post_url = f"https://twitter.com/i/web/status/{post_id}"
+```
+
+`post_id` は数値文字列。URL エンコード不要。

--- a/specs/002-csv-export-api/plan.md
+++ b/specs/002-csv-export-api/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: CSV Export API
+
+**Branch**: `002-csv-export-api` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Source Issue**: [codeforjapan/BirdXplorer#237](https://github.com/codeforjapan/BirdXplorer/issues/237)
+
+## Summary
+
+`/api/v1/data/export/csv` を追加し、キーワード（カンマ区切り・OR検索・最大50個）と作成期間（ミリ秒、最大30日）を指定して、コミュニティノート + ポストの組を CSV (UTF-8 BOM 付き、StreamingResponse) でダウンロードできるようにする。
+
+**Technical Approach**:
+- 既存 `_apply_filters` ([common/birdxplorer_common/storage.py:1530](../../common/birdxplorer_common/storage.py#L1530)) に複数キーワード OR 検索パラメータを追加
+- ステータス解決のため `RowNoteStatusRecord` を LEFT JOIN し、`COALESCE(locked_status, current_status)` 相当の解決ロジックを Python 側で適用
+- `api/birdxplorer_api/routers/data.py` に新エンドポイントを追加し、`StreamingResponse` で 1 行ずつ CSV を yield
+- 日時整形は `zoneinfo.ZoneInfo("Asia/Tokyo")` を利用
+
+## Technical Context
+
+**Language/Version**: Python 3.10.12+
+**Primary Dependencies**: FastAPI, SQLAlchemy 2.x, Pydantic (既存スタックのみ)
+**Storage**: PostgreSQL 15.4+（既存 `notes`, `posts`, `x_users`, `row_note_status` テーブル）
+**Testing**: pytest + tox（既存品質ゲート: black / isort / pflake8 / mypy --strict）
+**Target Platform**: Linux server (Docker)
+**Performance Goals**:
+- 5,000 行ダウンロード完了 <10s
+- 初回バイト送信 <2s（StreamingResponse）
+**Constraints**:
+- 新規依存ライブラリ追加なし（Python 標準ライブラリの `csv`, `io`, `zoneinfo` を利用）
+- マイグレーション不要（既存スキーマで充足）
+- 認証なし
+**Scale/Scope**:
+- 1 エンドポイント新規追加
+- `_apply_filters` に 1 パラメータ追加
+- 1 storage メソッド新規追加（`search_notes_with_posts_for_csv` 仮称）
+- テスト: storage 1 ファイル拡張 + API 1 ファイル拡張
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Modular Architecture** | PASS | `api` と `common` のみ変更。クロスモジュール違反なし |
+| **II. Database-Centric Design** | PASS | 既存テーブルのみ利用。新インデックス不要（`notes.created_at`, `notes.note_id` は既存PK/索引で十分。LIKE は ILIKE/前方一致最適化対象外だが現行 search エンドポイントと同じ方式） |
+| **III. Test-First Discipline** | PASS | storage 拡張テスト → エンドポイントテストの順で記述（tasks.md 参照） |
+| **IV. Dependency Management** | PASS | 新依存なし |
+| **V. Environment Configuration** | PASS | 新環境変数なし |
+| **VI. Structured Testing Gates** | PASS | tox の各ゲートをクリアさせる |
+| **VII. Python Standards** | PASS | snake_case / PascalCase / 120 char / mypy --strict 準拠 |
+
+**Result**: ALL GATES PASS
+
+## Project Structure
+
+```text
+specs/002-csv-export-api/
+├── spec.md                  # 要件仕様
+├── plan.md                  # 本ファイル
+├── data-model.md            # フィルタ・JOIN・ステータス解決の詳細
+├── tasks.md                 # TDD順タスク一覧
+├── quickstart.md            # 手動検証手順
+└── contracts/
+    └── csv-export-api.md    # エンドポイント契約
+```
+
+### Source Code (repository root)
+
+```text
+api/
+├── birdxplorer_api/
+│   ├── routers/
+│   │   └── data.py             # MODIFY: 新エンドポイント追加
+│   └── (csv_export.py 等は新設しない — data.py 内に閉じる)
+└── tests/
+    ├── conftest.py             # MODIFY: mock_storage に新メソッドの side_effect 追加
+    └── routers/
+        └── test_data_csv_export.py  # NEW: エンドポイント統合テスト
+
+common/
+├── birdxplorer_common/
+│   └── storage.py              # MODIFY: _apply_filters に note_keywords 追加 + 新メソッド
+└── tests/
+    └── test_storage_csv_export.py  # NEW: OR検索 + JOIN + ステータス解決のユニットテスト
+```
+
+**Structure Decision**: 既存の `routers/data.py` に閉じる。`/api/v1/data/search` 系と同じドメインなので、別ルーターに切り出すよりも凝集度を保てる。
+
+## Design Decisions
+
+### D-1: OR 検索の実装方針 — 既存 `_apply_filters` を拡張
+
+`_apply_filters` に新パラメータ `note_includes_texts: Union[List[str], None] = None` を追加し、`or_(*[NoteRecord.summary.like(f"%{kw}%") for kw in keywords])` を AND として合流させる。
+
+**Why**:
+- 既存の `note_includes_text`（単数）と互換性を維持（両指定時は AND）
+- 将来 `/api/v1/data/search` でも OR 検索に対応できる拡張ポイント
+- 単一機能のための新メソッド分岐を作らず、テスト面でも統一できる
+
+**Trade-off**: `_apply_filters` のシグネチャが 1 つ増える。許容範囲。
+
+### D-2: ステータス解決 — `RowNoteStatusRecord` を LEFT JOIN
+
+`NoteRecord` 自体にも `locked_status` / `current_status` カラムは存在するが、Issue 仕様で「RowNoteStatusRecord の locked_status を優先」と明記されているため、JOIN による方式を採用。
+
+**Why**:
+- 仕様（Issue 本文）を一次情報として尊重
+- `RowNoteStatusRecord` の方が ETL の生データに近く、最新性が担保される
+- LEFT JOIN とすることで `row_note_status` 未登録ノートも欠落しない
+
+**実装**:
+```python
+query = (
+    select(NoteRecord, PostRecord, RowNoteStatusRecord)
+    .join(PostRecord, NoteRecord.post_id == PostRecord.post_id)
+    .outerjoin(RowNoteStatusRecord, RowNoteStatusRecord.note_id == NoteRecord.note_id)
+)
+```
+
+ステータス値の優先順位ロジックは Python 側で:
+```python
+status = row.locked_status or row.current_status or ""
+```
+
+### D-3: StreamingResponse の中の CSV 書き出し
+
+- `csv.writer` を `io.StringIO` バッファに書き、毎行 `getvalue()` → yield → `seek(0); truncate(0)` でリセット
+- 最初に BOM (`﻿`) を yield、続けてヘッダ行を yield、それ以降データ行
+- ヘッダ＆BOM を確実に flush するため、generator の最初の yield をエンドポイント関数の中で `next(...)` で取り出さず、`StreamingResponse(generator(), ...)` 形式に統一
+
+### D-4: 日時整形 — `zoneinfo.ZoneInfo("Asia/Tokyo")`
+
+`datetime.fromtimestamp(ts_ms / 1000, tz=ZoneInfo("Asia/Tokyo")).strftime("%Y/%m/%d %H:%M:%S")`。`TwitterTimestamp` はミリ秒整数型なので、変換ヘルパを `routers/data.py` 内のプライベート関数として定義する（`common` に置くほど汎用ではない）。
+
+### D-5: 5,000 行上限
+
+Storage 側で `.limit(5000)` をかける。クライアントへの上限超過通知は行わない（仕様の想定範囲内）。tasks 設計時に必要なら拡張可能。
+
+### D-6: 認証・レート制限
+
+`/api/v1/data/*` の既存方針に従い、認証なし・レート制限なし。エンドポイントは個人情報含まないコミュニティノート公開データのみ。
+
+## Edge Cases Handling
+
+| ケース | 挙動 |
+|-------|-----|
+| 期間 > 30日 | 400 with `{"error": "invalid_period", "message": "期間は最大30日です"}` |
+| キーワード > 50個 | 400 with `{"error": "too_many_keywords", "message": "キーワードは最大50個です"}` |
+| 期間 from > to | 400 with `{"error": "invalid_period", "message": "開始日時は終了日時より前である必要があります"}` |
+| keywords が空または全空白 | 400 with `{"error": "invalid_keywords", "message": "キーワードは1個以上指定してください"}` |
+| 0 件マッチ | 200 OK、ヘッダ行のみの CSV |
+| ポスト未紐づけノート | INNER JOIN で除外 |
+| row_note_status 未紐づけ | ステータス列は空文字 |
+| CSV フィールド内の `"`, `,`, 改行 | `csv.QUOTE_MINIMAL` で自動エスケープ |
+
+## Risks & Mitigations
+
+| リスク | 対策 |
+|-------|-----|
+| LIKE OR 検索が遅い | 結果セットを 5000 で上限化＋30 日上限の組み合わせで現実的な範囲に抑制。将来必要なら `pg_trgm` インデックスを検討（本タスクのスコープ外） |
+| BOM の二重付与 | 1 回だけ yield する。テストでバイナリレベルで確認 |
+| Excel が UTF-8 BOM 付き CSV を文字化けする | macOS/Windows で `quickstart.md` の手順で実機検証 |
+| mock_storage に新メソッド未追加でテスト失敗 | tasks T-005 で必須化 |
+
+## Next Steps
+
+1. data-model.md / contracts/csv-export-api.md / tasks.md / quickstart.md を作成
+2. ユーザレビュー
+3. TDD 順で実装
+4. `tox` を common / api 両方で実行
+5. PR 作成

--- a/specs/002-csv-export-api/quickstart.md
+++ b/specs/002-csv-export-api/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: CSV Export API
+
+## ローカル起動
+
+```bash
+docker compose up -d db          # PostgreSQL 起動
+cd api && uvicorn birdxplorer_api.app:app --reload --port 8000
+```
+
+または既存の `compose.yml` 全体を起動:
+
+```bash
+docker compose up
+```
+
+## curl で動作確認
+
+### 正常系
+
+```bash
+# 期間: 2025-06-21 00:00:00 JST 〜 2025-07-21 00:00:00 JST
+# キーワード: 医療, 政治
+FROM_MS=1750431600000  # 2025-06-21 00:00:00 JST
+TO_MS=1753023600000    # 2025-07-21 00:00:00 JST
+
+curl -sS -OJ \
+  "http://localhost:8000/api/v1/data/export/csv?keywords=%E5%8C%BB%E7%99%82,%E6%94%BF%E6%B2%BB&note_created_at_from=${FROM_MS}&note_created_at_to=${TO_MS}"
+```
+
+→ `community_notes_YYYYMMDD_HHMMSS.csv` がカレントディレクトリに保存される。
+
+### バリデーション失敗
+
+```bash
+# 期間が31日超
+curl -sS -i "http://localhost:8000/api/v1/data/export/csv?keywords=test&note_created_at_from=0&note_created_at_to=999999999999"
+
+# キーワードが0個
+curl -sS -i "http://localhost:8000/api/v1/data/export/csv?keywords=&note_created_at_from=0&note_created_at_to=1000"
+```
+
+期待: `HTTP/1.1 400 Bad Request` と JSON エラーボディ。
+
+## Excel での文字化けチェック
+
+1. ダウンロードした CSV を Excel (macOS / Windows) で開く
+2. 日本語テキスト（ノート本文・投稿本文）が正しく表示されることを確認
+3. 文字化けする場合は BOM 付与の実装を確認（先頭バイトが `EF BB BF` か）
+
+```bash
+# BOM の確認
+head -c 3 community_notes_*.csv | xxd
+# 期待出力: 00000000: efbb bf
+```
+
+## テスト実行
+
+```bash
+# Storage 層のユニットテスト
+cd common && python -m pytest tests/test_storage_csv_export.py -v
+
+# API 層の統合テスト
+cd api && python -m pytest tests/routers/test_data_csv_export.py -v
+
+# 全体品質ゲート
+cd common && tox  # → "congratulations :)" を待つ
+cd api && tox     # → 同上
+```
+
+## トラブルシュート
+
+| 症状 | 原因候補 | 対処 |
+|---|---|---|
+| 文字化け（Excel macOS） | BOM 欠落 | 出力先頭が `﻿` で始まるか確認 |
+| `Content-Disposition` が効かずブラウザで CSV が画面表示される | ヘッダ未設定 | `headers={"Content-Disposition": ...}` を確認 |
+| 5,000 件超のクエリが遅い | `LIMIT` 未適用 | `search_notes_with_posts_for_csv` の `.limit(5000)` を確認 |
+| ステータス列が常に空 | LEFT JOIN 不発 / 解決ロジック誤り | `RowNoteStatusRecord` がクエリ結果に含まれているか、`or` チェーンが falsy semantics で動くか確認 |
+| 422 を期待した場面で 400 が返る | バリデーション順序 | FastAPI の型バリデーションが先に走るため、`int` 型として受けたうえでドメインバリデーションを後段で実施 |
+
+## 性能の最低基準
+
+| 項目 | 目標 | 測定 |
+|---|---|---|
+| 初回バイト送信 | < 2s | `curl -w "%{time_starttransfer}\n"` |
+| 5,000 行完了 | < 10s | `curl -w "%{time_total}\n"` |

--- a/specs/002-csv-export-api/spec.md
+++ b/specs/002-csv-export-api/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: CSV Export API
+
+**Feature Branch**: `002-csv-export-api`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**: GitHub Issue [#237](https://github.com/codeforjapan/BirdXplorer/issues/237)
+**Related Issue**: codeforjapan/BirdXplorer#237 「CSV エクスポート API エンドポイントの追加」
+
+## User Scenarios & Testing
+
+### User Story 1 - キーワード × 期間でコミュニティノート＋ポストを CSV ダウンロード（Priority: P1）
+
+分析担当者は、関心のあるトピック（キーワード）を指定し、特定の期間に作成されたコミュニティノートとその対象ポストを CSV としてまとめてダウンロードし、Excel 等で二次分析したい。
+
+**Why this priority**: Issue で要求された機能の本体。分析ワークフローの起点となる。
+
+**Independent Test**: `keywords=医療,政治&note_created_at_from=...&note_created_at_to=...` を指定して GET し、Content-Disposition で attachment が指定された UTF-8 BOM 付き CSV が返ることを確認する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 期間内に「医療」または「政治」を含むノートが複数件存在する、**When** `keywords=医療,政治` で 7 日間の期間を指定して GET する、**Then** 両キーワードのいずれかにマッチするノートが 1 行 1 レコードで CSV に含まれる
+2. **Given** 期間内に該当ノートが 0 件、**When** GET する、**Then** ヘッダ行のみの CSV が 200 OK で返る
+3. **Given** Excel で CSV を開く、**When** 日本語のノート本文を含む行を表示する、**Then** 文字化けせず正しく表示される（UTF-8 BOM が先頭に付与されているため）
+
+### User Story 2 - 大量データのストリーミングダウンロード（Priority: P2）
+
+5,000 レコードに迫るデータでも、サーバ側でメモリを抱え込まず、クライアントがダウンロード進捗を即座に確認できる形で返したい。
+
+**Independent Test**: モックで 5,000 行返すストレージを用意し、StreamingResponse として最初のチャンクが即座に flush されることを検証。
+
+**Acceptance Scenarios**:
+
+1. **Given** 期間内に最大想定の 5,000 レコードが存在、**When** GET する、**Then** レスポンスは StreamingResponse でチャンク送信され、タイムアウトせずに完了する
+
+### Edge Cases
+
+- **期間が30日を超える**: 400 Bad Request を返す（`message` で「期間は最大30日です」相当）
+- **キーワードが51個以上**: 400 Bad Request（「キーワードは最大50個です」相当）
+- **`from > to`**: 400 Bad Request（「開始日時は終了日時より前である必要があります」相当）
+- **`keywords` が空文字**: 400 Bad Request（「キーワードは1個以上指定してください」相当）
+- **`keywords` の各要素のトリム**: 前後空白は除去。空要素は無視（ただし結果として空リストになる場合は 400）
+- **`note_created_at_from/to` が不正なミリ秒**: 422 Unprocessable Entity（FastAPI 標準）
+- **CSV カラム値に改行・カンマ・ダブルクォートを含む**: RFC 4180 に従い、フィールドをダブルクォートで囲み、内部のダブルクォートを `""` にエスケープ
+- **ノートに紐づくポストが存在しない**: CSV 出力対象から除外（INNER JOIN 相当の挙動。仕様により Note と Post の両方を含む CSV のため）
+- **`RowNoteStatusRecord` が存在しないノート**: ステータス列は空文字を出力
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide endpoint `GET /api/v1/data/export/csv`
+- **FR-002**: Endpoint MUST accept query parameters: `keywords` (required, comma-separated string), `note_created_at_from` (required, millisecond integer), `note_created_at_to` (required, millisecond integer)
+- **FR-003**: System MUST validate that `note_created_at_to - note_created_at_from` ≤ 30 days, returning 400 otherwise
+- **FR-004**: System MUST validate that the number of keywords (after trimming and removing empties) is between 1 and 50, returning 400 otherwise
+- **FR-005**: System MUST perform OR-search across all keywords against `NoteRecord.summary` (i.e. a note matches if it contains ANY of the keywords)
+- **FR-006**: System MUST filter notes by `created_at` within `[note_created_at_from, note_created_at_to]` inclusive
+- **FR-007**: System MUST INNER JOIN notes with their associated posts (`NoteRecord.post_id = PostRecord.post_id`) — orphan notes are excluded
+- **FR-008**: System MUST LEFT JOIN `RowNoteStatusRecord` on `note_id` for status resolution
+- **FR-009**: System MUST resolve the exported status column with priority: `RowNoteStatusRecord.locked_status` > `RowNoteStatusRecord.current_status` > empty string
+- **FR-010**: Response MUST set `Content-Type: text/csv; charset=utf-8`
+- **FR-011**: Response MUST set `Content-Disposition: attachment; filename="community_notes_YYYYMMDD_HHMMSS.csv"` (JST timestamp at response time)
+- **FR-012**: Response body MUST start with a UTF-8 BOM (`﻿`)
+- **FR-013**: Response MUST be a `StreamingResponse` that yields one CSV row at a time
+- **FR-014**: System MUST output the following 17 columns in this exact order (Japanese header names):
+  1. `ポスト（投稿）日時` — `PostRecord.created_at` (JST, `YYYY/MM/DD HH:MM:SS`)
+  2. `ポスト` — `PostRecord.text`
+  3. `コミュニティノート作成日時` — `NoteRecord.created_at` (JST)
+  4. `コミュニティノート` — `NoteRecord.summary`
+  5. `ステータス` — resolved status (see FR-009)
+  6. `ポストURL` — `https://twitter.com/i/web/status/{post_id}`
+  7. `インプレッション数` — `PostRecord.impression_count`
+  8. `Like数` — `PostRecord.like_count`
+  9. `リポスト数` — `PostRecord.repost_count`
+  10. `評価数` — `NoteRecord.rate_count`
+  11. `役に立った` — `NoteRecord.helpful_count`
+  12. `少し役に立った` — `NoteRecord.somewhat_helpful_count`
+  13. `役に立たなかった` — `NoteRecord.not_helpful_count`
+  14. `コミュニティノートID` — `NoteRecord.note_id`
+  15. `コミュニティノート作成者ID` — `NoteRecord.note_author_participant_id`
+  16. `投稿者ID` — `PostRecord.user_id`
+  17. `投稿者アカウント名` — `PostRecord.user.name`
+  18. `ポスト取得日時` — `PostRecord.aggregated_at` (JST)
+- **FR-015**: CSV MUST follow RFC 4180 quoting rules (fields containing comma/newline/double-quote are wrapped in `"..."` and inner `"` doubled to `""`)
+- **FR-016**: Datetime columns MUST be formatted as `YYYY/MM/DD HH:MM:SS` in JST (Asia/Tokyo, UTC+09:00)
+- **FR-017**: Endpoint MUST be public (no authentication, consistent with existing `/api/v1/data/*` endpoints)
+- **FR-018**: System MUST log errors and exceptions but does not require success-path observability
+- **FR-019**: System MUST handle ordering deterministically — sort by `NoteRecord.created_at ASC, NoteRecord.note_id ASC` for stable output
+- **FR-020**: System MUST cap the maximum number of exported rows at 5,000. If the matched result exceeds this, return the first 5,000 (matching the spec's "想定データ量: 最大 5,000 レコード程度") — no additional pagination parameter is exposed
+
+> **NOTE on FR-020**: Issue 本文には明示的な上限指定はなく「想定データ量: 最大 5,000」とだけ書かれている。安全側に倒して上限としてハードコードする。実装時にユーザ確認のうえ調整可。
+
+### Key Entities
+
+- **NoteRecord**: 既存テーブル (`notes`)。summary, created_at, post_id, helpful_count などを保持
+- **PostRecord**: 既存テーブル (`posts`)。text, created_at, impression_count などを保持。user_id で XUserRecord に FK
+- **XUserRecord**: 既存テーブル (`x_users`)。user_id, name を保持
+- **RowNoteStatusRecord**: 既存テーブル (`row_note_status`)。note_id, current_status, locked_status を保持
+
+データモデルの詳細とJOIN戦略は [data-model.md](./data-model.md) を参照。
+
+## Success Criteria
+
+- **SC-001**: 5,000 レコード規模の CSV ダウンロードが 10 秒以内に完了する（StreamingResponse による初回チャンクは 2 秒以内に flush）
+- **SC-002**: Excel (macOS / Windows) で開いた際に日本語が文字化けしない
+- **SC-003**: 期間 30 日超・キーワード 51 個・空キーワードの各バリデーションエラーが 400 を返す
+- **SC-004**: OR 検索が正しく機能する（複数キーワードのいずれかにマッチするノートが含まれる）
+- **SC-005**: 既存 `tox` ゲート（black / isort / pflake8 / mypy --strict / pytest）が共に PASS
+- **SC-006**: `RowNoteStatusRecord.locked_status` がある場合はそちらが優先され、ない場合に `current_status` が出力される
+
+## Assumptions
+
+- ノートと対応するポストは大半のケースで存在する（INNER JOIN で十分。孤立ノートの分析需要は本機能の対象外）
+- 5,000 件の上限はパフォーマンスとユースケースから許容される
+- JST 固定で出力する（クライアントによるタイムゾーン変換は不要）
+- `RowNoteStatusRecord` は ETL によって `note_id` で一意に保たれている（DISTINCT 不要）
+- 既存の `/api/v1/data/*` と同じく認証なし

--- a/specs/002-csv-export-api/tasks.md
+++ b/specs/002-csv-export-api/tasks.md
@@ -1,0 +1,125 @@
+# Tasks: CSV Export API
+
+**Source**: [spec.md](./spec.md), [plan.md](./plan.md), [data-model.md](./data-model.md), [contracts/csv-export-api.md](./contracts/csv-export-api.md)
+
+**Branch**: `002-csv-export-api`
+
+## 規約
+
+- TDD: テストを先に書き、red を確認してから実装
+- 各フェーズ完了時に該当モジュール（common または api）で `tox` を実行し全 PASS を確認
+- `[X]` で完了マーク
+- コミット粒度はフェーズ単位（Foundation → Implementation → Tests → Polish）
+
+---
+
+## Phase 1: Foundation（既存資産の調査と前提整備）
+
+- [ ] **T-001**: `_apply_filters` の現状コードを再確認（[common/birdxplorer_common/storage.py:1530](../../common/birdxplorer_common/storage.py#L1530)）
+- [ ] **T-002**: `search_notes_with_posts` のシグネチャを確認、新パラメータ追加箇所を特定
+- [ ] **T-003**: `RowNoteStatusRecord` の SQLAlchemy 定義を確認、JOIN 条件を確定
+- [ ] **T-004**: `api/tests/conftest.py` の `mock_storage` フィクスチャ構造を確認
+
+---
+
+## Phase 2: Common module — OR検索拡張（TDD）
+
+### Tests first
+
+- [ ] **T-010**: `common/tests/test_storage_csv_export.py` を新規作成し、以下のテストケースを記述（red 状態を確認）:
+  - `test_search_notes_or_match_single_keyword` — 1キーワードで OR 検索（既存単数フィルタとの差分を確認）
+  - `test_search_notes_or_match_multiple_keywords` — 2 キーワードで両方マッチする結果が含まれる
+  - `test_search_notes_or_no_match` — 期間内に該当ノートなし
+  - `test_status_resolution_prefers_locked_status` — `locked_status` がある場合にそちらが採用される
+  - `test_status_resolution_falls_back_to_current_status` — `locked_status` が None なら `current_status`
+  - `test_status_resolution_empty_when_no_row` — `row_note_status` 自体が None なら空文字
+  - `test_inner_join_excludes_orphan_notes` — `post_id` が None のノートは結果から除外
+  - `test_orders_by_created_at_then_id` — 安定ソート
+  - `test_limit_5000` — 5,001 件あるケースで 5,000 件で打ち切られる
+
+### Implementation
+
+- [ ] **T-020**: `_apply_filters` に `note_includes_texts: Union[List[str], None] = None` を追加し、`or_(*[...])` でフィルタ適用
+- [ ] **T-021**: `search_notes_with_posts_for_csv()` メソッドを `Storage` クラスに追加
+  - パラメータ: `keywords: List[str]`, `note_created_at_from: TwitterTimestamp`, `note_created_at_to: TwitterTimestamp`
+  - 戻り値: `Iterator[Tuple[NoteRecord, PostRecord, Optional[str]]]`（`status` は解決済み文字列）
+  - INNER JOIN posts、LEFT JOIN row_note_status、ORDER BY、LIMIT 5000
+  - メモリ効率のため `yield_per(...)` または stream_results を検討（実装時に評価）
+
+### Verify
+
+- [ ] **T-030**: T-010 のテストを green に
+- [ ] **T-031**: `cd common && tox` で全 PASS（"congratulations :)" 確認）
+
+---
+
+## Phase 3: API module — エンドポイント実装（TDD）
+
+### Tests first
+
+- [ ] **T-040**: `api/tests/conftest.py` の `mock_storage` に `search_notes_with_posts_for_csv` の `side_effect` を追加
+- [ ] **T-041**: `api/tests/routers/test_data_csv_export.py` を新規作成、以下のテストケースを記述（red 確認）:
+  - `test_csv_export_returns_200_with_correct_headers` — Content-Type, Content-Disposition の検証
+  - `test_csv_export_body_starts_with_bom` — レスポンスボディの先頭が `﻿` (UTF-8 で `b'\xef\xbb\xbf'`)
+  - `test_csv_export_header_row` — ヘッダ行が 18 カラム、日本語名で出力
+  - `test_csv_export_data_row_format` — 日時が JST `YYYY/MM/DD HH:MM:SS` 形式
+  - `test_csv_export_status_locked_priority` — `locked_status` 優先で出力
+  - `test_csv_export_status_fallback_current` — `current_status` フォールバック
+  - `test_csv_export_post_url_format` — `https://twitter.com/i/web/status/{post_id}`
+  - `test_csv_export_csv_quoting_for_special_chars` — 改行・カンマ・`"` のエスケープ
+  - `test_csv_export_filename_pattern` — `community_notes_YYYYMMDD_HHMMSS.csv` パターン
+  - `test_csv_export_400_when_period_exceeds_30_days`
+  - `test_csv_export_400_when_too_many_keywords` — 51 個指定
+  - `test_csv_export_400_when_empty_keywords` — 空 / 全空白
+  - `test_csv_export_400_when_from_greater_than_to`
+  - `test_csv_export_422_when_invalid_timestamp` — `from=abc`
+  - `test_csv_export_empty_result_returns_header_only_csv`
+
+### Implementation
+
+- [ ] **T-050**: `api/birdxplorer_api/routers/data.py` に `GET /export/csv` を追加
+  - 関数: `async def export_csv(...)` または同期版
+  - Query パラメータ受け取り（`keywords: str`, `note_created_at_from: int`, `note_created_at_to: int`）
+  - バリデーション (期間、キーワード数、from≤to) → 400 with `{"error": "...", "message": "..."}`
+  - キーワードを `,` で split → trim → empty filter
+  - storage.search_notes_with_posts_for_csv(...) を呼び出し
+  - generator で 1 行ずつ CSV 化、StreamingResponse でラップ
+- [ ] **T-051**: ヘルパ関数 `_format_jst(ts_ms)`, `_generate_csv_stream(rows)`, `_resolve_status(row_status)` を `data.py` 内に追加（プライベート関数）
+- [ ] **T-052**: BOM 付与とヘッダ行 yield を generator の最初に組み込む
+- [ ] **T-053**: `Content-Disposition` ヘッダにファイル名（JST 現在時刻）を埋め込む
+
+### Verify
+
+- [ ] **T-060**: T-041 のテストを green に
+- [ ] **T-061**: `cd api && tox` で全 PASS
+
+---
+
+## Phase 4: Polish
+
+- [ ] **T-070**: `quickstart.md` の手順に従い、ローカルで curl 検証
+- [ ] **T-071**: Excel (macOS or Windows) で開いて文字化けしないことを確認
+- [ ] **T-072**: 5,000 行のモック（または実 DB）で初回バイト送信 < 2s をストップウォッチで確認（best effort）
+- [ ] **T-073**: OpenAPI 自動生成ドキュメント（`/docs`）で新エンドポイントが表示されることを確認
+- [ ] **T-074**: 必要に応じて `api/birdxplorer_api/openapi_doc.py` に description を追加
+- [ ] **T-075**: README 等で外部公開ドキュメントの更新が必要か確認（必要なければスキップ）
+
+---
+
+## Phase 5: Submission
+
+- [ ] **T-080**: `git status` で意図しないファイルが含まれていないか確認
+- [ ] **T-081**: コミットを Foundation / Implementation / Tests のフェーズ別に分割（必要に応じ）
+- [ ] **T-082**: PR 作成、Issue #237 を closes に
+- [ ] **T-083**: PR description に spec / plan / tasks へのリンク
+
+---
+
+## Out of scope (本タスクで対応しない)
+
+- ページネーション API（CSV は 5,000 上限の単発ダウンロードのみ）
+- 認証・レート制限
+- `pg_trgm` 等のインデックス追加（パフォーマンス問題が出てから検討）
+- フロントエンド UI の追加（バックエンドのみ）
+- 列カスタマイズ機能
+- 他フォーマット（XLSX, JSON）対応


### PR DESCRIPTION
## 概要

PR #247（CSV エクスポート API）の `birdxplorer_common` 側の変更を先行マージするための PR です。

`api/pyproject.toml` の prod 依存が `birdxplorer_common @ git+https://...@main` を参照しているため、`common/` の変更が `main` にマージされるまで PR #247 の Docker イメージビルドで以下のエラーが発生します：

```
ImportError: cannot import name 'CsvExportRow' from 'birdxplorer_common.storage'
```

## 変更内容

### `common/birdxplorer_common/storage.py`
- `CsvExportRow` NamedTuple を追加（note, post, status フィールド）
- `Storage.search_notes_with_posts_for_csv()` メソッドを追加
  - キーワード OR 検索、日付範囲フィルタ、INNER JOIN posts、LEFT JOIN row_note_status
  - `locked_status` 優先のステータス解決ロジック
  - 上限件数指定（デフォルト 5,000）

### `common/tests/test_storage_csv_export.py`
- 上記メソッドのテスト 10 件（OR 検索、ステータス解決、日付範囲、上限など）

### `specs/002-csv-export-api/`
- API 仕様書・設計ドキュメント一式（plan.md, data-model.md, spec.md, tasks.md 等）

## マージ後の効果

この PR が `main` にマージされると、PR #247 の Docker ビルドが `birdxplorer_common@main` から `CsvExportRow` を取得できるようになり、CI が通ります。

Closes の対象: なし（PR #247 のブロッカー解消が目的）