### PR TITLE
fix: Link URL の上限を 2083 文字から 8192 文字に緩和

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -10,7 +10,6 @@ from dateutil.parser import parse as dateutil_parse
 from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import Field as PydanticField
-from pydantic import HttpUrl
 from typing_extensions import Annotated
 
 from birdxplorer_api.openapi_doc import (
@@ -23,6 +22,7 @@ from birdxplorer_api.openapi_doc import (
 from birdxplorer_common.models import (
     BaseModel,
     LanguageCode,
+    LongHttpUrl,
     Note,
     NoteId,
     PaginationMeta,
@@ -493,7 +493,7 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
         offset: int = Query(default=0, ge=0, **V1DataPostsDocs.params["offset"]),
         limit: int = Query(default=100, gt=0, le=1000, **V1DataPostsDocs.params["limit"]),
         search_text: Union[None, str] = Query(default=None, **V1DataPostsDocs.params["search_text"]),
-        search_url: Union[None, HttpUrl] = Query(default=None, **V1DataPostsDocs.params["search_url"]),
+        search_url: Union[None, LongHttpUrl] = Query(default=None, **V1DataPostsDocs.params["search_url"]),
         media: bool = Query(default=True, **V1DataPostsDocs.params["media"]),
     ) -> PostListResponse:
         try:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -10,7 +10,6 @@ from fastapi.testclient import TestClient
 from polyfactory import Use
 from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.pytest_plugin import register_fixture
-from pydantic import HttpUrl
 from pytest import fixture
 
 from birdxplorer_common.exceptions import UserEnrollmentNotFoundError
@@ -18,6 +17,7 @@ from birdxplorer_common.models import (
     LanguageCode,
     Link,
     LinkId,
+    LongHttpUrl,
     Media,
     Note,
     NoteId,
@@ -432,7 +432,7 @@ def mock_storage(
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
-        search_url: Union[HttpUrl, None] = None,
+        search_url: Union[LongHttpUrl, None] = None,
         offset: Union[int, None] = None,
         limit: Union[int, None] = None,
         with_media: bool = True,
@@ -482,7 +482,7 @@ def mock_storage(
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
-        search_url: Union[HttpUrl, None] = None,
+        search_url: Union[LongHttpUrl, None] = None,
     ) -> int:
         return len(list(_get_posts(post_ids, note_ids, user_ids, start, end, search_text, search_url)))
 

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1448,7 +1448,7 @@ class Storage:
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
-        search_url: Union[HttpUrl, None] = None,
+        search_url: Union[LongHttpUrl, None] = None,
         offset: Union[int, None] = None,
         limit: int = 100,
         with_media: bool = True,
@@ -1492,7 +1492,7 @@ class Storage:
         start: Union[TwitterTimestamp, None] = None,
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
-        search_url: Union[HttpUrl, None] = None,
+        search_url: Union[LongHttpUrl, None] = None,
     ) -> int:
         with Session(self.engine) as sess:
             query = sess.query(PostRecord)


### PR DESCRIPTION
## 概要

issue #242 の修正。`GET /api/v1/data/posts` が特定の offset で常に 500 を返す問題を解消する。

## 根本原因

ETL の `post_transform_lambda.py` が `unwound_url`（リダイレクト展開後 URL）を長さチェックなしで DB に保存している。Pydantic の `HttpUrl` は 2083 文字制限を持つため、それを超える URL を持つ投稿を API が読み出す際に `ValidationError` が発生し 500 エラーになっていた。

## 修正内容

- `LongHttpUrl = Annotated[AnyUrl, UrlConstraints(max_length=8192, allowed_schemes=["http", "https"])]` を定義
- `Link.url`（Pydantic モデル）と `LinkRecord.url`（SQLAlchemy ORM）の型を `HttpUrl` → `LongHttpUrl` に変更
- DB カラムの型変更は不要（既に `TEXT` 相当で長さ制限なし）

8192 文字は Apache/Nginx のデフォルト上限に合わせた値。`unwound_url` は実際にリダイレクトを辿って取得した URL であり、Web サーバーが受理した URL なので 8192 文字を超えることは実質ない。

## 確認事項

- [ ] black: 変更なし
- [ ] pflake8: エラーなし
- [ ] mypy: 既存エラー（`polymorphic_serialization`）のみ、本 PR 起因のエラーなし
- [ ] `Link` doctest: パス（`AnyUrl` の repr に合わせて更新）