### PR TITLE
fix: グラフAPIクエリのwork_memを設定し本番タイムアウトを解消

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     func,
     or_,
     select,
+    text,
 )
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
@@ -665,6 +666,7 @@ class Storage:
 
         # Execute query
         with Session(self._engine) as session:
+            session.execute(text("SET LOCAL work_mem = '256MB'"))
             result = session.execute(query)
             rows = result.fetchall()
 
@@ -774,6 +776,7 @@ class Storage:
 
         # Execute query
         with Session(self._engine) as session:
+            session.execute(text("SET LOCAL work_mem = '256MB'"))
             result = session.execute(query)
             rows = result.fetchall()
 
@@ -876,6 +879,7 @@ class Storage:
 
         # Execute query
         with Session(self._engine) as session:
+            session.execute(text("SET LOCAL work_mem = '256MB'"))
             result = session.execute(query)
             rows = result.fetchall()
 
@@ -1000,6 +1004,7 @@ class Storage:
 
         # Execute query
         with Session(self._engine) as session:
+            session.execute(text("SET LOCAL work_mem = '256MB'"))
             result = session.execute(query)
             rows = result.fetchall()
 
@@ -1124,6 +1129,7 @@ class Storage:
 
         # Execute query
         with Session(self._engine) as session:
+            session.execute(text("SET LOCAL work_mem = '256MB'"))
             result = session.execute(query)
             rows = result.fetchall()
 


### PR DESCRIPTION
## 問題

本番環境（birdxplorer.code4japan.org）で `/resources/graphs/notes-annual` エンドポイントが Vercel の 60 秒タイムアウトを超えて 504 エラーが発生していた。

## 原因

RDS Performance Insights による調査結果：

- `notes` テーブルの月次集計クエリ（1年分 = 最大365日）が3分以上かかっていた
- Wait Events: `IO:BufFileRead` が高負荷 → GROUP BY のソート処理がデフォルト `work_mem = 4MB` でディスクにスピルしていた
- RDS パラメータグループ `default.postgres16` を使用しており `work_mem` が未設定（エンジンデフォルト）

## 修正内容

グラフAPI用の5つのストレージメソッドで、セッション開始時に `SET LOCAL work_mem = '256MB'` を実行するよう変更：

- `get_daily_note_counts`
- `get_daily_post_counts`
- `get_monthly_note_counts` ← タイムアウトの直接原因
- `get_note_evaluation_points`
- `get_post_influence_points`

`SET LOCAL` によりトランザクション終了後に自動リセットされるため、他のクエリには影響しない。

## 注意点

同時接続数が増えた場合（目安: 10人以上が同時にグラフページを開く）はメモリ圧迫のリスクあり。
その際は `128MB` への引き下げ、またはマテリアライズドビューによる事前集計を検討する。