### PR TITLE
feat: add ratingSourceBucketed, suggestion, suggestionId to ratings ETL

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -294,7 +294,7 @@ class RowNoteRatingRecord(Base):
     not_helpful_note_not_needed: Mapped[BinaryBool] = mapped_column(nullable=False)
     rated_on_tweet_id: Mapped[PostId] = mapped_column(nullable=False)
     rating_source_bucketed: Mapped[Optional[str]] = mapped_column(nullable=True)
-    suggestion: Mapped[Optional[str]] = mapped_column(nullable=True)
+    suggestion: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     suggestion_id: Mapped[Optional[str]] = mapped_column(nullable=True)
 
 

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -293,6 +293,9 @@ class RowNoteRatingRecord(Base):
     not_helpful_opinion_speculation: Mapped[BinaryBool] = mapped_column(nullable=False)
     not_helpful_note_not_needed: Mapped[BinaryBool] = mapped_column(nullable=False)
     rated_on_tweet_id: Mapped[PostId] = mapped_column(nullable=False)
+    rating_source_bucketed: Mapped[Optional[str]] = mapped_column(nullable=True)
+    suggestion: Mapped[Optional[str]] = mapped_column(nullable=True)
+    suggestion_id: Mapped[Optional[str]] = mapped_column(nullable=True)
 
 
 class RowPostRecord(Base):

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -558,6 +558,12 @@ def _validate_rating_row(row: dict, existing_row_note_ids: set) -> bool:
         if value not in ["HELPFUL", "SOMEWHAT_HELPFUL", "NOT_HELPFUL"]:
             row["helpfulness_level"] = None
 
+    # rating_source_bucketedフィールドのバリデーション
+    if "rating_source_bucketed" in row:
+        value = row["rating_source_bucketed"]
+        if value not in ["DEFAULT", "POPULATION_SAMPLED"]:
+            row["rating_source_bucketed"] = None
+
     # 空文字列フィールドをNoneに変換
     for key, value in row.items():
         if value == "" and key not in ["helpfulness_level"]:
@@ -819,6 +825,9 @@ _RATING_COLUMNS = [
     "not_helpful_opinion_speculation",
     "not_helpful_note_not_needed",
     "rated_on_tweet_id",
+    "rating_source_bucketed",
+    "suggestion",
+    "suggestion_id",
 ]
 
 

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -395,3 +395,83 @@ class TestExtractRatingsErrorRecovery:
             extract_ratings(mock_session, "2026/03/01", {"n1"})
 
         mock_cleanup.assert_called_once_with(mock_session)
+
+
+class TestValidateRatingRowNewFields:
+    """新規3フィールドに対する _validate_rating_row のテスト"""
+
+    def _make_row(self, **overrides: str) -> dict:
+        row = {
+            "note_id": "n1",
+            "rater_participant_id": "r1",
+            "created_at_millis": "1000",
+            "version": "1",
+            "agree": "1",
+            "disagree": "0",
+            "helpful": "1",
+            "not_helpful": "0",
+            "helpfulness_level": "HELPFUL",
+            "rated_on_tweet_id": "t1",
+        }
+        row.update(overrides)
+        return row
+
+    def test_rating_source_bucketed_default_kept(self) -> None:
+        row = self._make_row(rating_source_bucketed="DEFAULT")
+        _validate_rating_row(row, {"n1"})
+        assert row["rating_source_bucketed"] == "DEFAULT"
+
+    def test_rating_source_bucketed_population_sampled_kept(self) -> None:
+        row = self._make_row(rating_source_bucketed="POPULATION_SAMPLED")
+        _validate_rating_row(row, {"n1"})
+        assert row["rating_source_bucketed"] == "POPULATION_SAMPLED"
+
+    def test_rating_source_bucketed_invalid_set_to_none(self) -> None:
+        row = self._make_row(rating_source_bucketed="INVALID_VALUE")
+        _validate_rating_row(row, {"n1"})
+        assert row["rating_source_bucketed"] is None
+
+    def test_rating_source_bucketed_empty_set_to_none(self) -> None:
+        row = self._make_row(rating_source_bucketed="")
+        _validate_rating_row(row, {"n1"})
+        assert row["rating_source_bucketed"] is None
+
+    def test_suggestion_empty_set_to_none(self) -> None:
+        row = self._make_row(suggestion="")
+        _validate_rating_row(row, {"n1"})
+        assert row["suggestion"] is None
+
+    def test_suggestion_text_kept(self) -> None:
+        row = self._make_row(suggestion="This note should include a citation.")
+        _validate_rating_row(row, {"n1"})
+        assert row["suggestion"] == "This note should include a citation."
+
+    def test_suggestion_id_empty_set_to_none(self) -> None:
+        row = self._make_row(suggestion_id="")
+        _validate_rating_row(row, {"n1"})
+        assert row["suggestion_id"] is None
+
+    def test_suggestion_id_value_kept(self) -> None:
+        row = self._make_row(suggestion_id="1234567890123456789")
+        _validate_rating_row(row, {"n1"})
+        assert row["suggestion_id"] == "1234567890123456789"
+
+
+class TestRatingColumns:
+    """_RATING_COLUMNS の内容検証"""
+
+    def test_contains_rating_source_bucketed(self) -> None:
+        assert "rating_source_bucketed" in _RATING_COLUMNS
+
+    def test_contains_suggestion(self) -> None:
+        assert "suggestion" in _RATING_COLUMNS
+
+    def test_contains_suggestion_id(self) -> None:
+        assert "suggestion_id" in _RATING_COLUMNS
+
+    def test_rated_on_tweet_id_before_new_columns(self) -> None:
+        idx_rated = _RATING_COLUMNS.index("rated_on_tweet_id")
+        idx_source = _RATING_COLUMNS.index("rating_source_bucketed")
+        idx_suggestion = _RATING_COLUMNS.index("suggestion")
+        idx_suggestion_id = _RATING_COLUMNS.index("suggestion_id")
+        assert idx_rated < idx_source < idx_suggestion < idx_suggestion_id

--- a/migrate/migration/versions/add_rating_new_columns.py
+++ b/migrate/migration/versions/add_rating_new_columns.py
@@ -1,0 +1,34 @@
+"""add new columns to row_note_ratings
+
+Revision ID: add_rating_new_columns
+Revises: add_notes_covering_index
+Create Date: 2026-06-29
+
+X Community Notes added three new fields to the ratings TSV:
+- ratingSourceBucketed (2025-09-30): DEFAULT or POPULATION_SAMPLED
+- suggestion (2026-02-04): user-entered suggestion text for collaborative notes
+- suggestionId (2026-05-28): unique ID of the suggestion
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "add_rating_new_columns"
+down_revision: Union[str, None] = "add_notes_covering_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("row_note_ratings", sa.Column("rating_source_bucketed", sa.String(), nullable=True))
+    op.add_column("row_note_ratings", sa.Column("suggestion", sa.Text(), nullable=True))
+    op.add_column("row_note_ratings", sa.Column("suggestion_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("row_note_ratings", "suggestion_id")
+    op.drop_column("row_note_ratings", "suggestion")
+    op.drop_column("row_note_ratings", "rating_source_bucketed")


### PR DESCRIPTION
## 概要

X Community Notes の ratings TSV に追加された3つの新しいフィールドを ETL パイプラインに追加します。

### 追加フィールド

| TSV フィールド | DB カラム | 型 | 追加時期 | 説明 |
|---|---|---|---|---|
| `ratingSourceBucketed` | `rating_source_bucketed` | `String(nullable)` | 2025-09-30 | レーティングの送信元区分。`DEFAULT` または `POPULATION_SAMPLED` |
| `suggestion` | `suggestion` | `Text(nullable)` | 2026-02-04 | ユーザーが入力したコラボレーティブノート用の改善提案テキスト |
| `suggestionId` | `suggestion_id` | `String(nullable)` | 2026-05-28 | 改善提案のユニーク ID |

## 変更内容

### 1. Alembic マイグレーション

`migrate/migration/versions/add_rating_new_columns.py`

`row_note_ratings` テーブルに3カラムを追加。`down_revision = "add_notes_covering_index"` からチェーン。

### 2. SQLAlchemy ORM モデル

`common/birdxplorer_common/storage.py`

`RowNoteRatingRecord` に `Mapped[Optional[str]]` フィールドを3つ追加。

### 3. ETL 処理

`etl/src/birdxplorer_etl/extract_ecs.py`

- `_RATING_COLUMNS` に3カラムを追加（COPY コマンドのカラムリスト）
- `_validate_rating_row` に `rating_source_bucketed` のバリデーション追加（`DEFAULT` / `POPULATION_SAMPLED` 以外は `None` に正規化）

## テスト

`etl/tests/test_extract_ratings_swap.py` に追加:

- `TestValidateRatingRowNewFields`（8テスト）: 各フィールドの正常系・異常系バリデーション
- `TestRatingColumns`（4テスト）: `_RATING_COLUMNS` のリスト検証

全 41 テスト通過確認済み。

## 動作確認

実際の ratings TSV（`https://ton.twimg.com/birdwatch-public-data/2026/06/28/noteRatings/ratings-00000.zip`）のヘッダーを確認し、3フィールドが TSV 最後尾に存在することを確認した上で実装。