### PR TITLE
docs: update OpenAPI spec definitions and usage docs

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -591,6 +591,67 @@ v1_data_search_sort_order = FastAPIEndpointParamDocs(
     },
 )
 
+v1_data_search_note_search_mode: FastAPIEndpointParamDocs = {
+    "description": """
+`note_includes_text` で指定した複数キーワードの結合方法。
+
+| 値  | 意味                                     |
+| :-: | :--------------------------------------- |
+| or  | いずれかのキーワードを含むノートを取得   |
+| and | すべてのキーワードを含むノートのみを取得 |
+""",
+    "openapi_examples": {
+        "or": {
+            "summary": "OR 検索 (デフォルト)",
+            "value": "or",
+        },
+        "and": {
+            "summary": "AND 検索",
+            "value": "and",
+        },
+    },
+}
+
+v1_data_search_post_search_mode: FastAPIEndpointParamDocs = {
+    "description": """
+`post_includes_text` で指定した複数キーワードの結合方法。
+
+| 値  | 意味                                      |
+| :-: | :---------------------------------------- |
+| or  | いずれかのキーワードを含むポストを取得    |
+| and | すべてのキーワードを含むポストのみを取得  |
+""",
+    "openapi_examples": {
+        "or": {
+            "summary": "OR 検索 (デフォルト)",
+            "value": "or",
+        },
+        "and": {
+            "summary": "AND 検索",
+            "value": "and",
+        },
+    },
+}
+
+v1_data_search_include_total: FastAPIEndpointParamDocs = {
+    "description": """
+レスポンスに検索結果の総件数 (`meta.total`) を含めるかどうか。
+
+`false` にすると COUNT クエリをスキップしてレスポンスが高速化される。
+件数が不要な場合や `/search/count` で非同期取得する場合に利用する。
+""",
+    "openapi_examples": {
+        "true": {
+            "summary": "総件数を含める (デフォルト)",
+            "value": True,
+        },
+        "false": {
+            "summary": "総件数を含めない (高速化)",
+            "value": False,
+        },
+    },
+}
+
 # Get /api/v1/data/search の OpenAPI ドキュメント
 V1DataSearchDocs = FastAPIEndpointDocs(
     "アドバンスドサーチでデータを取得するエンドポイント",
@@ -615,5 +676,110 @@ V1DataSearchDocs = FastAPIEndpointDocs(
         "sort_order": v1_data_search_sort_order,
         "offset": v1_data_posts_offset,
         "limit": v1_data_posts_limit,
+        "note_search_mode": v1_data_search_note_search_mode,
+        "post_search_mode": v1_data_search_post_search_mode,
+        "include_total": v1_data_search_include_total,
+    },
+)
+
+# Get /api/v1/data/search/count の OpenAPI ドキュメント
+V1DataSearchCountDocs = FastAPIEndpointDocs(
+    "検索結果の総件数を取得するエンドポイント",
+    {
+        "note_includes_text": v1_data_notes_search_text,
+        "note_excludes_text": v1_data_notes_search_text,
+        "post_includes_text": v1_data_posts_search_text,
+        "post_excludes_text": v1_data_posts_search_text,
+        "language": v1_data_notes_language,
+        "topic_ids": v1_date_notes_topic_ids,
+        "note_status": v1_data_notes_current_status,
+        "note_created_at_from": v1_data_notes_created_at_from,
+        "note_created_at_to": v1_data_notes_created_at_to,
+        "x_user_name": v1_data_x_user_name,
+        "x_user_followers_count_from": v1_data_x_user_follower_count,
+        "x_user_follow_count_from": v1_data_x_user_follow_count,
+        "post_like_count_from": v1_data_post_like_count,
+        "post_repost_count_from": v1_data_post_repost_count,
+        "post_impression_count_from": v1_data_post_impression_count,
+        "post_includes_media": v1_data_post_includes_media,
+        "note_search_mode": v1_data_search_note_search_mode,
+        "post_search_mode": v1_data_search_post_search_mode,
+    },
+)
+
+v1_data_export_keywords: FastAPIEndpointParamDocs = {
+    "description": """
+検索キーワード。カンマ区切りまたは複数回指定で最大 50 個まで指定できる。最低 1 個必須。
+
+指定したキーワードを含むコミュニティノートが対象となる。
+結合方法は `search_mode` パラメータで切り替えられる。
+""",
+    "openapi_examples": {
+        "single": {
+            "summary": "1 キーワード",
+            "value": ["選挙"],
+        },
+        "comma": {
+            "summary": "カンマ区切りで複数指定",
+            "value": ["選挙,投票"],
+        },
+    },
+}
+
+v1_data_export_note_created_at_from: FastAPIEndpointParamDocs = {
+    "description": """
+取得するコミュニティノートの作成日時の下限 (ミリ秒単位の UNIX EPOCH TIMESTAMP)。必須。
+期間は最大 30 日。
+""",
+    "openapi_examples": {
+        "normal": {
+            "summary": "2025 / 1 / 1 00:00 (JST) 以降",
+            "value": 1735657200000,
+        },
+    },
+}
+
+v1_data_export_note_created_at_to: FastAPIEndpointParamDocs = {
+    "description": """
+取得するコミュニティノートの作成日時の上限 (ミリ秒単位の UNIX EPOCH TIMESTAMP)。必須。
+期間は最大 30 日。
+""",
+    "openapi_examples": {
+        "normal": {
+            "summary": "2025 / 1 / 31 23:59 (JST) まで",
+            "value": 1738335540000,
+        },
+    },
+}
+
+v1_data_export_search_mode: FastAPIEndpointParamDocs = {
+    "description": """
+キーワードの結合方法。
+
+| 値  | 意味                                     |
+| :-: | :--------------------------------------- |
+| or  | いずれかのキーワードを含むノートを取得   |
+| and | すべてのキーワードを含むノートのみを取得 |
+""",
+    "openapi_examples": {
+        "or": {
+            "summary": "OR 検索 (デフォルト)",
+            "value": "or",
+        },
+        "and": {
+            "summary": "AND 検索",
+            "value": "and",
+        },
+    },
+}
+
+# Get /api/v1/data/export/csv の OpenAPI ドキュメント
+V1DataExportCsvDocs = FastAPIEndpointDocs(
+    "キーワード（カンマ区切り、最大 50 個）と作成期間（ミリ秒、最大 30 日）を指定して、コミュニティノート + ポストを CSV（UTF-8 BOM 付き）でダウンロードするエンドポイント",
+    {
+        "keywords": v1_data_export_keywords,
+        "note_created_at_from": v1_data_export_note_created_at_from,
+        "note_created_at_to": v1_data_export_note_created_at_to,
+        "search_mode": v1_data_export_search_mode,
     },
 )

--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -591,8 +591,8 @@ v1_data_search_sort_order = FastAPIEndpointParamDocs(
     },
 )
 
-v1_data_search_note_search_mode: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_search_note_search_mode = FastAPIEndpointParamDocs(
+    description="""
 `note_includes_text` で指定した複数キーワードの結合方法。
 
 | 値  | 意味                                     |
@@ -600,7 +600,7 @@ v1_data_search_note_search_mode: FastAPIEndpointParamDocs = {
 | or  | いずれかのキーワードを含むノートを取得   |
 | and | すべてのキーワードを含むノートのみを取得 |
 """,
-    "openapi_examples": {
+    openapi_examples={
         "or": {
             "summary": "OR 検索 (デフォルト)",
             "value": "or",
@@ -610,10 +610,10 @@ v1_data_search_note_search_mode: FastAPIEndpointParamDocs = {
             "value": "and",
         },
     },
-}
+)
 
-v1_data_search_post_search_mode: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_search_post_search_mode = FastAPIEndpointParamDocs(
+    description="""
 `post_includes_text` で指定した複数キーワードの結合方法。
 
 | 値  | 意味                                      |
@@ -621,7 +621,7 @@ v1_data_search_post_search_mode: FastAPIEndpointParamDocs = {
 | or  | いずれかのキーワードを含むポストを取得    |
 | and | すべてのキーワードを含むポストのみを取得  |
 """,
-    "openapi_examples": {
+    openapi_examples={
         "or": {
             "summary": "OR 検索 (デフォルト)",
             "value": "or",
@@ -631,16 +631,16 @@ v1_data_search_post_search_mode: FastAPIEndpointParamDocs = {
             "value": "and",
         },
     },
-}
+)
 
-v1_data_search_include_total: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_search_include_total = FastAPIEndpointParamDocs(
+    description="""
 レスポンスに検索結果の総件数 (`meta.total`) を含めるかどうか。
 
 `false` にすると COUNT クエリをスキップしてレスポンスが高速化される。
 件数が不要な場合や `/search/count` で非同期取得する場合に利用する。
 """,
-    "openapi_examples": {
+    openapi_examples={
         "true": {
             "summary": "総件数を含める (デフォルト)",
             "value": True,
@@ -650,7 +650,7 @@ v1_data_search_include_total: FastAPIEndpointParamDocs = {
             "value": False,
         },
     },
-}
+)
 
 # Get /api/v1/data/search の OpenAPI ドキュメント
 V1DataSearchDocs = FastAPIEndpointDocs(
@@ -707,14 +707,14 @@ V1DataSearchCountDocs = FastAPIEndpointDocs(
     },
 )
 
-v1_data_export_keywords: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_export_keywords = FastAPIEndpointParamDocs(
+    description="""
 検索キーワード。カンマ区切りまたは複数回指定で最大 50 個まで指定できる。最低 1 個必須。
 
 指定したキーワードを含むコミュニティノートが対象となる。
 結合方法は `search_mode` パラメータで切り替えられる。
 """,
-    "openapi_examples": {
+    openapi_examples={
         "single": {
             "summary": "1 キーワード",
             "value": ["選挙"],
@@ -724,36 +724,36 @@ v1_data_export_keywords: FastAPIEndpointParamDocs = {
             "value": ["選挙,投票"],
         },
     },
-}
+)
 
-v1_data_export_note_created_at_from: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_export_note_created_at_from = FastAPIEndpointParamDocs(
+    description="""
 取得するコミュニティノートの作成日時の下限 (ミリ秒単位の UNIX EPOCH TIMESTAMP)。必須。
 期間は最大 30 日。
 """,
-    "openapi_examples": {
+    openapi_examples={
         "normal": {
             "summary": "2025 / 1 / 1 00:00 (JST) 以降",
             "value": 1735657200000,
         },
     },
-}
+)
 
-v1_data_export_note_created_at_to: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_export_note_created_at_to = FastAPIEndpointParamDocs(
+    description="""
 取得するコミュニティノートの作成日時の上限 (ミリ秒単位の UNIX EPOCH TIMESTAMP)。必須。
 期間は最大 30 日。
 """,
-    "openapi_examples": {
+    openapi_examples={
         "normal": {
             "summary": "2025 / 1 / 31 23:59 (JST) まで",
             "value": 1738335540000,
         },
     },
-}
+)
 
-v1_data_export_search_mode: FastAPIEndpointParamDocs = {
-    "description": """
+v1_data_export_search_mode = FastAPIEndpointParamDocs(
+    description="""
 キーワードの結合方法。
 
 | 値  | 意味                                     |
@@ -761,7 +761,7 @@ v1_data_export_search_mode: FastAPIEndpointParamDocs = {
 | or  | いずれかのキーワードを含むノートを取得   |
 | and | すべてのキーワードを含むノートのみを取得 |
 """,
-    "openapi_examples": {
+    openapi_examples={
         "or": {
             "summary": "OR 検索 (デフォルト)",
             "value": "or",
@@ -771,7 +771,7 @@ v1_data_export_search_mode: FastAPIEndpointParamDocs = {
             "value": "and",
         },
     },
-}
+)
 
 # Get /api/v1/data/export/csv の OpenAPI ドキュメント
 V1DataExportCsvDocs = FastAPIEndpointDocs(

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -13,8 +13,10 @@ from pydantic import Field as PydanticField
 from typing_extensions import Annotated
 
 from birdxplorer_api.openapi_doc import (
+    V1DataExportCsvDocs,
     V1DataNotesDocs,
     V1DataPostsDocs,
+    V1DataSearchCountDocs,
     V1DataSearchDocs,
     V1DataTopicsDocs,
     V1DataUserEnrollmentsDocs,
@@ -542,26 +544,54 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
 
         return PostListResponse(data=posts, meta=PaginationMeta(next=next_url, prev=prev_url, total=total_count))
 
-    @router.get("/search/count", description="検索結果の総件数を取得する", response_model=SearchCountResponse)
+    @router.get("/search/count", description=V1DataSearchCountDocs.description, response_model=SearchCountResponse)
     def search_count(
-        note_includes_text: Union[None, List[str]] = Query(default=None),
-        note_excludes_text: Union[None, str] = Query(default=None),
-        post_includes_text: Union[None, List[str]] = Query(default=None),
-        post_excludes_text: Union[None, str] = Query(default=None),
-        language: Union[LanguageCode, None] = Query(default=None),
-        topic_ids: Union[List[TopicId], None] = Query(default=None),
-        note_status: Union[None, List[str]] = Query(default=None),
-        note_created_at_from: Union[None, TwitterTimestamp, str] = Query(default=None),
-        note_created_at_to: Union[None, TwitterTimestamp, str] = Query(default=None),
-        x_user_names: Union[List[str], None] = Query(default=None),
-        x_user_followers_count_from: Union[None, int] = Query(default=None),
-        x_user_follow_count_from: Union[None, int] = Query(default=None),
-        post_like_count_from: Union[None, int] = Query(default=None),
-        post_repost_count_from: Union[None, int] = Query(default=None),
-        post_impression_count_from: Union[None, int] = Query(default=None),
-        post_includes_media: Union[bool, None] = Query(default=None),
-        note_search_mode: TextSearchMode = Query(default=TextSearchMode.OR),
-        post_search_mode: TextSearchMode = Query(default=TextSearchMode.OR),
+        note_includes_text: Union[None, List[str]] = Query(
+            default=None, **V1DataSearchCountDocs.params["note_includes_text"]
+        ),
+        note_excludes_text: Union[None, str] = Query(
+            default=None, **V1DataSearchCountDocs.params["note_excludes_text"]
+        ),
+        post_includes_text: Union[None, List[str]] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_includes_text"]
+        ),
+        post_excludes_text: Union[None, str] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_excludes_text"]
+        ),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchCountDocs.params["language"]),
+        topic_ids: Union[List[TopicId], None] = Query(default=None, **V1DataSearchCountDocs.params["topic_ids"]),
+        note_status: Union[None, List[str]] = Query(default=None, **V1DataSearchCountDocs.params["note_status"]),
+        note_created_at_from: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataSearchCountDocs.params["note_created_at_from"]
+        ),
+        note_created_at_to: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataSearchCountDocs.params["note_created_at_to"]
+        ),
+        x_user_names: Union[List[str], None] = Query(default=None, **V1DataSearchCountDocs.params["x_user_name"]),
+        x_user_followers_count_from: Union[None, int] = Query(
+            default=None, **V1DataSearchCountDocs.params["x_user_followers_count_from"]
+        ),
+        x_user_follow_count_from: Union[None, int] = Query(
+            default=None, **V1DataSearchCountDocs.params["x_user_follow_count_from"]
+        ),
+        post_like_count_from: Union[None, int] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_like_count_from"]
+        ),
+        post_repost_count_from: Union[None, int] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_repost_count_from"]
+        ),
+        post_impression_count_from: Union[None, int] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_impression_count_from"]
+        ),
+        post_includes_media: Union[bool, None] = Query(
+            default=None, **V1DataSearchCountDocs.params["post_includes_media"]
+        ),
+        note_search_mode: TextSearchMode = Query(
+            default=TextSearchMode.OR, **V1DataSearchCountDocs.params["note_search_mode"]
+        ),
+        post_search_mode: TextSearchMode = Query(
+            default=TextSearchMode.OR, **V1DataSearchCountDocs.params["post_search_mode"]
+        ),
     ) -> SearchCountResponse:
         try:
             if note_created_at_from is not None and isinstance(note_created_at_from, str):
@@ -633,16 +663,12 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
         sort_order: SortOrder = Query(default=SortOrder.DESC, **V1DataSearchDocs.params["sort_order"]),
         offset: int = Query(default=0, ge=0, **V1DataSearchDocs.params["offset"]),
         limit: int = Query(default=100, gt=0, le=1000, **V1DataSearchDocs.params["limit"]),
-        include_total: bool = Query(
-            default=True,
-            description="総件数を含める。falseにするとCOUNTクエリをスキップしてレスポンスが高速化されます。"
-            "件数は /search/count で非同期に取得できます。",
-        ),
+        include_total: bool = Query(default=True, **V1DataSearchDocs.params["include_total"]),
         note_search_mode: TextSearchMode = Query(
-            default=TextSearchMode.OR, description="note_includes_text の複数キーワード結合方法（or / and）"
+            default=TextSearchMode.OR, **V1DataSearchDocs.params["note_search_mode"]
         ),
         post_search_mode: TextSearchMode = Query(
-            default=TextSearchMode.OR, description="post_includes_text の複数キーワード結合方法（or / and）"
+            default=TextSearchMode.OR, **V1DataSearchDocs.params["post_search_mode"]
         ),
     ) -> SearchResponse:
         # Convert timestamp strings to TwitterTimestamp objects
@@ -753,19 +779,14 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
 
     @router.get(
         "/export/csv",
-        description=(
-            "キーワード(カンマ区切り、最大50個)と作成期間(ミリ秒、最大30日)を指定して、"
-            "コミュニティノート + ポストを CSV(UTF-8 BOM 付き)でダウンロードする。"
-        ),
+        description=V1DataExportCsvDocs.description,
     )
     def export_csv(
         request: Request,
-        keywords: List[str] = Query(..., description="カンマ区切りのキーワード。最大50個、最低1個"),
-        note_created_at_from: int = Query(..., description="ノート作成期間の開始(ミリ秒)"),
-        note_created_at_to: int = Query(..., description="ノート作成期間の終了(ミリ秒)"),
-        search_mode: TextSearchMode = Query(
-            default=TextSearchMode.OR, description="キーワードの結合方法（or: いずれかを含む / and: すべてを含む）"
-        ),
+        keywords: List[str] = Query(..., **V1DataExportCsvDocs.params["keywords"]),
+        note_created_at_from: int = Query(..., **V1DataExportCsvDocs.params["note_created_at_from"]),
+        note_created_at_to: int = Query(..., **V1DataExportCsvDocs.params["note_created_at_to"]),
+        search_mode: TextSearchMode = Query(default=TextSearchMode.OR, **V1DataExportCsvDocs.params["search_mode"]),
     ) -> Response:
         if export_api_key and request.headers.get("X-API-Key") != export_api_key:
             return JSONResponse(

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -206,12 +206,27 @@ Swagger UIでは以下の情報を確認できます：
 
 主要なエンドポイント：
 
-- `/api/v1/data/posts`: Postデータを取得
-- `/api/v1/data/notes`: コミュニティノートデータを取得
-- `/api/v1/data/topics`: トピックデータを取得
-- `/api/v1/data/search`: 検索機能
+**データ取得系**
+- `/api/v1/data/topics`: AI 自動分類されたトピック一覧を取得
+- `/api/v1/data/notes`: コミュニティノートを取得（トピック・言語・ステータス・テキスト等でフィルタ）
+- `/api/v1/data/posts`: X の投稿データを取得
+- `/api/v1/data/user-enrollments/{participant_id}`: コミュニティノート参加ユーザー情報を取得
 
-各エンドポイントの詳細なパラメータや使用例はSwagger UIで確認できます。
+**検索系**
+- `/api/v1/data/search`: アドバンスドサーチ（ノート本文・投稿本文・ユーザー属性・日付等で絞り込み。OR/AND 検索対応）
+- `/api/v1/data/search/count`: 検索結果の総件数のみを高速に取得
+- `/api/v1/data/export/csv`: キーワード＋期間指定でコミュニティノート＋投稿を CSV ダウンロード（最大 30 日・50 キーワード）
+
+**グラフ・統計系**
+- `/api/v1/graphs/daily-notes`: ノートの日別作成数
+- `/api/v1/graphs/daily-posts`: 投稿の日別件数
+- `/api/v1/graphs/notes-annual`: ノートの月別集計
+- `/api/v1/graphs/notes-evaluation`: ノートの評価指標
+- `/api/v1/graphs/notes-evaluation-status`: ノートの評価ステータス別指標
+- `/api/v1/graphs/post-influence`: 投稿の影響度
+- `/api/v1/graphs/top-note-accounts`: 上位ノート作成アカウント
+
+各エンドポイントの詳細なパラメータや使用例は Swagger UI (`/docs`) で確認できます。
 
 ---
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -48,3 +48,91 @@ tech_posts = posts_res.json()["data"]
 with open("tech_posts.json", "w") as f:
     f.write(json.dumps(tech_posts, ensure_ascii=False, indent=2))
 ```
+
+## OR / AND 検索でコミュニティノートと投稿を同時に取得する
+
+`/api/v1/data/search` エンドポイントは、ノート本文・投稿本文・ユーザー属性などを組み合わせたアドバンスドサーチに対応しています。
+
+`note_search_mode` / `post_search_mode` に `and` を指定すると、複数キーワードの **AND 検索** ができます（デフォルトは `or`）。
+
+以下の例では「選挙」かつ「投票」を両方含む日本語コミュニティノートとその投稿を取得します。
+
+```python
+#!python3.10
+import json
+import requests
+
+BASE_URL = "https://birdxplorer.onrender.com"
+
+search_res = requests.get(
+    f"{BASE_URL}/api/v1/data/search",
+    params={
+        "note_includes_text": ["選挙", "投票"],  # 2 キーワードを AND 検索
+        "note_search_mode": "and",
+        "language": "ja",
+        "limit": 100,
+        "include_total": "false",  # 件数不要なら false にするとレスポンスが速くなる
+    },
+)
+results = search_res.json()["data"]
+
+with open("election_notes.json", "w") as f:
+    f.write(json.dumps(results, ensure_ascii=False, indent=2))
+```
+
+## CSV エクスポートでコミュニティノートをダウンロードする
+
+`/api/v1/data/export/csv` エンドポイントは、キーワードと期間（最大 30 日）を指定してコミュニティノート＋投稿データを CSV (UTF-8 BOM 付き) でダウンロードします。
+
+> [!NOTE]
+> このエンドポイントは API キー (`X-API-Key` ヘッダー) が必要な場合があります。
+
+```python
+#!python3.10
+import requests
+
+BASE_URL = "https://birdxplorer.onrender.com"
+
+# 2025/1/1 00:00 JST ～ 2025/1/31 23:59 JST
+NOTE_CREATED_AT_FROM = 1735657200000
+NOTE_CREATED_AT_TO = 1738335540000
+
+response = requests.get(
+    f"{BASE_URL}/api/v1/data/export/csv",
+    params={
+        "keywords": "選挙,投票",          # カンマ区切りまたは複数指定で最大 50 個
+        "note_created_at_from": NOTE_CREATED_AT_FROM,
+        "note_created_at_to": NOTE_CREATED_AT_TO,
+        "search_mode": "or",              # or (デフォルト) または and
+    },
+    headers={
+        "X-API-Key": "your-api-key-here", # API キーが設定されている場合
+    },
+)
+
+with open("notes_export.csv", "wb") as f:
+    f.write(response.content)  # UTF-8 BOM 付き CSV
+```
+
+CSV の列は以下の順序で出力されます：
+
+| 列名 | 内容 |
+|---|---|
+| ポスト（投稿）日時 | JST |
+| ポスト | 投稿本文 |
+| コミュニティノート作成日時 | JST |
+| コミュニティノート | ノート本文 |
+| ステータス | NEEDS_MORE_RATINGS / CURRENTLY_RATED_HELPFUL / CURRENTLY_RATED_NOT_HELPFUL |
+| ポストURL | X の投稿 URL |
+| インプレッション数 | |
+| Like数 | |
+| リポスト数 | |
+| 評価数 | 総評価数 |
+| 役に立った | |
+| 少し役に立った | |
+| 役に立たなかった | |
+| コミュニティノートID | |
+| コミュニティノート作成者ID | |
+| 投稿者ID | |
+| 投稿者アカウント名 | |
+| ポスト取得日時 | ETL がデータを取得した日時 (JST) |


### PR DESCRIPTION
## Summary

- `openapi_doc.py` に欠落していたパラメータ定義を追加
  - `note_search_mode`, `post_search_mode`, `include_total` を `V1DataSearchDocs.params` に追加
  - `/search/count` 用 `V1DataSearchCountDocs` を新規追加
  - `/export/csv` 用 `V1DataExportCsvDocs` を新規追加
- `data.py` の `/search/count`・`/search`・`/export/csv` エンドポイントを新規 Docs オブジェクト参照に切り替え（機能ロジック変更なし）
- `docs/developer_guide.md` のエンドポイント一覧を最新仕様（データ取得系・検索系・グラフ系 計14エンドポイント）に更新
- `docs/example.md` に `/search`（OR/AND検索）と `/export/csv` の Python 使用例を追加

## Test plan

- [ ] `cd api && tox` が全 PASS であること（ローカル環境の starlette filterwarnings 設定との不整合は pre-existing）
- [ ] `docker-compose up` 後に `http://localhost:8000/docs` を開き Swagger UI で以下を確認:
  - `/search` に `note_search_mode`, `post_search_mode`, `include_total` のドキュメントと examples が表示される
  - `/search/count` の全パラメータにドキュメントが表示される
  - `/export/csv` の全パラメータにドキュメントが表示される