### PR TITLE
fix: disable gunicorn control socket to stop startup permission errors

### DIFF
--- a/api/Dockerfile.prd
+++ b/api/Dockerfile.prd
@@ -43,4 +43,6 @@ USER app
 COPY --from=builder /usr/local/lib/python${PYTHON_VERSION_CODE}/site-packages /usr/local/lib/python${PYTHON_VERSION_CODE}/site-packages
 COPY --chown=app:app . ./
 
-ENTRYPOINT ["python", "-m", "gunicorn", "birdxplorer_api.main:app", "-k", "uvicorn.workers.UvicornWorker", "-w", "1", "--bind", "0.0.0.0:10000"]
+# --no-control-socket: gunicorn 25+ の control socket はデフォルト有効だが、
+# 非 root ユーザー(ホームディレクトリ無し)ではソケット作成に失敗し起動毎に ERROR ログが出るため無効化
+ENTRYPOINT ["python", "-m", "gunicorn", "birdxplorer_api.main:app", "-k", "uvicorn.workers.UvicornWorker", "-w", "1", "--bind", "0.0.0.0:10000", "--no-control-socket"]


### PR DESCRIPTION
## 概要

dev の API ログに起動のたびに出ている以下の ERROR を解消します:

```
[ERROR] Control server error: [Errno 13] Permission denied: '/home/app'
```

## 原因

- gunicorn 25 から [control socket](https://gunicorn.org/guides/gunicornc/)（`gunicornc` による実行時管理機能）が**デフォルト有効**になった
- `api/pyproject.toml` は gunicorn をバージョン固定していないため、イメージビルド時に 25+ が入る
- `Dockerfile.prd` の実行ユーザーは `useradd -r` で作られており**ホームディレクトリが存在しない**ため、デフォルトのソケットパス（`$HOME/.gunicorn/gunicorn.ctl`）の作成が `Permission denied` で失敗し、起動毎に ERROR が記録される

サービス動作への実害はありません（HTTP worker は正常起動する）が、1週間以上前からノイズとして出続けていました。

## 対応

ENTRYPOINT に `--no-control-socket` を追加して機能ごと無効化します。この API は ECS タスク単位でスケール・入れ替えする運用のため、control socket（worker の動的増減・graceful reload・stats 取得）の用途がなく、無効化によるデメリットはありません。

フラグは gunicorn 26.0.0 で実在することを確認済み（`--no-control-socket   Disable control socket. [False]`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)