### PR TITLE
fix: Link URL の上限を 2083 文字から 8192 文字に緩和 (common)

### DIFF
--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -19,6 +19,9 @@ from typing import (
 from uuid import UUID
 
 import pycountry
+from pydantic import (
+    AnyUrl,
+)
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import (
     ConfigDict,
@@ -35,7 +38,10 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.main import IncEx
+from pydantic.networks import UrlConstraints
 from pydantic_core import core_schema
+
+LongHttpUrl = Annotated[AnyUrl, UrlConstraints(max_length=8192, allowed_schemes=["http", "https"])]
 
 StrT = TypeVar("StrT", bound="BaseString")
 IntT = TypeVar("IntT", bound="BaseInt")
@@ -881,15 +887,15 @@ class Link(BaseModel):
     t.co に短縮される前の URL ごとに一意な ID を持つ。
 
     >>> Link.model_validate_json('{"linkId": "d5d15194-6574-0c01-8f6f-15abd72b2cf6", "url": "https://example.com"}')
-    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=HttpUrl('https://example.com/'))
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=AnyUrl('https://example.com/'))
     >>> Link(url="https://example.com/")
-    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=HttpUrl('https://example.com/'))
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=AnyUrl('https://example.com/'))
     >>> Link(link_id=UUID("d5d15194-6574-0c01-8f6f-15abd72b2cf6"), url="https://example.com/")
-    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=HttpUrl('https://example.com/'))
+    Link(link_id=LinkId('d5d15194-6574-0c01-8f6f-15abd72b2cf6'), url=AnyUrl('https://example.com/'))
     """  # noqa: E501
 
     link_id: Annotated[LinkId, PydanticField(description="リンクを識別できる UUID")]
-    url: Annotated[HttpUrl, PydanticField(description="リンクが指す URL")]
+    url: Annotated[LongHttpUrl, PydanticField(description="リンクが指す URL")]
 
     @model_validator(mode="before")
     def validate_link_id(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -27,6 +27,7 @@ from .models import (
 from .models import Link as LinkModel
 from .models import (
     LinkId,
+    LongHttpUrl,
     Media,
     MediaDetails,
     MediaType,
@@ -89,6 +90,7 @@ class Base(DeclarativeBase):
         UserId: String,
         UserName: String,
         HttpUrl: String,
+        LongHttpUrl: String,
         NonNegativeInt: DECIMAL,
         MediaDetails: JSON,
         BinaryBool: CHAR,
@@ -145,7 +147,7 @@ class LinkRecord(Base):
     __tablename__ = "links"
 
     link_id: Mapped[LinkId] = mapped_column(primary_key=True)
-    url: Mapped[HttpUrl] = mapped_column(nullable=False, index=True)
+    url: Mapped[LongHttpUrl] = mapped_column(nullable=False, index=True)
 
 
 class PostLinkAssociation(Base):


### PR DESCRIPTION
## 概要

issue #242 の根本修正。`GET /api/v1/data/posts` が特定の offset で 500 を返す問題の common パッケージ側の対応。

## 根本原因

ETL の `post_transform_lambda.py` が `unwound_url`（リダイレクト展開後 URL）を長さチェックなしで DB に保存している。Pydantic の `HttpUrl` は 2083 文字制限を持つため、それを超える URL を持つ投稿を API が読み出す際に `ValidationError` が発生し 500 エラーになっていた。

## 修正内容

- `LongHttpUrl = Annotated[AnyUrl, UrlConstraints(max_length=8192, allowed_schemes=["http", "https"])]` を定義
- `Link.url`（Pydantic モデル）と `LinkRecord.url`（SQLAlchemy ORM）の型を `HttpUrl` → `LongHttpUrl` に変更
- DB カラムの型変更は不要（既に `TEXT` 相当で制限なし）

8192 文字は Apache/Nginx のデフォルト上限に合わせた値。

## 備考

このPRは common パッケージのみの変更です。このPRのマージ後に、api 側の対応（PR #252）をマージする想定です。