### PR TITLE
feat(common): add export_api_key to GlobalSettings

### DIFF
--- a/common/birdxplorer_common/settings.py
+++ b/common/birdxplorer_common/settings.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import Field, PostgresDsn, computed_field
 from pydantic_settings import BaseSettings as PydanticBaseSettings
 from pydantic_settings import SettingsConfigDict
@@ -40,3 +42,4 @@ class GlobalSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
     logger_settings: LoggerSettings = Field(default_factory=LoggerSettings)
     storage_settings: PostgresStorageSettings
+    export_api_key: Optional[str] = None


### PR DESCRIPTION
## 概要

PR #247（CSV エクスポート API）のデプロイが以下のエラーで落ちているため、`birdxplorer_common` の `GlobalSettings` への `export_api_key` 追加を先行マージします。

```
AttributeError: 'GlobalSettings' object has no attribute 'export_api_key'
```

`api/pyproject.toml` の prod 依存が `birdxplorer_common @ git+https://...@main` を参照しているため、`common/` の変更は `main` にある必要があります（#248 と同様の対応）。

## 変更内容

`common/birdxplorer_common/settings.py` に `export_api_key: Optional[str] = None` を追加。  
環境変数名: `BX_EXPORT_API_KEY`

## 関連 PR

- #247 CSV エクスポート API（ブロック中）
- #248 `CsvExportRow` 先行マージ（マージ済み）