### PR TITLE
fix: notes-annual タイムアウト根本解消 — カバリングインデックス追加

### DIFF
--- a/migrate/migration/versions/add_notes_covering_index.py
+++ b/migrate/migration/versions/add_notes_covering_index.py
@@ -1,0 +1,47 @@
+"""add covering index for notes-annual query
+
+Revision ID: add_notes_covering_index
+Revises: add_search_query_indexes
+Create Date: 2026-06-19
+
+notes-annual エンドポイントが 60 秒タイムアウトする問題の根本対策。
+
+既存の ix_notes_created_at は WHERE 句の絞り込みには使えるが、
+CASE WHEN で参照する current_status / has_been_helpfuled は
+ヒープページを都度フェッチしており IO:DataFileRead が高騰していた。
+
+(created_at, current_status, has_been_helpfuled) の複合インデックスにより
+インデックスオンリースキャンが可能になり、ヒープアクセスを排除する。
+
+CREATE INDEX CONCURRENTLY を使用するため、トランザクション外で実行する。
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "add_notes_covering_index"
+down_revision: Union[str, None] = "add_search_query_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # CREATE INDEX CONCURRENTLY はトランザクション内で実行できないため
+    # autocommit_block を使って明示的にトランザクション外で実行する
+    with op.get_context().autocommit_block():
+        op.execute(
+            sa.text(
+                """
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notes_annual_covering
+                ON notes (created_at, current_status, has_been_helpfuled)
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(sa.text("DROP INDEX CONCURRENTLY IF EXISTS ix_notes_annual_covering"))


### PR DESCRIPTION
## 問題

PR #250 で `work_mem = 256MB` を設定したが、本番で引き続き 504 タイムアウトが発生している。

## 根本原因の追加調査

RDS Performance Insights（修正後も継続して高負荷）:

```
IO:DataFileRead  = 7.7  ← ヒープページの大量読み込み
IO:BufFileRead   = 1.4  ← sort ディスクスピル（work_mem では改善済み）
```

`notes-annual` クエリは `ix_notes_created_at` で日付絞り込み後、
**CASE WHEN が `current_status` と `has_been_helpfuled` を評価するためにヒープページを都度フェッチ**している。
1年分 = 数十万〜数百万行のヒープアクセスが `IO:DataFileRead` の原因。

## 対策

`(created_at, current_status, has_been_helpfuled)` のカバリングインデックスを追加。

- インデックスオンリースキャンが有効になり、ヒープアクセスを排除
- `CREATE INDEX CONCURRENTLY` により、インデックス構築中も書き込みロックなし
- `work_mem` 増加（PR #250）と組み合わせることで二重に効く

## 期待する効果

| Wait Event | 修正前 | 期待値 |
|---|---|---|
| `IO:DataFileRead` | 7.7 | ≈ 0（インデックスオンリースキャン） |
| `IO:BufFileRead` | 1.4 | ≈ 0（work_mem #250 と合わせて） |
| クエリ応答時間 | 60秒超 | < 5秒 |