### PR TITLE
fix: links.url インデックスの hash 化とリンクURLの書き込み境界バリデーション

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -6,6 +6,7 @@ from pydantic import AnyUrl, HttpUrl
 from sqlalchemy import (
     BigInteger,
     ForeignKey,
+    Index,
     and_,
     case,
     create_engine,
@@ -152,9 +153,12 @@ class XUserRecord(Base):
 
 class LinkRecord(Base):
     __tablename__ = "links"
+    # btree は行サイズ上限（約2704バイト）があり長いURLを格納できないため hash を使う。
+    # 検索は完全一致（search_url）のみなので hash で十分。
+    __table_args__ = (Index("ix_links_url", "url", postgresql_using="hash"),)
 
     link_id: Mapped[LinkId] = mapped_column(primary_key=True)
-    url: Mapped[LongHttpUrl] = mapped_column(nullable=False, index=True)
+    url: Mapped[LongHttpUrl] = mapped_column(nullable=False)
 
 
 class PostLinkAssociation(Base):

--- a/common/tests/test_storage.py
+++ b/common/tests/test_storage.py
@@ -14,7 +14,13 @@ from birdxplorer_common.models import (
     TopicId,
     TwitterTimestamp,
 )
-from birdxplorer_common.storage import NoteRecord, PostRecord, Storage, TopicRecord
+from birdxplorer_common.storage import (
+    Base,
+    NoteRecord,
+    PostRecord,
+    Storage,
+    TopicRecord,
+)
 
 
 def test_get_topic_list(
@@ -232,3 +238,13 @@ def test_get_notes_by_language(
     expected = [note for note in note_samples if note.language == language]
     actual = list(storage.get_notes(language=language))
     assert expected == actual
+
+
+def test_links_url_index_uses_hash() -> None:
+    """links.url のインデックスは hash を使う
+
+    btree には行サイズ上限（約2704バイト）があり、長いURLのINSERTが
+    ProgramLimitExceeded で失敗するため。検索は完全一致のみなので hash で十分。
+    """
+    index = next(idx for idx in Base.metadata.tables["links"].indexes if idx.name == "ix_links_url")
+    assert index.dialect_options["postgresql"]["using"] == "hash"

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -67,7 +67,7 @@ def _send_sqs_batch(queue_url: str, messages: list, max_retries: int = 3):
                 break
             except RuntimeError:
                 raise
-            except Exception as e:
+            except Exception:
                 if attempt < max_retries - 1:
                     time.sleep((attempt + 1) * 1.0)
                 else:
@@ -160,7 +160,10 @@ def extract_data(postgresql: Session):
 
         while True:
             if settings.USE_DUMMY_DATA:
-                note_url = "https://raw.githubusercontent.com/codeforjapan/BirdXplorer/refs/heads/main/etl/data/notes_sample.tsv"
+                note_url = (
+                    "https://raw.githubusercontent.com/codeforjapan/BirdXplorer"
+                    "/refs/heads/main/etl/data/notes_sample.tsv"
+                )
             else:
                 note_url = f"https://ton.twimg.com/birdwatch-public-data/{dateString}/notes/notes-{file_index:05d}.zip"
 
@@ -650,7 +653,10 @@ def extract_ratings(postgresql: Session, dateString: str, existing_row_note_ids:
         file_index = 0
         while True:
             if settings.USE_DUMMY_DATA:
-                ratings_url = "https://raw.githubusercontent.com/codeforjapan/BirdXplorer/refs/heads/main/etl/data/notesRating_sample.tsv"
+                ratings_url = (
+                    "https://raw.githubusercontent.com/codeforjapan/BirdXplorer"
+                    "/refs/heads/main/etl/data/notesRating_sample.tsv"
+                )
             else:
                 ratings_url = (
                     f"https://ton.twimg.com/birdwatch-public-data/{dateString}/noteRatings/ratings-{file_index:05d}.zip"

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
@@ -6,9 +6,11 @@ from random import Random
 from typing import Any, Optional
 from uuid import UUID
 
+from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
+from birdxplorer_common.models import LongHttpUrl
 from birdxplorer_common.storage import (
     LinkRecord,
     MediaRecord,
@@ -38,6 +40,27 @@ def generate_link_id(url: str) -> UUID:
     random_number_generator = Random()
     random_number_generator.seed(url.encode("utf-8"))
     return UUID(int=random_number_generator.getrandbits(128))
+
+
+_link_url_adapter: TypeAdapter[LongHttpUrl] = TypeAdapter(LongHttpUrl)
+
+
+def select_valid_link_url(row_url: RowPostEmbedURLRecord) -> Optional[str]:
+    """unwound_url → expanded_url → url の順で、LongHttpUrlとして有効な最初のURLを返す
+
+    links.url はAPI読み出し時に LongHttpUrl（最大8192文字・http/httpsのみ）として
+    検証されるため、書き込み境界で無効なURLを弾いて読み出し時のValidationErrorを防ぐ。
+    全候補が無効な場合はNoneを返す（リンクをスキップ）。
+    """
+    for candidate in (row_url.unwound_url, row_url.expanded_url, row_url.url):
+        if not candidate:
+            continue
+        try:
+            _link_url_adapter.validate_python(candidate)
+        except ValidationError:
+            continue
+        return str(candidate)
+    return None
 
 
 def process_post_transform(
@@ -171,21 +194,24 @@ def process_post_transform(
         link_entries = []
         link_assoc_entries = []
         for row_url in row_urls:
-            # unwound_urlを使用（最終的なリダイレクト先URL）
-            final_url = row_url.unwound_url or row_url.expanded_url or row_url.url
+            final_url = select_valid_link_url(row_url)
+            if final_url is None:
+                logger.warning(f"[SKIPPED] No valid link URL for post {post_id}: url={str(row_url.url)[:100]!r}")
+                continue
             link_id = generate_link_id(final_url)
             link_entries.append({"link_id": link_id, "url": final_url})
             link_assoc_entries.append({"post_id": post_id, "link_id": link_id})
 
-        stmt = insert(LinkRecord).values(link_entries).on_conflict_do_nothing(index_elements=["link_id"])
-        postgresql.execute(stmt)
-        stmt = (
-            insert(PostLinkAssociation)
-            .values(link_assoc_entries)
-            .on_conflict_do_nothing(index_elements=["post_id", "link_id"])
-        )
-        postgresql.execute(stmt)
-        logger.info(f"[STAGED] {len(row_urls)} link records for post {post_id}")
+        if link_entries:
+            stmt = insert(LinkRecord).values(link_entries).on_conflict_do_nothing(index_elements=["link_id"])
+            postgresql.execute(stmt)
+            stmt = (
+                insert(PostLinkAssociation)
+                .values(link_assoc_entries)
+                .on_conflict_do_nothing(index_elements=["post_id", "link_id"])
+            )
+            postgresql.execute(stmt)
+            logger.info(f"[STAGED] {len(link_entries)} link records for post {post_id}")
 
     return {"status": "success"}
 

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/topic_detect_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/topic_detect_lambda.py
@@ -85,7 +85,7 @@ def lambda_handler(event, context):
                     logger.info(f"[TOPICS] Set {len(topics)} topics to AI service")
 
                 # トピック推定を実行（リトライ付き）
-                logger.info(f"[PROCESSING] Calling AI service for topic detection...")
+                logger.info("[PROCESSING] Calling AI service for topic detection...")
                 topics_info = call_ai_api_with_retry(
                     ai_service.detect_topic,
                     note_id,
@@ -108,7 +108,7 @@ def lambda_handler(event, context):
                         "data": {"topic_ids": topic_ids},
                     }
 
-                    logger.info(f"[SQS_SEND] Sending topics update to db-write queue...")
+                    logger.info("[SQS_SEND] Sending topics update to db-write queue...")
                     message_id = sqs_handler.send_message(queue_url=db_write_queue_url, message_body=db_write_message)
 
                     if message_id:
@@ -127,7 +127,7 @@ def lambda_handler(event, context):
                         "processing_type": "tweet_lookup",
                         "skip_tweet_lookup": skip_tweet_lookup,
                     }
-                    logger.info(f"[SQS_SEND] Sending tweet lookup message...")
+                    logger.info("[SQS_SEND] Sending tweet lookup message...")
                     message_id = sqs_handler.send_message(
                         queue_url=TWEET_LOOKUP_QUEUE_URL, message_body=tweet_lookup_message
                     )
@@ -145,7 +145,7 @@ def lambda_handler(event, context):
             elif not post_id:
                 logger.warning(f"[WARNING] Note {note_id} has no post_id, skipping tweet lookup")
             elif not TWEET_LOOKUP_QUEUE_URL:
-                logger.warning(f"[CONFIG_WARNING] TWEET_LOOKUP_QUEUE_URL is not configured, skipping SQS message")
+                logger.warning("[CONFIG_WARNING] TWEET_LOOKUP_QUEUE_URL is not configured, skipping SQS message")
 
             result = {
                 "statusCode": 200,

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -1,7 +1,6 @@
-import io
 import logging
 import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -108,7 +107,6 @@ class TestCreateStagingTable:
         mock_session = MagicMock()
         _create_staging_table(mock_session)
 
-        calls = [str(c) for c in mock_session.execute.call_args_list]
         # DROP IF EXISTS が2回、CREATE UNLOGGED が1回
         assert len(mock_session.execute.call_args_list) == 3
         mock_session.commit.assert_called_once()

--- a/etl/tests/test_post_transform_lambda.py
+++ b/etl/tests/test_post_transform_lambda.py
@@ -1,7 +1,10 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from birdxplorer_etl.lib.lambda_handler.post_transform_lambda import lambda_handler, process_post_transform
+from birdxplorer_etl.lib.lambda_handler.post_transform_lambda import (
+    lambda_handler,
+    select_valid_link_url,
+)
 
 
 def _make_row_post(post_id: str = "post_001", author_id: str = "author_001") -> MagicMock:
@@ -129,9 +132,7 @@ class TestUrlBulkInsert:
 
         row_post = _make_row_post()
         row_user = _make_row_user()
-        url_list = [
-            _make_row_url(f"https://t.co/{i}", unwound_url=f"https://example.com/page/{i}") for i in range(3)
-        ]
+        url_list = [_make_row_url(f"https://t.co/{i}", unwound_url=f"https://example.com/page/{i}") for i in range(3)]
 
         mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
         mock_scalars = MagicMock()
@@ -158,9 +159,7 @@ class TestMediaAndUrlBulkInsert:
         row_post = _make_row_post()
         row_user = _make_row_user()
         media_list = [_make_row_media(f"media_{i}") for i in range(3)]
-        url_list = [
-            _make_row_url(f"https://t.co/{i}", unwound_url=f"https://example.com/page/{i}") for i in range(2)
-        ]
+        url_list = [_make_row_url(f"https://t.co/{i}", unwound_url=f"https://example.com/page/{i}") for i in range(2)]
 
         mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
         mock_scalars = MagicMock()
@@ -199,3 +198,96 @@ class TestMediaKeySuffixRemoval:
         result = lambda_handler(_make_sqs_event(post_id=post_id), {})
 
         assert result["batchItemFailures"] == []
+
+
+class TestSelectValidLinkUrl:
+    """リンクURLの検証とフォールバックを検証
+
+    links.url は API 読み出し時に LongHttpUrl（最大8192文字・http/https のみ）として
+    検証されるため、書き込み境界で valid な URL のみを選択する。
+    """
+
+    def test_valid_unwound_url_selected(self) -> None:
+        """unwound_urlが有効ならそのまま採用される"""
+        row_url = _make_row_url(
+            "https://t.co/abc",
+            expanded_url="https://example.com/expanded",
+            unwound_url="https://example.com/unwound",
+        )
+        assert select_valid_link_url(row_url) == "https://example.com/unwound"
+
+    def test_too_long_unwound_falls_back_to_expanded(self) -> None:
+        """unwound_urlが8192文字を超える場合、expanded_urlにフォールバックする"""
+        long_url = "https://example.com/?q=" + "a" * 8200
+        row_url = _make_row_url(
+            "https://t.co/abc",
+            expanded_url="https://example.com/expanded",
+            unwound_url=long_url,
+        )
+        assert select_valid_link_url(row_url) == "https://example.com/expanded"
+
+    def test_falls_back_to_short_url_when_others_too_long(self) -> None:
+        """unwound_urlとexpanded_urlが両方長すぎる場合、t.co短縮URLにフォールバックする"""
+        long_url = "https://example.com/?q=" + "a" * 8200
+        row_url = _make_row_url("https://t.co/abc", expanded_url=long_url, unwound_url=long_url)
+        assert select_valid_link_url(row_url) == "https://t.co/abc"
+
+    def test_non_http_scheme_rejected(self) -> None:
+        """http/https以外のスキームは拒否されフォールバックする"""
+        row_url = _make_row_url("https://t.co/abc", unwound_url="ftp://example.com/file")
+        assert select_valid_link_url(row_url) == "https://t.co/abc"
+
+    def test_returns_none_when_all_invalid(self) -> None:
+        """全候補が無効な場合はNoneを返す"""
+        row_url = _make_row_url("not-a-url")
+        assert select_valid_link_url(row_url) is None
+
+
+class TestInvalidUrlSkipped:
+    """無効なURLしか持たないリンクはスキップされ、投稿変換自体は成功することを検証"""
+
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.init_postgresql")
+    def test_all_invalid_urls_skip_link_insert(self, mock_init_pg: MagicMock) -> None:
+        """全URLが無効な場合、リンクのINSERTは行われず、メッセージは成功扱いになる"""
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        row_post = _make_row_post()
+        row_user = _make_row_user()
+        url_list = [_make_row_url("not-a-url")]
+
+        mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
+        mock_scalars = MagicMock()
+        mock_scalars.all.side_effect = [[], url_list]  # no media, 1 invalid url
+        mock_session.execute.return_value.scalars.return_value = mock_scalars
+
+        result = lambda_handler(_make_sqs_event(), {})
+
+        assert result["batchItemFailures"] == []
+        # Executes: row_post select, row_user select, x_user insert, post insert,
+        #           media select, url select = 6 calls (link insert はスキップ)
+        assert mock_session.execute.call_count == 6
+
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.init_postgresql")
+    def test_mixed_urls_insert_only_valid(self, mock_init_pg: MagicMock) -> None:
+        """有効・無効URLが混在する場合、有効なもののみINSERTされる"""
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        row_post = _make_row_post()
+        row_user = _make_row_user()
+        url_list = [
+            _make_row_url("https://t.co/ok", unwound_url="https://example.com/valid"),
+            _make_row_url("not-a-url"),
+        ]
+
+        mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
+        mock_scalars = MagicMock()
+        mock_scalars.all.side_effect = [[], url_list]
+        mock_session.execute.return_value.scalars.return_value = mock_scalars
+
+        result = lambda_handler(_make_sqs_event(), {})
+
+        assert result["batchItemFailures"] == []
+        # 有効URLが1件あるので link insert + link assoc insert は実行される = 8 calls
+        assert mock_session.execute.call_count == 8

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from birdxplorer_etl.lib.lambda_handler.postlookup_lambda import (
-    MAX_MESSAGES_PER_INVOCATION,
-    TIMEOUT_BUFFER_MS,
     _poll_message,
     _process_single_tweet,
     connect_to_endpoint,

--- a/etl/tests/test_report_github.py
+++ b/etl/tests/test_report_github.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from birdxplorer_etl.scripts.report_github import create_report_pr
 
@@ -44,11 +44,14 @@ class TestCreateReportPr:
         pr_resp.raise_for_status = MagicMock()
 
         mock_post.side_effect = [
-            blob_resp, blob_resp, blob_resp, blob_resp,  # 4 blobs
-            tree_resp,      # tree
+            blob_resp,
+            blob_resp,
+            blob_resp,
+            blob_resp,  # 4 blobs
+            tree_resp,  # tree
             new_commit_resp,  # commit
-            branch_resp,    # ref
-            pr_resp,        # PR
+            branch_resp,  # ref
+            pr_resp,  # PR
         ]
 
         static_files = {
@@ -130,8 +133,13 @@ class TestCreateReportPr:
         pr_resp.raise_for_status = MagicMock()
 
         mock_post.side_effect = [
-            blob_resp, blob_resp, blob_resp,  # 3 blobs (1 static + 2 config)
-            tree_resp, new_commit_resp, branch_resp, pr_resp,
+            blob_resp,
+            blob_resp,
+            blob_resp,  # 3 blobs (1 static + 2 config)
+            tree_resp,
+            new_commit_resp,
+            branch_resp,
+            pr_resp,
         ]
 
         url = create_report_pr(

--- a/migrate/migration/versions/change_links_url_index_to_hash.py
+++ b/migrate/migration/versions/change_links_url_index_to_hash.py
@@ -1,0 +1,36 @@
+"""change links url index to hash
+
+Revision ID: change_links_url_index_to_hash
+Revises: add_row_note_requests_table
+Create Date: 2026-07-06
+
+links.url の btree インデックスには行サイズ上限（btree v4 で約2704バイト）があり、
+それを超える長い URL の INSERT が ProgramLimitExceeded で失敗する。
+url の検索は完全一致（posts の search_url フィルタ）のみのため、
+行サイズ制限のない hash インデックスに置き換える。
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "change_links_url_index_to_hash"
+down_revision: Union[str, None] = "add_row_note_requests_table"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """ix_links_url を btree から hash に置き換える。"""
+    op.drop_index("ix_links_url", table_name="links")
+    op.create_index("ix_links_url", "links", ["url"], unique=False, postgresql_using="hash")
+
+
+def downgrade() -> None:
+    """ix_links_url を btree に戻す。
+
+    注意: 約2704バイトを超える URL が既に格納されている場合、
+    btree の再作成は失敗する。
+    """
+    op.drop_index("ix_links_url", table_name="links")
+    op.create_index("ix_links_url", "links", ["url"], unique=False)


### PR DESCRIPTION
## 概要

post-transform DLQ に溜まっていた処理失敗の解消。長い URL を含む投稿の変換が `links` テーブルへの INSERT で失敗し、同一バッチの正常なメッセージも巻き添えで DLQ 落ちしていた。

## 根本原因

\`\`\`
psycopg2.errors.ProgramLimitExceeded: index row size 2904 exceeds
btree version 4 maximum 2704 for index "ix_links_url"
\`\`\`

- btree インデックスには行サイズ約 2704 バイトの上限があり、それを超える URL（スパムのキーワード詰め URL 等、圧縮の効かない長い文字列）の INSERT が失敗する
- #252 で Pydantic 側の上限を 8192 文字に緩和したが、DB インデックスの物理制約は残っていた（2704 バイト〜8192 文字のギャップ）

## 修正内容

### 1. `ix_links_url` を btree → hash に変更（migrate + common）

- hash インデックスは値でなく 4 バイトのハッシュを格納するため行サイズ上限がない
- `links.url` の検索は完全一致（posts の `search_url` フィルタ）のみのため hash で十分
- 既存クエリの変更は不要

### 2. リンク URL の書き込み境界バリデーション（etl）

- `links.url` は API 読み出し時に `LongHttpUrl`（最大 8192 文字・http/https のみ）として検証されるため、無効な URL が DB に入ると読み出しが 500 になる（#242 と同じ構図）
- インデックス変更で「門番」がなくなるため、`unwound_url → expanded_url → url` の順に `LongHttpUrl` で検証して最初に通ったものを採用するフォールバックを追加
- 全候補が無効な場合はリンクのみスキップし、投稿変換は継続

### 3. 既存 lint エラーの修正（etl）

- main で pflake8 が失敗していた既存の未使用 import 等 12 件を修正（tox 通過に必要）

## 検証

- tox: common / etl / migrate すべて通過
- PostgreSQL 15.4 コンテナでの E2E:
  - btree 状態で本番と同一エラーを再現（非圧縮性 3200 文字 URL の INSERT が `ProgramLimitExceeded`）
  - マイグレーション適用後、同じ INSERT が成功
  - 完全一致検索が `Index Scan using ix_links_url` を使用することを EXPLAIN で確認

## デプロイ後の作業

dev デプロイ（マイグレーション自動実行）後、`dev-bird-xplorer-post-transform-dlq` の 5 件を redrive する（毒メッセージ含め全件成功する見込み）。