### PR TITLE
fix: switch vector index to disk-based search mode (notes-v2)

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -20,7 +20,9 @@ from birdxplorer_etl import settings
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-INDEX_NAME = "notes-v1"
+# v2: ディスクベースベクトル検索(mode: on_disk)に変更。
+# notesテーブルは約293万件あり、in-memoryのHNSW(約19GB)はm6g.largeに収まらないため。
+INDEX_NAME = "notes-v2"
 ALIAS_NAME = "notes"
 
 # spec: 2026-07-08-opensearch-phase2-etl-design.md §7
@@ -59,7 +61,12 @@ INDEX_BODY = {
             "embedding": {
                 "type": "knn_vector",
                 "dimension": 1536,
-                "method": {"name": "hnsw", "engine": "faiss", "space_type": "cosinesimil"},
+                # on_disk: faiss/HNSW + 32x圧縮(バイナリ量子化)+ リスコアがデフォルト。
+                # メモリ必要量が約1/32になり、全ノートを現行ドメインに収められる。
+                # BQはcosine非対応だがOpenAI embeddingは単位ベクトルのためinnerproduct=cosineと同順位。
+                "space_type": "innerproduct",
+                "data_type": "float",
+                "mode": "on_disk",
             },
         }
     },
@@ -88,7 +95,11 @@ def _get_client() -> OpenSearch:
 
 
 def _ensure_index(client: OpenSearch) -> None:
-    """notes-v1インデックスとnotesエイリアスがなければ作成する(冪等)"""
+    """インデックスとnotesエイリアスがなければ作成する(冪等)
+
+    エイリアスが旧バージョンのインデックスを向いている場合は付け替える
+    (マッピング変更時のゼロダウン移行。旧インデックスは削除せず残す)。
+    """
     global _index_ensured
     if _index_ensured:
         return
@@ -99,6 +110,16 @@ def _ensure_index(client: OpenSearch) -> None:
     if not client.indices.exists_alias(name=ALIAS_NAME):
         client.indices.put_alias(index=INDEX_NAME, name=ALIAS_NAME)
         logger.info(f"Created alias {ALIAS_NAME} -> {INDEX_NAME}")
+    elif not client.indices.exists_alias(index=INDEX_NAME, name=ALIAS_NAME):
+        client.indices.update_aliases(
+            body={
+                "actions": [
+                    {"remove": {"index": "*", "alias": ALIAS_NAME}},
+                    {"add": {"index": INDEX_NAME, "alias": ALIAS_NAME}},
+                ]
+            }
+        )
+        logger.info(f"Moved alias {ALIAS_NAME} -> {INDEX_NAME}")
 
     _index_ensured = True
 

--- a/etl/tests/test_search_index_writer_lambda.py
+++ b/etl/tests/test_search_index_writer_lambda.py
@@ -43,12 +43,17 @@ class TestEnsureIndex:
 
         client.indices.create.assert_called_once()
         create_kwargs = client.indices.create.call_args.kwargs
-        assert create_kwargs["index"] == "notes-v1"
+        assert create_kwargs["index"] == "notes-v2"
         mappings = create_kwargs["body"]["mappings"]["properties"]
         assert mappings["embedding"]["type"] == "knn_vector"
         assert mappings["embedding"]["dimension"] == 1536
+        # ディスクベースベクトル検索(約293万ノートをm6g.largeのメモリに収めるため)
+        assert mappings["embedding"]["mode"] == "on_disk"
+        # BQはcosine非対応。OpenAI embeddingは単位ベクトルなのでinnerproduct=cosine同順位
+        assert mappings["embedding"]["space_type"] == "innerproduct"
+        assert "method" not in mappings["embedding"]
         assert mappings["text"]["fields"]["ja"]["analyzer"] == "ja_analyzer"
-        client.indices.put_alias.assert_called_once_with(index="notes-v1", name="notes")
+        client.indices.put_alias.assert_called_once_with(index="notes-v2", name="notes")
 
     def test_skips_when_index_exists(self) -> None:
         client = MagicMock()
@@ -59,6 +64,27 @@ class TestEnsureIndex:
 
         client.indices.create.assert_not_called()
         client.indices.put_alias.assert_not_called()
+        client.indices.update_aliases.assert_not_called()
+
+    def test_moves_alias_from_old_index(self) -> None:
+        """エイリアスが旧インデックス(notes-v1)を向いている場合は notes-v2 に付け替える"""
+        client = MagicMock()
+        client.indices.exists.return_value = True
+
+        def _exists_alias(**kwargs: object) -> bool:
+            # name のみ指定(エイリアス自体の存在確認)は True、
+            # index 付き指定(notes-v2 を向いているかの確認)は False を返す
+            return "index" not in kwargs
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        writer._ensure_index(client)
+
+        client.indices.put_alias.assert_not_called()
+        client.indices.update_aliases.assert_called_once()
+        actions = client.indices.update_aliases.call_args.kwargs["body"]["actions"]
+        assert {"remove": {"index": "*", "alias": "notes"}} in actions
+        assert {"add": {"index": "notes-v2", "alias": "notes"}} in actions
 
     def test_second_call_is_cached(self) -> None:
         client = MagicMock()


### PR DESCRIPTION
## 概要

notes テーブルの実件数が **2,928,373 件**(設計想定「数十万」の約10倍)と判明し、in-memory HNSW(1536次元 ×293万 ≈ 19GB)が現行ドメイン m6g.large の k-NN メモリ(約2〜4GB)に収まらないため、**ディスクベースベクトル検索**に切り替える。

- インデックスを `notes-v2` として再作成: `mode: "on_disk"`(faiss/HNSW/32x バイナリ量子化 + リスコア)→ メモリ必要量 約0.6GB、EBS 使用 25〜30GB(100GB 内)
- `space_type` を `cosinesimil` → `innerproduct` に変更(BQ は cosine 非対応。OpenAI embedding は単位ベクトルのため innerproduct = cosine と同順位。**検索クエリ実装時もこの前提を維持すること**)
- `_ensure_index` を強化: エイリアス `notes` が旧インデックス(notes-v1)を向いている場合、自動で notes-v2 に付け替える(ゼロダウン移行)。notes-v1 は削除せず残置(別途クリーンアップ可)
- 代償: 検索レイテンシ増(リスコアでディスク読み込み)。セマンティック検索/RAG 用途では許容

## 経緯

初回バックフィルは195.6万件投入時点で停止し滞留分は purge 済み。本 PR のデプロイ後に全量(293万件)を再実行する。BirdXplorer-cdk#24(Lambda 同時実行 1→5)とセットで、本 PR の CI デプロイで両方反映される。

## 検証

- 10 テスト + tox 全パス(マッピングの mode/space_type、エイリアス付け替えの3分岐を含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)