### PR TITLE
feat: ingest Community Notes note requests (batSignals) and expose via API

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -707,6 +707,67 @@ V1DataSearchCountDocs = FastAPIEndpointDocs(
     },
 )
 
+v1_data_note_requests_tweet_ids: FastAPIEndpointParamDocs = {
+    "description": """
+取得するノートリクエストの対象 Post の ID のリスト。指定しない場合は全てのノートリクエストが対象になる。
+""",
+}
+
+v1_data_note_requests_tweet_created_at_from: FastAPIEndpointParamDocs = {
+    "description": """
+対象 Post の作成日時の下限。**指定した日時と同時かそれより新しい** Post へのリクエストのみを取得する。
+形式は UNIX EPOCH TIME (ミリ秒)。Post の作成日時は tweet ID (snowflake) から算出したもの。
+""",
+}
+
+v1_data_note_requests_tweet_created_at_to: FastAPIEndpointParamDocs = {
+    "description": """
+対象 Post の作成日時の上限。**指定した日時より古い** Post へのリクエストのみを取得する。
+形式は UNIX EPOCH TIME (ミリ秒)。
+""",
+}
+
+v1_data_note_requests_has_post: FastAPIEndpointParamDocs = {
+    "description": """
+Post の取得状況で絞り込む。`true` で BirdXplorer が Post 本文を取得済みのもののみ、
+`false` で未取得のもののみを返す。指定しない場合は両方を返す。
+""",
+}
+
+v1_data_note_requests_offset: FastAPIEndpointParamDocs = {
+    "description": """
+取得するノートリクエストのリストの先頭からのオフセット。ページネーションに利用される。
+""",
+}
+
+v1_data_note_requests_limit: FastAPIEndpointParamDocs = {
+    "description": """
+取得するノートリクエストの最大数。最大 1000。
+""",
+}
+
+V1DataNoteRequestsDocs = FastAPIEndpointDocs(
+    "コミュニティノートのリクエスト (Note Requests) のデータを取得するエンドポイント",
+    {
+        "tweet_ids": v1_data_note_requests_tweet_ids,
+        "tweet_created_at_from": v1_data_note_requests_tweet_created_at_from,
+        "tweet_created_at_to": v1_data_note_requests_tweet_created_at_to,
+        "has_post": v1_data_note_requests_has_post,
+        "offset": v1_data_note_requests_offset,
+        "limit": v1_data_note_requests_limit,
+    },
+)
+
+V1DataNoteRequestsCountDocs = FastAPIEndpointDocs(
+    "条件に一致するコミュニティノートのリクエストの件数を取得するエンドポイント",
+    {
+        "tweet_ids": v1_data_note_requests_tweet_ids,
+        "tweet_created_at_from": v1_data_note_requests_tweet_created_at_from,
+        "tweet_created_at_to": v1_data_note_requests_tweet_created_at_to,
+        "has_post": v1_data_note_requests_has_post,
+    },
+)
+
 v1_data_export_keywords = FastAPIEndpointParamDocs(
     description="""
 検索キーワード。カンマ区切りまたは複数回指定で最大 50 個まで指定できる。最低 1 個必須。

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -14,6 +14,8 @@ from typing_extensions import Annotated
 
 from birdxplorer_api.openapi_doc import (
     V1DataExportCsvDocs,
+    V1DataNoteRequestsCountDocs,
+    V1DataNoteRequestsDocs,
     V1DataNotesDocs,
     V1DataPostsDocs,
     V1DataSearchCountDocs,
@@ -27,6 +29,7 @@ from birdxplorer_common.models import (
     LongHttpUrl,
     Note,
     NoteId,
+    NoteRequest,
     PaginationMeta,
     ParticipantId,
     Post,
@@ -378,6 +381,11 @@ class SearchCountResponse(BaseModel):
     total: Annotated[int, PydanticField(description="検索結果の総件数")]
 
 
+class NoteRequestListResponse(BaseModel):
+    data: Annotated[List[NoteRequest], PydanticField(description="ノートリクエストのリスト")]
+    meta: PaginationMeta
+
+
 def str_to_twitter_timestamp(s: str) -> TwitterTimestamp:
     try:
         return TwitterTimestamp.from_int(int(s))
@@ -543,6 +551,94 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
             prev_url = f"{base_url}?offset={prev_offset}&limit={limit}"
 
         return PostListResponse(data=posts, meta=PaginationMeta(next=next_url, prev=prev_url, total=total_count))
+
+    @router.get(
+        "/note-requests",
+        description=V1DataNoteRequestsDocs.description,
+        response_model=NoteRequestListResponse,
+    )
+    def get_note_requests(
+        request: Request,
+        tweet_ids: Union[List[PostId], None] = Query(default=None, **V1DataNoteRequestsDocs.params["tweet_ids"]),
+        tweet_created_at_from: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataNoteRequestsDocs.params["tweet_created_at_from"]
+        ),
+        tweet_created_at_to: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataNoteRequestsDocs.params["tweet_created_at_to"]
+        ),
+        has_post: Union[bool, None] = Query(default=None, **V1DataNoteRequestsDocs.params["has_post"]),
+        offset: int = Query(default=0, ge=0, **V1DataNoteRequestsDocs.params["offset"]),
+        limit: int = Query(default=100, gt=0, le=1000, **V1DataNoteRequestsDocs.params["limit"]),
+    ) -> NoteRequestListResponse:
+        try:
+            if tweet_created_at_from is not None and isinstance(tweet_created_at_from, str):
+                tweet_created_at_from = ensure_twitter_timestamp(tweet_created_at_from)
+            if tweet_created_at_to is not None and isinstance(tweet_created_at_to, str):
+                tweet_created_at_to = ensure_twitter_timestamp(tweet_created_at_to)
+        except OverflowError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        note_requests = list(
+            storage.get_note_requests(
+                tweet_ids=tweet_ids,
+                tweet_created_at_from=tweet_created_at_from,
+                tweet_created_at_to=tweet_created_at_to,
+                has_post=has_post,
+                offset=offset,
+                limit=limit,
+            )
+        )
+        total_count = storage.get_number_of_note_requests(
+            tweet_ids=tweet_ids,
+            tweet_created_at_from=tweet_created_at_from,
+            tweet_created_at_to=tweet_created_at_to,
+            has_post=has_post,
+        )
+
+        base_url = str(request.url).split("?")[0]
+        next_offset = offset + limit
+        prev_offset = max(offset - limit, 0)
+        next_url = None
+        if next_offset < total_count:
+            next_url = f"{base_url}?offset={next_offset}&limit={limit}"
+        prev_url = None
+        if offset > 0:
+            prev_url = f"{base_url}?offset={prev_offset}&limit={limit}"
+
+        return NoteRequestListResponse(
+            data=note_requests, meta=PaginationMeta(next=next_url, prev=prev_url, total=total_count)
+        )
+
+    @router.get(
+        "/note-requests/count",
+        description=V1DataNoteRequestsCountDocs.description,
+        response_model=SearchCountResponse,
+    )
+    def get_note_requests_count(
+        tweet_ids: Union[List[PostId], None] = Query(default=None, **V1DataNoteRequestsCountDocs.params["tweet_ids"]),
+        tweet_created_at_from: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataNoteRequestsCountDocs.params["tweet_created_at_from"]
+        ),
+        tweet_created_at_to: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataNoteRequestsCountDocs.params["tweet_created_at_to"]
+        ),
+        has_post: Union[bool, None] = Query(default=None, **V1DataNoteRequestsCountDocs.params["has_post"]),
+    ) -> SearchCountResponse:
+        try:
+            if tweet_created_at_from is not None and isinstance(tweet_created_at_from, str):
+                tweet_created_at_from = ensure_twitter_timestamp(tweet_created_at_from)
+            if tweet_created_at_to is not None and isinstance(tweet_created_at_to, str):
+                tweet_created_at_to = ensure_twitter_timestamp(tweet_created_at_to)
+        except OverflowError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        total_count = storage.get_number_of_note_requests(
+            tweet_ids=tweet_ids,
+            tweet_created_at_from=tweet_created_at_from,
+            tweet_created_at_to=tweet_created_at_to,
+            has_post=has_post,
+        )
+        return SearchCountResponse(total=total_count)
 
     @router.get("/search/count", description=V1DataSearchCountDocs.description, response_model=SearchCountResponse)
     def search_count(

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -71,7 +71,6 @@ testpaths = ["tests", "birdxplorer_api"]
 filterwarnings = [
     "error",
     "ignore:The \\'app\\' shortcut is now deprecated. Use the explicit style \\'transport=WSGITransport\\(app=\\.\\.\\.\\)\\' instead\\.",
-    "ignore::starlette.exceptions.StarletteDeprecationWarning",
 ]
 
 [tool.black]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -88,6 +88,7 @@ class PostFactory(ModelFactory[Post]):
 @register_fixture(name="note_request_factory")
 class NoteRequestFactory(ModelFactory[NoteRequest]):
     __model__ = NoteRequest
+    __check_model__ = False
 
 
 @register_fixture(name="link_factory")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -21,6 +21,8 @@ from birdxplorer_common.models import (
     Media,
     Note,
     NoteId,
+    NoteRequest,
+    NoteRequestSuggestion,
     ParticipantId,
     Post,
     PostId,
@@ -81,6 +83,11 @@ class MediaFactory(ModelFactory[Media]):
 class PostFactory(ModelFactory[Post]):
     __model__ = Post
     __check_model__ = False
+
+
+@register_fixture(name="note_request_factory")
+class NoteRequestFactory(ModelFactory[NoteRequest]):
+    __model__ = NoteRequest
 
 
 @register_fixture(name="link_factory")
@@ -347,12 +354,44 @@ https://t.co/yyyyyyyyyyy/ #学び #自己啓発""",
 
 
 @fixture
+def note_request_samples(
+    note_request_factory: NoteRequestFactory, post_samples: List[Post]
+) -> Generator[List[NoteRequest], None, None]:
+    note_requests = [
+        note_request_factory.build(
+            tweet_id=post_samples[0].post_id,
+            note_request_feed_eligible_at=1782900000000,
+            api_small_feed_eligible_at=None,
+            api_large_feed_eligible_at=None,
+            api_xl_feed_eligible_at=None,
+            source_links=[],
+            suggestions=[],
+            tweet_created_at=1782870000000,
+            post=post_samples[0],
+        ),
+        note_request_factory.build(
+            tweet_id="9994567890123456789",
+            note_request_feed_eligible_at=None,
+            api_small_feed_eligible_at=None,
+            api_large_feed_eligible_at=None,
+            api_xl_feed_eligible_at=None,
+            source_links=["https://x.com/i/status/123"],
+            suggestions=[NoteRequestSuggestion(suggestion_id="1", suggestion="テスト", source_link=None)],
+            tweet_created_at=1782950000000,
+            post=None,
+        ),
+    ]
+    yield note_requests
+
+
+@fixture
 def mock_storage(
     user_enrollment_samples: List[UserEnrollment],
     topic_samples: List[Topic],
     media_samples: List[Media],
     post_samples: List[Post],
     note_samples: List[Note],
+    note_request_samples: List[NoteRequest],
     link_samples: List[Link],
 ) -> Generator[MagicMock, None, None]:
     mock = MagicMock(spec=Storage)
@@ -604,6 +643,45 @@ def mock_storage(
         return []
 
     mock.search_notes_with_posts_for_csv.side_effect = _search_notes_with_posts_for_csv
+
+    def _get_note_requests(
+        tweet_ids: Union[List[PostId], None] = None,
+        tweet_created_at_from: Union[TwitterTimestamp, None] = None,
+        tweet_created_at_to: Union[TwitterTimestamp, None] = None,
+        has_post: Union[bool, None] = None,
+        offset: Union[int, None] = None,
+        limit: int = 100,
+    ) -> Generator[NoteRequest, None, None]:
+        filtered = []
+        for r in note_request_samples:
+            if tweet_ids is not None and r.tweet_id not in tweet_ids:
+                continue
+            if tweet_created_at_from is not None and (
+                r.tweet_created_at is None or r.tweet_created_at < tweet_created_at_from
+            ):
+                continue
+            if tweet_created_at_to is not None and (
+                r.tweet_created_at is None or r.tweet_created_at >= tweet_created_at_to
+            ):
+                continue
+            if has_post is True and r.post is None:
+                continue
+            if has_post is False and r.post is not None:
+                continue
+            filtered.append(r)
+        yield from filtered[offset or 0 : (offset or 0) + limit]
+
+    mock.get_note_requests.side_effect = _get_note_requests
+
+    def _get_number_of_note_requests(
+        tweet_ids: Union[List[PostId], None] = None,
+        tweet_created_at_from: Union[TwitterTimestamp, None] = None,
+        tweet_created_at_to: Union[TwitterTimestamp, None] = None,
+        has_post: Union[bool, None] = None,
+    ) -> int:
+        return len(list(_get_note_requests(tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post, 0, 10**9)))
+
+    mock.get_number_of_note_requests.side_effect = _get_number_of_note_requests
 
     yield mock
 

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -3,7 +3,7 @@ from typing import List
 
 from fastapi.testclient import TestClient
 
-from birdxplorer_common.models import Note, Post, Topic, UserEnrollment
+from birdxplorer_common.models import Note, NoteRequest, Post, Topic, UserEnrollment
 
 
 def test_user_enrollments_get(client: TestClient, user_enrollment_samples: List[UserEnrollment]) -> None:
@@ -267,3 +267,35 @@ def test_notes_get_accepts_non_enum_language(client: TestClient, note_samples: L
     response = client.get("/api/v1/data/notes/?language=zh")
     assert response.status_code == 200
     assert response.json()["meta"]["total"] == 0
+
+
+def test_note_requests_get(client: TestClient, note_request_samples: List[NoteRequest]) -> None:
+    response = client.get("/api/v1/data/note-requests")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert res_json == {
+        "data": [json.loads(d.model_dump_json()) for d in note_request_samples],
+        "meta": {"next": None, "prev": None, "total": 2},
+    }
+
+
+def test_note_requests_get_has_post_true(client: TestClient, note_request_samples: List[NoteRequest]) -> None:
+    response = client.get("/api/v1/data/note-requests?has_post=true")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert [d["tweetId"] for d in res_json["data"]] == [str(note_request_samples[0].tweet_id)]
+
+
+def test_note_requests_get_by_tweet_created_at_from(
+    client: TestClient, note_request_samples: List[NoteRequest]
+) -> None:
+    response = client.get("/api/v1/data/note-requests?tweet_created_at_from=1782900000000")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert [d["tweetId"] for d in res_json["data"]] == [str(note_request_samples[1].tweet_id)]
+
+
+def test_note_requests_count(client: TestClient, note_request_samples: List[NoteRequest]) -> None:
+    response = client.get("/api/v1/data/note-requests/count")
+    assert response.status_code == 200
+    assert response.json() == {"total": 2}

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -940,6 +940,65 @@ class Post(BaseModel):
         return HttpUrl(f"https://x.com/{self.x_user.name}/status/{self.post_id}")
 
 
+class NoteRequestSuggestion(BaseModel):
+    suggestion_id: Annotated[Optional[str], PydanticField(default=None, description="Suggestion の ID")]
+    suggestion: Annotated[
+        Optional[str],
+        PydanticField(default=None, description="ノートリクエスト時にユーザーが入力した、ノートが必要と考える理由"),
+    ]
+    source_link: Annotated[
+        Optional[str], PydanticField(default=None, description="Suggestion に添えられたソースリンク")
+    ]
+
+
+class NoteRequest(BaseModel):
+    tweet_id: Annotated[PostId, PydanticField(description="ノートリクエストが表示された Post の ID")]
+    note_request_feed_eligible_at: Annotated[
+        Optional[TwitterTimestamp],
+        PydanticField(
+            default=None,
+            description="アプリ内リクエストフィードの掲載基準を満たした日時 (ミリ秒 UNIX EPOCH)。未達の場合 null",
+        ),
+    ]
+    api_small_feed_eligible_at: Annotated[
+        Optional[TwitterTimestamp],
+        PydanticField(
+            default=None,
+            description="AI Note Writer API の small フィードの掲載基準を満たした日時 (ミリ秒 UNIX EPOCH)。未達の場合 null",
+        ),
+    ]
+    api_large_feed_eligible_at: Annotated[
+        Optional[TwitterTimestamp],
+        PydanticField(
+            default=None,
+            description="AI Note Writer API の large フィードの掲載基準を満たした日時 (ミリ秒 UNIX EPOCH)。未達の場合 null",
+        ),
+    ]
+    api_xl_feed_eligible_at: Annotated[
+        Optional[TwitterTimestamp],
+        PydanticField(
+            default=None,
+            description="AI Note Writer API の xl フィードの掲載基準を満たした日時 (ミリ秒 UNIX EPOCH)。未達の場合 null",
+        ),
+    ]
+    source_links: Annotated[
+        List[str],
+        PydanticField(default_factory=lambda: [], description="リクエスト時に添えられた X Post URL のリスト"),
+    ]
+    suggestions: Annotated[
+        List[NoteRequestSuggestion],
+        PydanticField(default_factory=lambda: [], description="リクエスト理由の Suggestion のリスト"),
+    ]
+    tweet_created_at: Annotated[
+        Optional[TwitterTimestamp],
+        PydanticField(
+            default=None,
+            description="Post の作成日時 (snowflake ID から算出、ミリ秒 UNIX EPOCH)。2010年以前の旧 ID は null",
+        ),
+    ]
+    post: Annotated[Optional[Post], PydanticField(default=None, description="取得済みの場合、Post の情報")]
+
+
 class PaginationMeta(BaseModel):
     next: Annotated[
         Optional[HttpUrl],

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -4,6 +4,7 @@ from typing import Any, Generator, List, NamedTuple, Optional, Tuple, Union
 from psycopg2.extensions import AsIs, register_adapter
 from pydantic import AnyUrl, HttpUrl
 from sqlalchemy import (
+    BigInteger,
     ForeignKey,
     and_,
     case,
@@ -14,6 +15,7 @@ from sqlalchemy import (
     select,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 from sqlalchemy.orm.query import RowReturningQuery
@@ -36,6 +38,10 @@ from .models import (
 from .models import Note as NoteModel
 from .models import (
     NoteId,
+)
+from .models import NoteRequest as NoteRequestModel
+from .models import NoteRequestSuggestion as NoteRequestSuggestionModel
+from .models import (
     NotesClassification,
     NotesHarmful,
     NoteStatusHistory,
@@ -296,6 +302,20 @@ class RowNoteRatingRecord(Base):
     rating_source_bucketed: Mapped[Optional[str]] = mapped_column(nullable=True)
     suggestion: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     suggestion_id: Mapped[Optional[str]] = mapped_column(nullable=True)
+
+
+class RowNoteRequestRecord(Base):
+    __tablename__ = "row_note_requests"
+
+    tweet_id: Mapped[PostId] = mapped_column(primary_key=True)
+    note_request_feed_eligible_at_millis: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    api_small_feed_eligible_at_millis: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    api_large_feed_eligible_at_millis: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    api_xl_feed_eligible_at_millis: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    source_links: Mapped[Optional[Any]] = mapped_column(JSONB, nullable=True)
+    suggestions: Mapped[Optional[Any]] = mapped_column(JSONB, nullable=True)
+    tweet_created_at: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    lookup_enqueued_at: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
 
 
 class RowPostRecord(Base):
@@ -1524,6 +1544,92 @@ class Storage:
                     .filter(LinkRecord.url == search_url)
                 )
             return query.count()
+
+    def _note_request_record_to_model(
+        self, record: RowNoteRequestRecord, post_record: Optional[PostRecord]
+    ) -> NoteRequestModel:
+        def _millis(value: Optional[int]) -> Optional[TwitterTimestamp]:
+            return TwitterTimestamp.from_int(value) if value is not None else None
+
+        suggestions = [
+            NoteRequestSuggestionModel(
+                suggestion_id=str(s["suggestion_id"]) if s.get("suggestion_id") is not None else None,
+                suggestion=s.get("suggestion"),
+                source_link=s.get("source_link") or None,
+            )
+            for s in (record.suggestions or [])
+            if isinstance(s, dict)
+        ]
+        return NoteRequestModel(
+            tweet_id=record.tweet_id,
+            note_request_feed_eligible_at=_millis(record.note_request_feed_eligible_at_millis),
+            api_small_feed_eligible_at=_millis(record.api_small_feed_eligible_at_millis),
+            api_large_feed_eligible_at=_millis(record.api_large_feed_eligible_at_millis),
+            api_xl_feed_eligible_at=_millis(record.api_xl_feed_eligible_at_millis),
+            source_links=list(record.source_links or []),
+            suggestions=suggestions,
+            tweet_created_at=_millis(record.tweet_created_at),
+            post=self._post_record_to_model(post_record, with_media=True) if post_record is not None else None,
+        )
+
+    @staticmethod
+    def _apply_note_request_filters(
+        query: Any,
+        tweet_ids: Union[List[PostId], None] = None,
+        tweet_created_at_from: Union[TwitterTimestamp, None] = None,
+        tweet_created_at_to: Union[TwitterTimestamp, None] = None,
+        has_post: Union[bool, None] = None,
+    ) -> Any:
+        if tweet_ids is not None:
+            query = query.filter(RowNoteRequestRecord.tweet_id.in_(tweet_ids))
+        if tweet_created_at_from is not None:
+            query = query.filter(RowNoteRequestRecord.tweet_created_at >= tweet_created_at_from)
+        if tweet_created_at_to is not None:
+            query = query.filter(RowNoteRequestRecord.tweet_created_at < tweet_created_at_to)
+        if has_post is True:
+            query = query.filter(PostRecord.post_id.isnot(None))
+        elif has_post is False:
+            query = query.filter(PostRecord.post_id.is_(None))
+        return query
+
+    def get_note_requests(
+        self,
+        tweet_ids: Union[List[PostId], None] = None,
+        tweet_created_at_from: Union[TwitterTimestamp, None] = None,
+        tweet_created_at_to: Union[TwitterTimestamp, None] = None,
+        has_post: Union[bool, None] = None,
+        offset: Union[int, None] = None,
+        limit: int = 100,
+    ) -> Generator[NoteRequestModel, None, None]:
+        with Session(self.engine) as sess:
+            query = sess.query(RowNoteRequestRecord, PostRecord).outerjoin(
+                PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id
+            )
+            query = self._apply_note_request_filters(
+                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post
+            )
+            query = query.order_by(RowNoteRequestRecord.tweet_id)
+            if offset is not None:
+                query = query.offset(offset)
+            query = query.limit(limit)
+            for record, post_record in query.all():
+                yield self._note_request_record_to_model(record, post_record)
+
+    def get_number_of_note_requests(
+        self,
+        tweet_ids: Union[List[PostId], None] = None,
+        tweet_created_at_from: Union[TwitterTimestamp, None] = None,
+        tweet_created_at_to: Union[TwitterTimestamp, None] = None,
+        has_post: Union[bool, None] = None,
+    ) -> int:
+        with Session(self.engine) as sess:
+            query = sess.query(RowNoteRequestRecord).outerjoin(
+                PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id
+            )
+            query = self._apply_note_request_filters(
+                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post
+            )
+            return int(query.count())
 
     def _apply_filters(
         self,

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1629,9 +1629,10 @@ class Storage:
         has_post: Union[bool, None] = None,
     ) -> int:
         with Session(self.engine) as sess:
-            query = sess.query(RowNoteRequestRecord).outerjoin(
-                PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id
-            )
+            query = sess.query(RowNoteRequestRecord)
+            if has_post is not None:
+                # posts への join は has_post フィルタでのみ必要 (post_id は PK 同士なので行数は変わらない)
+                query = query.outerjoin(PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id)
             query = self._apply_note_request_filters(
                 query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post
             )

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1549,7 +1549,13 @@ class Storage:
         self, record: RowNoteRequestRecord, post_record: Optional[PostRecord]
     ) -> NoteRequestModel:
         def _millis(value: Optional[int]) -> Optional[TwitterTimestamp]:
-            return TwitterTimestamp.from_int(value) if value is not None else None
+            if value is None:
+                return None
+            try:
+                return TwitterTimestamp.from_int(value)
+            except ValueError:
+                # 外部データ由来の範囲外 millis で API 全体を 500 にしない
+                return None
 
         suggestions = [
             NoteRequestSuggestionModel(

--- a/common/tests/test_storage_note_requests.py
+++ b/common/tests/test_storage_note_requests.py
@@ -1,0 +1,121 @@
+from typing import Any, Dict, List
+
+import pytest
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from birdxplorer_common.models import Post
+from birdxplorer_common.storage import PostRecord, RowNoteRequestRecord, Storage
+
+
+@pytest.fixture
+def note_request_records_sample(
+    engine_for_test: Engine,
+    post_records_sample: List[PostRecord],
+) -> List[RowNoteRequestRecord]:
+    records = [
+        # post_records_sample[0] と同じ tweet_id → 投稿 join あり
+        RowNoteRequestRecord(
+            tweet_id="2234567890123456781",
+            note_request_feed_eligible_at_millis=1782900000000,
+            api_small_feed_eligible_at_millis=None,
+            api_large_feed_eligible_at_millis=None,
+            api_xl_feed_eligible_at_millis=1782900000000,
+            source_links=["https://x.com/i/status/123"],
+            suggestions=[{"suggestion_id": 123, "suggestion": "テスト説明", "source_link": ""}],
+            tweet_created_at=1782870000000,
+            lookup_enqueued_at=None,
+        ),
+        # 投稿未取得のリクエスト
+        RowNoteRequestRecord(
+            tweet_id="9994567890123456789",
+            note_request_feed_eligible_at_millis=None,
+            api_small_feed_eligible_at_millis=None,
+            api_large_feed_eligible_at_millis=None,
+            api_xl_feed_eligible_at_millis=None,
+            source_links=None,
+            suggestions=None,
+            tweet_created_at=1782950000000,
+            lookup_enqueued_at=None,
+        ),
+        # snowflake 以前の旧 tweet（tweet_created_at 無し）
+        RowNoteRequestRecord(
+            tweet_id="20",
+            note_request_feed_eligible_at_millis=None,
+            api_small_feed_eligible_at_millis=None,
+            api_large_feed_eligible_at_millis=1774176942021,
+            api_xl_feed_eligible_at_millis=None,
+            source_links=None,
+            suggestions=None,
+            tweet_created_at=None,
+            lookup_enqueued_at=None,
+        ),
+    ]
+    with Session(engine_for_test) as sess:
+        sess.add_all(records)
+        sess.commit()
+    return records
+
+
+def test_get_note_requests_all(
+    engine_for_test: Engine,
+    note_request_records_sample: List[RowNoteRequestRecord],
+    post_samples: List[Post],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    actual = list(storage.get_note_requests())
+    # tweet_id 昇順（文字列順）で返る
+    assert [str(r.tweet_id) for r in actual] == ["20", "2234567890123456781", "9994567890123456789"]
+    by_id = {str(r.tweet_id): r for r in actual}
+    with_post = by_id["2234567890123456781"]
+    assert with_post.post is not None
+    assert with_post.post.post_id == post_samples[0].post_id
+    assert with_post.source_links == ["https://x.com/i/status/123"]
+    assert len(with_post.suggestions) == 1
+    assert with_post.suggestions[0].suggestion == "テスト説明"
+    assert with_post.suggestions[0].suggestion_id == "123"
+    assert with_post.note_request_feed_eligible_at == 1782900000000
+    assert by_id["9994567890123456789"].post is None
+    assert by_id["20"].tweet_created_at is None
+
+
+@pytest.mark.parametrize(
+    ["filter_args", "expected_tweet_ids"],
+    [
+        [dict(tweet_ids=["2234567890123456781"]), ["2234567890123456781"]],
+        [dict(tweet_created_at_from=1782900000000), ["9994567890123456789"]],
+        [dict(tweet_created_at_to=1782900000000), ["2234567890123456781"]],
+        [dict(has_post=True), ["2234567890123456781"]],
+        [dict(has_post=False), ["20", "9994567890123456789"]],
+        [dict(offset=1, limit=1), ["2234567890123456781"]],
+    ],
+)
+def test_get_note_requests_filters(
+    engine_for_test: Engine,
+    note_request_records_sample: List[RowNoteRequestRecord],
+    filter_args: Dict[str, Any],
+    expected_tweet_ids: List[str],
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    actual = [str(r.tweet_id) for r in storage.get_note_requests(**filter_args)]
+    assert actual == expected_tweet_ids
+
+
+@pytest.mark.parametrize(
+    ["filter_args", "expected_count"],
+    [
+        [dict(), 3],
+        [dict(tweet_ids=["2234567890123456781"]), 1],
+        [dict(has_post=True), 1],
+        [dict(has_post=False), 2],
+        [dict(tweet_created_at_from=1782900000000), 1],
+    ],
+)
+def test_get_number_of_note_requests(
+    engine_for_test: Engine,
+    note_request_records_sample: List[RowNoteRequestRecord],
+    filter_args: Dict[str, Any],
+    expected_count: int,
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    assert storage.get_number_of_note_requests(**filter_args) == expected_count

--- a/common/tests/test_storage_note_requests.py
+++ b/common/tests/test_storage_note_requests.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from birdxplorer_common.models import Post
+from birdxplorer_common.models import Post, PostId
 from birdxplorer_common.storage import PostRecord, RowNoteRequestRecord, Storage
 
 
@@ -119,3 +119,26 @@ def test_get_number_of_note_requests(
 ) -> None:
     storage = Storage(engine=engine_for_test)
     assert storage.get_number_of_note_requests(**filter_args) == expected_count
+
+
+def test_get_note_requests_out_of_range_millis_returns_none(engine_for_test: Engine) -> None:
+    # TwitterTimestamp の下限未満の異常値が DB に入っていても API を 500 にせず None に落とす
+    with Session(engine_for_test) as sess:
+        sess.add(
+            RowNoteRequestRecord(
+                tweet_id="30",
+                note_request_feed_eligible_at_millis=123,
+                api_small_feed_eligible_at_millis=None,
+                api_large_feed_eligible_at_millis=None,
+                api_xl_feed_eligible_at_millis=None,
+                source_links=None,
+                suggestions=None,
+                tweet_created_at=None,
+                lookup_enqueued_at=None,
+            )
+        )
+        sess.commit()
+    storage = Storage(engine=engine_for_test)
+    actual = list(storage.get_note_requests(tweet_ids=[PostId.from_str("30")]))
+    assert len(actual) == 1
+    assert actual[0].note_request_feed_eligible_at is None

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -19,6 +19,7 @@ from birdxplorer_common.storage import (
     NoteRecord,
     RowNoteRatingRecord,
     RowNoteRecord,
+    RowNoteRequestRecord,
     RowNoteStatusRecord,
 )
 
@@ -439,6 +440,10 @@ def extract_data(postgresql: Session):
     phase_start = time.time()
     backfill_missing_notes(postgresql)
     logging.info(f"[PHASE_COMPLETE] Backfill: {time.time() - phase_start:.1f}s")
+
+    # Note Requests (batSignals) の取り込みと投稿 lookup の enqueue
+    extract_note_requests(postgresql)
+    enqueue_note_request_lookups(postgresql)
 
     return
 
@@ -1013,3 +1018,105 @@ def parse_note_request_row(row: dict):
         "suggestions": _parse_note_request_suggestions(row.get("suggestions"), tweet_id),
         "tweet_created_at": tweet_created_at_from_id(int(tweet_id)),
     }
+
+
+_NOTE_REQUEST_UPDATE_COLUMNS = [
+    "note_request_feed_eligible_at_millis",
+    "api_small_feed_eligible_at_millis",
+    "api_large_feed_eligible_at_millis",
+    "api_xl_feed_eligible_at_millis",
+    "source_links",
+    "suggestions",
+]
+
+
+def _flush_note_request_batch(postgresql: Session, batch: list):
+    if not batch:
+        return
+    stmt = insert(RowNoteRequestRecord).values(batch)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["tweet_id"],
+        set_={col: getattr(stmt.excluded, col) for col in _NOTE_REQUEST_UPDATE_COLUMNS},
+    )
+    postgresql.execute(stmt)
+    postgresql.commit()
+
+
+def extract_note_requests(postgresql: Session):
+    """batSignals (Note Requests) の日次スナップショットを row_note_requests に UPSERT する。"""
+    phase_start = time.time()
+    for days_ago in range(3):  # 今日、昨日、一昨日
+        date = datetime.now() - timedelta(days=days_ago)
+        dateString = date.strftime("%Y/%m/%d")
+        url = f"https://ton.twimg.com/birdwatch-public-data/{dateString}/batSignals/batSignals-00000.zip"
+        logging.info(f"Fetching note requests from: {url}")
+        res = requests.get(url)
+        if res.status_code == 404:
+            logging.info(f"No note requests data available for {dateString}, trying previous day")
+            continue
+        if res.status_code != 200:
+            logging.warning(f"Unexpected status code {res.status_code} for note requests, skipping day")
+            continue
+        with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
+            tsv_filename = "batSignals-00000.tsv"
+            if tsv_filename not in zip_file.namelist():
+                logging.error(f"TSV file {tsv_filename} not found in the zip file.")
+                return
+            with zip_file.open(tsv_filename) as tsv_file:
+                tsv_data = tsv_file.read().decode("utf-8").splitlines()
+                reader = csv.DictReader(tsv_data, delimiter="\t")
+                reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                rows_by_id = {}
+                total = 0
+                for row in reader:
+                    parsed = parse_note_request_row(row)
+                    if parsed is None:
+                        continue
+                    rows_by_id[parsed["tweet_id"]] = parsed
+                    if len(rows_by_id) >= 10000:
+                        _flush_note_request_batch(postgresql, list(rows_by_id.values()))
+                        total += len(rows_by_id)
+                        rows_by_id = {}
+                _flush_note_request_batch(postgresql, list(rows_by_id.values()))
+                total += len(rows_by_id)
+        logging.info(f"[PHASE_COMPLETE] NoteRequests: {total} rows in {time.time() - phase_start:.1f}s")
+        return
+    logging.warning("No note requests data found in the last 3 days")
+
+
+def enqueue_note_request_lookups(postgresql: Session, batch_limit: int = 10000):
+    """2026-07-01 以降に作成され、投稿未取得かつ未 enqueue の tweet を tweet-lookup-queue に流す。"""
+    if not settings.TWEET_LOOKUP_QUEUE_URL:
+        logging.info("TWEET_LOOKUP_QUEUE_URL not set, skipping note request lookups")
+        return
+    now_millis = int(time.time() * 1000)
+    total = 0
+    while True:
+        rows = postgresql.execute(
+            text(
+                "SELECT r.tweet_id FROM row_note_requests r "
+                "WHERE r.tweet_created_at >= :min_created_at "
+                "AND r.lookup_enqueued_at IS NULL "
+                "AND NOT EXISTS (SELECT 1 FROM row_posts p WHERE p.post_id = r.tweet_id) "
+                "ORDER BY r.tweet_id LIMIT :batch_limit"
+            ),
+            {
+                "min_created_at": NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT,
+                "batch_limit": batch_limit,
+            },
+        ).fetchall()
+        if not rows:
+            break
+        tweet_ids = [r[0] for r in rows]
+        messages = [{"MessageBody": json.dumps({"tweet_id": tweet_id})} for tweet_id in tweet_ids]
+        _send_sqs_batch(settings.TWEET_LOOKUP_QUEUE_URL, messages)
+        postgresql.execute(
+            update(RowNoteRequestRecord)
+            .where(RowNoteRequestRecord.tweet_id.in_(tweet_ids))
+            .values(lookup_enqueued_at=now_millis)
+        )
+        postgresql.commit()
+        total += len(tweet_ids)
+        if len(rows) < batch_limit:
+            break
+    logging.info(f"Enqueued {total} note request tweet lookups")

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -442,8 +442,7 @@ def extract_data(postgresql: Session):
     logging.info(f"[PHASE_COMPLETE] Backfill: {time.time() - phase_start:.1f}s")
 
     # Note Requests (batSignals) の取り込みと投稿 lookup の enqueue
-    extract_note_requests(postgresql)
-    enqueue_note_request_lookups(postgresql)
+    run_note_requests_phase(postgresql)
 
     return
 
@@ -1120,3 +1119,12 @@ def enqueue_note_request_lookups(postgresql: Session, batch_limit: int = 10000):
         if len(rows) < batch_limit:
             break
     logging.info(f"Enqueued {total} note request tweet lookups")
+
+
+def run_note_requests_phase(postgresql: Session):
+    """Note Requests の取り込みと lookup enqueue。失敗しても extract 全体は落とさない。"""
+    try:
+        extract_note_requests(postgresql)
+        enqueue_note_request_lookups(postgresql)
+    except Exception:
+        logging.exception("Note requests phase failed, continuing")

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -948,3 +948,68 @@ def _cleanup_staging_table(postgresql: Session) -> None:
     except Exception as e:
         logging.warning(f"Staging table cleanup failed: {e}")
         postgresql.rollback()
+
+
+# ---- Note Requests (batSignals) ----
+
+TWITTER_SNOWFLAKE_EPOCH_MILLIS = 1288834974657
+# snowflake 以前の連番 ID は最大 ~3.0e10。snowflake ID は ~1e13 以上なので 1e12 を閾値にする
+_MIN_SNOWFLAKE_TWEET_ID = 1_000_000_000_000
+# 2026-07-01T00:00:00Z。これ以降に作成された tweet のみ X API lookup 対象にする
+NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT = 1782864000000
+
+
+def tweet_created_at_from_id(tweet_id: int):
+    """snowflake ID から作成時刻 (ミリ秒 UNIX EPOCH) を算出する。snowflake 以前の旧 ID は None。"""
+    if tweet_id < _MIN_SNOWFLAKE_TWEET_ID:
+        return None
+    return (tweet_id >> 22) + TWITTER_SNOWFLAKE_EPOCH_MILLIS
+
+
+def _parse_note_request_millis(value):
+    if value is None or value == "":
+        return None
+    try:
+        millis = int(value)
+    except ValueError:
+        return None
+    return millis if millis > 0 else None
+
+
+def _parse_note_request_source_links(value):
+    # sourceLinks は公式ドキュメントに反して JSON ではなくカンマ区切りの URL 文字列
+    if value is None or value.strip() == "":
+        return None
+    return [u for u in (s.strip() for s in value.split(",")) if u]
+
+
+def _parse_note_request_suggestions(value, tweet_id: str):
+    if value is None or value.strip() == "":
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        logging.warning(f"Failed to parse suggestions for tweet {tweet_id}: {value[:100]}")
+        return None
+    if not isinstance(parsed, list) or not parsed:
+        return None
+    return parsed
+
+
+def parse_note_request_row(row: dict):
+    """snake_case 化済みの batSignals TSV 行を row_note_requests のカラム dict に変換する。"""
+    tweet_id = (row.get("tweet_id") or "").strip()
+    if not tweet_id.isdigit():
+        return None
+    return {
+        "tweet_id": tweet_id,
+        "note_request_feed_eligible_at_millis": _parse_note_request_millis(
+            row.get("note_request_feed_eligible_at_millis")
+        ),
+        "api_small_feed_eligible_at_millis": _parse_note_request_millis(row.get("api_small_feed_eligible_at_millis")),
+        "api_large_feed_eligible_at_millis": _parse_note_request_millis(row.get("api_large_feed_eligible_at_millis")),
+        "api_xl_feed_eligible_at_millis": _parse_note_request_millis(row.get("api_xl_feed_eligible_at_millis")),
+        "source_links": _parse_note_request_source_links(row.get("source_links")),
+        "suggestions": _parse_note_request_suggestions(row.get("suggestions"), tweet_id),
+        "tweet_created_at": tweet_created_at_from_id(int(tweet_id)),
+    }

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -6,6 +6,7 @@ import os
 import time
 import zipfile
 from datetime import datetime, timedelta
+from typing import Optional
 
 import boto3
 import requests
@@ -957,13 +958,14 @@ def _cleanup_staging_table(postgresql: Session) -> None:
 # ---- Note Requests (batSignals) ----
 
 TWITTER_SNOWFLAKE_EPOCH_MILLIS = 1288834974657
-# snowflake 以前の連番 ID は最大 ~3.0e10。snowflake ID は ~1e13 以上なので 1e12 を閾値にする
+# snowflake 以前の連番 ID は最大 ~3.0e10。1e12 はその上に余裕を持たせた閾値
+# (snowflake 移行直後の数分間に採番された極小 ID は None 側に倒れるが実害なし)
 _MIN_SNOWFLAKE_TWEET_ID = 1_000_000_000_000
 # 2026-07-01T00:00:00Z。これ以降に作成された tweet のみ X API lookup 対象にする
 NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT = 1782864000000
 
 
-def tweet_created_at_from_id(tweet_id: int):
+def tweet_created_at_from_id(tweet_id: int) -> Optional[int]:
     """snowflake ID から作成時刻 (ミリ秒 UNIX EPOCH) を算出する。snowflake 以前の旧 ID は None。"""
     if tweet_id < _MIN_SNOWFLAKE_TWEET_ID:
         return None
@@ -1116,8 +1118,6 @@ def enqueue_note_request_lookups(postgresql: Session, batch_limit: int = 10000):
         )
         postgresql.commit()
         total += len(tweet_ids)
-        if len(rows) < batch_limit:
-            break
     logging.info(f"Enqueued {total} note request tweet lookups")
 
 

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -16,6 +16,7 @@ from birdxplorer_etl.extract_ecs import (  # noqa: E402
     enqueue_note_request_lookups,
     extract_note_requests,
     parse_note_request_row,
+    run_note_requests_phase,
     tweet_created_at_from_id,
 )
 
@@ -169,3 +170,21 @@ class TestEnqueueNoteRequestLookups:
                 enqueue_note_request_lookups(session)
         assert send.call_count == 0
         assert session.execute.call_count == 0
+
+
+class TestRunNoteRequestsPhase:
+    def test_swallows_exceptions(self):
+        session = MagicMock()
+        with patch(
+            "birdxplorer_etl.extract_ecs.extract_note_requests",
+            side_effect=RuntimeError("SQS send failed"),
+        ):
+            run_note_requests_phase(session)  # 例外が伝播しなければ成功
+
+    def test_calls_both_functions(self):
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.extract_note_requests") as ext:
+            with patch("birdxplorer_etl.extract_ecs.enqueue_note_request_lookups") as enq:
+                run_note_requests_phase(session)
+        ext.assert_called_once_with(session)
+        enq.assert_called_once_with(session)

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -149,7 +149,9 @@ class TestEnqueueNoteRequestLookups:
         session = MagicMock()
         select_result = MagicMock()
         select_result.fetchall.return_value = [("2072000000000000000",), ("2072000000000000001",)]
-        session.execute.side_effect = [select_result, MagicMock()]
+        empty_result = MagicMock()
+        empty_result.fetchall.return_value = []
+        session.execute.side_effect = [select_result, MagicMock(), empty_result]
         with patch("birdxplorer_etl.extract_ecs.settings") as mock_settings:
             mock_settings.TWEET_LOOKUP_QUEUE_URL = "https://sqs.example.com/queue"
             with patch("birdxplorer_etl.extract_ecs._send_sqs_batch") as send:
@@ -158,8 +160,8 @@ class TestEnqueueNoteRequestLookups:
         assert send.call_args[0][0] == "https://sqs.example.com/queue"
         bodies = [json.loads(m["MessageBody"]) for m in send.call_args[0][1]]
         assert bodies == [{"tweet_id": "2072000000000000000"}, {"tweet_id": "2072000000000000001"}]
-        # select + update の 2 回実行され、commit されている
-        assert session.execute.call_count == 2
+        # select + update + 終端確認の select の 3 回実行され、commit されている
+        assert session.execute.call_count == 3
         assert session.commit.call_count == 1
 
     def test_skips_when_queue_url_not_set(self):

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -1,0 +1,81 @@
+import json
+import sys
+from unittest.mock import MagicMock
+
+# extract_ecs.py は psycopg2 と settings を transitively import する（ECS/Lambda ランタイム専用）
+_mock_psycopg2 = MagicMock()
+_mock_psycopg2.extensions = MagicMock()
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+sys.modules.setdefault("psycopg2.extensions", _mock_psycopg2.extensions)
+sys.modules.setdefault("settings", MagicMock())
+
+from birdxplorer_etl.extract_ecs import (  # noqa: E402
+    NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT,
+    parse_note_request_row,
+    tweet_created_at_from_id,
+)
+
+
+class TestTweetCreatedAtFromId:
+    def test_known_snowflake_id(self):
+        # Snowflake ID from epoch calculation (tweet_id >> 22) + 1288834974657
+        # 1212092628029698048 >> 22 = 288985402114
+        # 288985402114 + 1288834974657 = 1577820376771
+        assert tweet_created_at_from_id(1212092628029698048) == 1577820376771
+
+    def test_pre_snowflake_id_returns_none(self):
+        assert tweet_created_at_from_id(20) is None
+
+    def test_min_constant_is_2026_07_01(self):
+        assert NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT == 1782864000000
+
+
+class TestParseNoteRequestRow:
+    def _row(self, **overrides):
+        row = {
+            "tweet_id": "1212092628029698048",
+            "note_request_feed_eligible_at_millis": "-1",
+            "api_small_feed_eligible_at_millis": "-1",
+            "api_large_feed_eligible_at_millis": "1774176942021",
+            "api_xl_feed_eligible_at_millis": "",
+            "source_links": "",
+            "suggestions": "[]",
+        }
+        row.update(overrides)
+        return row
+
+    def test_basic_row(self):
+        parsed = parse_note_request_row(self._row())
+        assert parsed == {
+            "tweet_id": "1212092628029698048",
+            "note_request_feed_eligible_at_millis": None,
+            "api_small_feed_eligible_at_millis": None,
+            "api_large_feed_eligible_at_millis": 1774176942021,
+            "api_xl_feed_eligible_at_millis": None,
+            "source_links": None,
+            "suggestions": None,
+            "tweet_created_at": 1577820376771,
+        }
+
+    def test_source_links_comma_separated(self):
+        parsed = parse_note_request_row(self._row(source_links="https://x.com/i/status/1,https://x.com/i/status/2"))
+        assert parsed["source_links"] == ["https://x.com/i/status/1", "https://x.com/i/status/2"]
+
+    def test_suggestions_json(self):
+        raw = json.dumps([{"suggestion_id": 123, "suggestion": "テスト", "source_link": ""}])
+        parsed = parse_note_request_row(self._row(suggestions=raw))
+        assert parsed["suggestions"] == [{"suggestion_id": 123, "suggestion": "テスト", "source_link": ""}]
+
+    def test_broken_suggestions_json_becomes_none(self):
+        parsed = parse_note_request_row(self._row(suggestions='[{"broken": '))
+        assert parsed["suggestions"] is None
+        # 他のカラムは影響を受けない
+        assert parsed["tweet_id"] == "1212092628029698048"
+
+    def test_invalid_tweet_id_returns_none(self):
+        assert parse_note_request_row(self._row(tweet_id="")) is None
+        assert parse_note_request_row(self._row(tweet_id="abc")) is None
+
+    def test_invalid_millis_becomes_none(self):
+        parsed = parse_note_request_row(self._row(api_large_feed_eligible_at_millis="abc"))
+        assert parsed["api_large_feed_eligible_at_millis"] is None

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -1,6 +1,8 @@
+import io
 import json
 import sys
-from unittest.mock import MagicMock
+import zipfile
+from unittest.mock import MagicMock, patch
 
 # extract_ecs.py は psycopg2 と settings を transitively import する（ECS/Lambda ランタイム専用）
 _mock_psycopg2 = MagicMock()
@@ -11,6 +13,8 @@ sys.modules.setdefault("settings", MagicMock())
 
 from birdxplorer_etl.extract_ecs import (  # noqa: E402
     NOTE_REQUEST_LOOKUP_MIN_TWEET_CREATED_AT,
+    enqueue_note_request_lookups,
+    extract_note_requests,
     parse_note_request_row,
     tweet_created_at_from_id,
 )
@@ -79,3 +83,89 @@ class TestParseNoteRequestRow:
     def test_invalid_millis_becomes_none(self):
         parsed = parse_note_request_row(self._row(api_large_feed_eligible_at_millis="abc"))
         assert parsed["api_large_feed_eligible_at_millis"] is None
+
+
+TSV_HEADER = (
+    "tweetId\tnoteRequestFeedEligibleAtMillis\tapiSmallFeedEligibleAtMillis"
+    "\tapiLargeFeedEligibleAtMillis\tapiXlFeedEligibleAtMillis\tsourceLinks\tsuggestions"
+)
+
+
+def _build_zip(tsv: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("batSignals-00000.tsv", tsv)
+    return buf.getvalue()
+
+
+class TestExtractNoteRequests:
+    def test_upserts_parsed_rows(self):
+        tsv = (
+            TSV_HEADER
+            + "\n1212092628029698048\t-1\t-1\t1774176942021\t1774176942021"
+            + "\thttps://x.com/i/status/1,https://x.com/i/status/2\t"
+            + json.dumps([{"suggestion_id": 1, "suggestion": "test", "source_link": ""}])
+            + "\n"
+        )
+        mock_res = MagicMock(status_code=200, content=_build_zip(tsv))
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.requests.get", return_value=mock_res):
+            with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                extract_note_requests(session)
+        assert flush.call_count == 1
+        batch = flush.call_args[0][1]
+        assert len(batch) == 1
+        assert batch[0]["tweet_id"] == "1212092628029698048"
+        assert batch[0]["tweet_created_at"] == 1577820376771
+        assert batch[0]["note_request_feed_eligible_at_millis"] is None
+        assert batch[0]["api_large_feed_eligible_at_millis"] == 1774176942021
+        assert batch[0]["source_links"] == ["https://x.com/i/status/1", "https://x.com/i/status/2"]
+        assert batch[0]["suggestions"] == [{"suggestion_id": 1, "suggestion": "test", "source_link": ""}]
+
+    def test_falls_back_to_previous_day_on_404(self):
+        tsv = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
+        res_404 = MagicMock(status_code=404)
+        res_200 = MagicMock(status_code=200, content=_build_zip(tsv))
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_404, res_200]) as get:
+            with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                extract_note_requests(session)
+        assert get.call_count == 2
+        assert flush.call_count == 1
+
+    def test_gives_up_after_3_days_of_404(self):
+        res_404 = MagicMock(status_code=404)
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.requests.get", return_value=res_404) as get:
+            with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                extract_note_requests(session)
+        assert get.call_count == 3
+        assert flush.call_count == 0
+
+
+class TestEnqueueNoteRequestLookups:
+    def test_sends_sqs_and_marks_enqueued(self):
+        session = MagicMock()
+        select_result = MagicMock()
+        select_result.fetchall.return_value = [("2072000000000000000",), ("2072000000000000001",)]
+        session.execute.side_effect = [select_result, MagicMock()]
+        with patch("birdxplorer_etl.extract_ecs.settings") as mock_settings:
+            mock_settings.TWEET_LOOKUP_QUEUE_URL = "https://sqs.example.com/queue"
+            with patch("birdxplorer_etl.extract_ecs._send_sqs_batch") as send:
+                enqueue_note_request_lookups(session)
+        assert send.call_count == 1
+        assert send.call_args[0][0] == "https://sqs.example.com/queue"
+        bodies = [json.loads(m["MessageBody"]) for m in send.call_args[0][1]]
+        assert bodies == [{"tweet_id": "2072000000000000000"}, {"tweet_id": "2072000000000000001"}]
+        # select + update の 2 回実行され、commit されている
+        assert session.execute.call_count == 2
+        assert session.commit.call_count == 1
+
+    def test_skips_when_queue_url_not_set(self):
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.settings") as mock_settings:
+            mock_settings.TWEET_LOOKUP_QUEUE_URL = None
+            with patch("birdxplorer_etl.extract_ecs._send_sqs_batch") as send:
+                enqueue_note_request_lookups(session)
+        assert send.call_count == 0
+        assert session.execute.call_count == 0

--- a/migrate/migration/versions/add_row_note_requests_table.py
+++ b/migrate/migration/versions/add_row_note_requests_table.py
@@ -1,0 +1,44 @@
+"""add row_note_requests table
+
+Revision ID: add_row_note_requests_table
+Revises: add_rating_new_columns
+Create Date: 2026-07-03
+
+Community Notes の公開データ Note Requests (batSignals) を格納するテーブル。
+- eligibility 系カラムは TSV の -1 を NULL に変換して保存する
+- source_links / suggestions は JSONB
+- tweet_created_at は snowflake ID から ETL 時に算出（snowflake 以前の旧 ID は NULL）
+- lookup_enqueued_at は tweet-lookup-queue への enqueue 済みマーカー
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "add_row_note_requests_table"
+down_revision: Union[str, None] = "add_rating_new_columns"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "row_note_requests",
+        sa.Column("tweet_id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("note_request_feed_eligible_at_millis", sa.BigInteger(), nullable=True),
+        sa.Column("api_small_feed_eligible_at_millis", sa.BigInteger(), nullable=True),
+        sa.Column("api_large_feed_eligible_at_millis", sa.BigInteger(), nullable=True),
+        sa.Column("api_xl_feed_eligible_at_millis", sa.BigInteger(), nullable=True),
+        sa.Column("source_links", postgresql.JSONB(), nullable=True),
+        sa.Column("suggestions", postgresql.JSONB(), nullable=True),
+        sa.Column("tweet_created_at", sa.BigInteger(), nullable=True),
+        sa.Column("lookup_enqueued_at", sa.BigInteger(), nullable=True),
+    )
+    op.create_index("ix_row_note_requests_tweet_created_at", "row_note_requests", ["tweet_created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_row_note_requests_tweet_created_at", table_name="row_note_requests")
+    op.drop_table("row_note_requests")


### PR DESCRIPTION
## 概要

Community Notes 公開データの **Note Requests**（どの投稿にコミュニティノートのリクエストが集まっているか）を ETL で取り込み、X API で投稿本文と突合して、BirdXplorer API から提供できるようにします。

データソース: `https://ton.twimg.com/birdwatch-public-data/{YYYY/MM/DD}/batSignals/batSignals-00000.zip`（公式ドキュメント上の名称は Note Requests、ファイルパスの内部名は batSignals。日次累積スナップショット、約49万行）

## 変更内容

### migrate
- `row_note_requests` テーブル追加（tweet_id PK / eligibility タイムスタンプ4種 / source_links・suggestions JSONB / tweet_created_at / lookup_enqueued_at + tweet_created_at インデックス）

### etl（`extract_ecs.py`）
- batSignals の日次ダウンロード（404 時は前日フォールバック、最大3日遡り）→ TSV パース → `INSERT ... ON CONFLICT` で全件 UPSERT
- パース仕様: eligibility の `-1` → NULL、`sourceLinks` はカンマ区切り URL 文字列 → JSONB リスト、`suggestions` は JSON 配列（壊れた JSON は警告ログ + NULL、行はスキップしない）、`tweet_created_at` は snowflake ID から算出
- **tweet 作成日 2026-07-01 以降**かつ `row_posts` 未取得かつ未 enqueue の tweetId を既存 tweet-lookup-queue へ enqueue（`{"tweet_id": ...}` 形式、postlookup lambda は無変更）。日次差分は平均約2,700件/日の見込み
- Note Requests フェーズの失敗は他の extract 処理に伝播しない（try/except で分離）

### common
- `RowNoteRequestRecord` / Pydantic `NoteRequest`・`NoteRequestSuggestion` モデル
- `Storage.get_note_requests()`（posts と outerjoin、has_post・日付範囲・tweet_ids フィルタ、ページネーション）/ `get_number_of_note_requests()`

### api
- `GET /api/v1/data/note-requests` — 一覧 + 投稿 join（未取得は `post: null`）、offset/limit（max 1000）
- `GET /api/v1/data/note-requests/count` — 件数
- OpenAPI ドキュメント追加

## テスト

- common: tox 通過（storage メソッドの実 PostgreSQL テスト 12 件追加、congratulations）
- api: tox 通過（エンドポイントテスト 4 件追加、congratulations）
- etl: pytest 193 passed（パーサー・extract・enqueue のユニットテストを追加。pflake8 の既存エラー14件は本 PR と無関係の既存コード起因）
- migrate: tox 通過

## デプロイ注意

- CDK 側の対応（ECS extract タスクへの `TWEET_LOOKUP_QUEUE_URL` 追加）は codeforjapan/BirdXplorer-cdk#20 で**マージ済み**
- 本 PR マージ→イメージ更新後、**CDK デプロイ（MigrationStack）で `row_note_requests` テーブルが作成されるまで**の間、新エンドポイント `/note-requests` は 500 を返し、ETL の note-requests フェーズはログにエラーを出してスキップされます（既存の extract 処理・既存エンドポイントへの影響なし）。マージ後は早めに CDK デプロイを実行してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 補足（レビュー指摘への対応メモ）

- `api/pyproject.toml` の `filterwarnings` から `ignore::starlette.exceptions.StarletteDeprecationWarning` を1行削除しています。starlette 1.0.0 で当該 warning クラスが削除されており、参照が残っていると pytest がコレクション時に落ちるための修正です（本 PR の主目的とは独立した既存問題の解消）
- `migrate/migration/py.typed` の追加は、本 PR で `sqlalchemy.dialects.postgresql.JSONB` を使い始めたことに伴い `mypy migration --strict` を通すためのものです（common の `birdxplorer_common/py.typed` と同じパッケージ直下配置）
- enqueue 処理は at-least-once です（SQS 送信成功後・マーカー更新前に失敗すると次回再 enqueue されうる）。postlookup lambda は同一 tweet_id の再処理に対して冪等なため実害はありません
