### PR TITLE
feat: add semantic and similar note search endpoints

### DIFF
--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -19,7 +19,6 @@ from .routers.data import gen_router as gen_data_router
 from .routers.graphs import gen_router as gen_graphs_router
 from .routers.system import gen_router as gen_system_router
 from .semantic_search import (
-    SemanticSearchSettings,
     SemanticSearchUnavailableError,
     gen_semantic_search_service,
 )
@@ -52,7 +51,7 @@ class QueryStringFlatteningMiddleware:
 def gen_app(settings: GlobalSettings) -> FastAPI:
     _ = get_logger(level=settings.logger_settings.level)
     storage = gen_storage(settings=settings)
-    semantic_search = gen_semantic_search_service(SemanticSearchSettings())
+    semantic_search = gen_semantic_search_service()
     app = FastAPI()
     app.add_middleware(CORSMiddleware, **settings.cors_settings.model_dump())
     app.add_middleware(QueryStringFlatteningMiddleware)

--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -1,10 +1,12 @@
 import csv
 import io
+from logging import getLogger
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode as encode_query_string
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic.alias_generators import to_snake
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -16,7 +18,13 @@ from .middlewares import TimingMiddleware
 from .routers.data import gen_router as gen_data_router
 from .routers.graphs import gen_router as gen_graphs_router
 from .routers.system import gen_router as gen_system_router
-from .semantic_search import SemanticSearchSettings, gen_semantic_search_service
+from .semantic_search import (
+    SemanticSearchSettings,
+    SemanticSearchUnavailableError,
+    gen_semantic_search_service,
+)
+
+logger = getLogger(__name__)
 
 
 class QueryStringFlatteningMiddleware:
@@ -49,6 +57,13 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
     app.add_middleware(CORSMiddleware, **settings.cors_settings.model_dump())
     app.add_middleware(QueryStringFlatteningMiddleware)
     app.add_middleware(TimingMiddleware)
+
+    @app.exception_handler(SemanticSearchUnavailableError)
+    def handle_semantic_search_unavailable(request: Request, exc: SemanticSearchUnavailableError) -> JSONResponse:
+        """SemanticSearchUnavailableError を 503 に変換するアプリレベルハンドラ"""
+        logger.error(f"semantic search unavailable: {exc}")
+        return JSONResponse(status_code=503, content={"detail": "semantic search is temporarily unavailable"})
+
     app.include_router(gen_system_router(), prefix="/api/v1/system")
     app.include_router(
         gen_data_router(storage=storage, export_api_key=settings.export_api_key, semantic_search=semantic_search),

--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -16,6 +16,7 @@ from .middlewares import TimingMiddleware
 from .routers.data import gen_router as gen_data_router
 from .routers.graphs import gen_router as gen_graphs_router
 from .routers.system import gen_router as gen_system_router
+from .semantic_search import SemanticSearchSettings, gen_semantic_search_service
 
 
 class QueryStringFlatteningMiddleware:
@@ -43,11 +44,15 @@ class QueryStringFlatteningMiddleware:
 def gen_app(settings: GlobalSettings) -> FastAPI:
     _ = get_logger(level=settings.logger_settings.level)
     storage = gen_storage(settings=settings)
+    semantic_search = gen_semantic_search_service(SemanticSearchSettings())
     app = FastAPI()
     app.add_middleware(CORSMiddleware, **settings.cors_settings.model_dump())
     app.add_middleware(QueryStringFlatteningMiddleware)
     app.add_middleware(TimingMiddleware)
     app.include_router(gen_system_router(), prefix="/api/v1/system")
-    app.include_router(gen_data_router(storage=storage, export_api_key=settings.export_api_key), prefix="/api/v1/data")
+    app.include_router(
+        gen_data_router(storage=storage, export_api_key=settings.export_api_key, semantic_search=semantic_search),
+        prefix="/api/v1/data",
+    )
     app.include_router(gen_graphs_router(storage=storage), prefix="/api/v1/graphs")
     return app

--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -682,6 +682,33 @@ V1DataSearchDocs = FastAPIEndpointDocs(
     },
 )
 
+v1_data_search_semantic_q: FastAPIEndpointParamDocs = {"description": "検索クエリ(自然文)"}
+
+v1_data_search_semantic_language: FastAPIEndpointParamDocs = {"description": "ノートの言語で絞り込み"}
+
+v1_data_search_semantic_limit: FastAPIEndpointParamDocs = {"description": "取得件数(最大100)"}
+
+v1_data_search_similar_note_id: FastAPIEndpointParamDocs = {"description": "起点となるノートのID"}
+
+# Get /api/v1/data/search/semantic の OpenAPI ドキュメント
+V1DataSearchSemanticDocs = FastAPIEndpointDocs(
+    "自然文クエリによるセマンティック検索。クエリをベクトル化し、意味的に近いノートを返します。",
+    {
+        "q": v1_data_search_semantic_q,
+        "language": v1_data_search_semantic_language,
+        "limit": v1_data_search_semantic_limit,
+    },
+)
+
+# Get /api/v1/data/search/similar/{note_id} の OpenAPI ドキュメント
+V1DataSearchSimilarDocs = FastAPIEndpointDocs(
+    "指定したノートに意味的に近いノートを返します(自分自身は除外)。",
+    {
+        "note_id": v1_data_search_similar_note_id,
+        "limit": v1_data_search_semantic_limit,
+    },
+)
+
 # Get /api/v1/data/search/count の OpenAPI ドキュメント
 V1DataSearchCountDocs = FastAPIEndpointDocs(
     "検索結果の総件数を取得するエンドポイント",

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -1,7 +1,6 @@
 import csv
 from datetime import datetime, timezone
 from io import StringIO
-from logging import getLogger
 from typing import Any, Dict, Generator, List, Optional, Tuple, TypeAlias, Union
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode
@@ -26,10 +25,7 @@ from birdxplorer_api.openapi_doc import (
     V1DataTopicsDocs,
     V1DataUserEnrollmentsDocs,
 )
-from birdxplorer_api.semantic_search import (
-    SemanticSearchService,
-    SemanticSearchUnavailableError,
-)
+from birdxplorer_api.semantic_search import SemanticSearchService
 from birdxplorer_common.models import (
     BaseModel,
     LanguageCode,
@@ -52,8 +48,6 @@ from birdxplorer_common.models import (
     UserId,
 )
 from birdxplorer_common.storage import CsvExportRow, Storage
-
-logger = getLogger(__name__)
 
 _CSV_EXPORT_JST = ZoneInfo("Asia/Tokyo")
 _CSV_EXPORT_THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
@@ -432,6 +426,12 @@ def gen_router(
     semantic_search: Optional[SemanticSearchService] = None,
 ) -> APIRouter:
     router = APIRouter()
+
+    def _require_semantic_search() -> SemanticSearchService:
+        """セマンティック検索が未設定の場合は503を送出するガードヘルパー"""
+        if semantic_search is None:
+            raise HTTPException(status_code=503, detail="semantic search is not configured")
+        return semantic_search
 
     @router.get(
         "/user-enrollments/{participant_id}",
@@ -985,14 +985,9 @@ def gen_router(
         language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchSemanticDocs.params["language"]),
         limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSemanticDocs.params["limit"]),
     ) -> SemanticSearchResponse:
-        if semantic_search is None:
-            raise HTTPException(status_code=503, detail="semantic search is not configured")
-        try:
-            vector = semantic_search.embed_query(q)
-            hits = semantic_search.knn_search(vector, limit=limit, language=language)
-        except SemanticSearchUnavailableError as e:
-            logger.error(f"semantic search unavailable: {e}")
-            raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
+        service = _require_semantic_search()
+        vector = service.embed_query(q)
+        hits = service.knn_search(vector, limit=limit, language=language)
         return _build_semantic_response(hits)
 
     @router.get(
@@ -1004,16 +999,11 @@ def gen_router(
         note_id: NoteId = Path(**V1DataSearchSimilarDocs.params["note_id"]),
         limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSimilarDocs.params["limit"]),
     ) -> SemanticSearchResponse:
-        if semantic_search is None:
-            raise HTTPException(status_code=503, detail="semantic search is not configured")
-        try:
-            vector = semantic_search.get_note_embedding(note_id)
-            if vector is None:
-                raise HTTPException(status_code=404, detail=f"note {note_id} is not indexed")
-            hits = semantic_search.knn_search(vector, limit=limit, exclude_note_id=note_id)
-        except SemanticSearchUnavailableError as e:
-            logger.error(f"semantic search unavailable: {e}")
-            raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
+        service = _require_semantic_search()
+        vector = service.get_note_embedding(note_id)
+        if vector is None:
+            raise HTTPException(status_code=404, detail=f"note {note_id} is not indexed")
+        hits = service.knn_search(vector, limit=limit, exclude_note_id=note_id)
         return _build_semantic_response(hits)
 
     return router

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -1,7 +1,7 @@
 import csv
 from datetime import datetime, timezone
 from io import StringIO
-from typing import Any, Dict, Generator, List, Optional, TypeAlias, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, TypeAlias, Union
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode
 from zoneinfo import ZoneInfo
@@ -20,8 +20,14 @@ from birdxplorer_api.openapi_doc import (
     V1DataPostsDocs,
     V1DataSearchCountDocs,
     V1DataSearchDocs,
+    V1DataSearchSemanticDocs,
+    V1DataSearchSimilarDocs,
     V1DataTopicsDocs,
     V1DataUserEnrollmentsDocs,
+)
+from birdxplorer_api.semantic_search import (
+    SemanticSearchService,
+    SemanticSearchUnavailableError,
 )
 from birdxplorer_common.models import (
     BaseModel,
@@ -381,6 +387,15 @@ class SearchCountResponse(BaseModel):
     total: Annotated[int, PydanticField(description="検索結果の総件数")]
 
 
+class SemanticSearchResult(BaseModel):
+    note: Note
+    score: float
+
+
+class SemanticSearchResponse(BaseModel):
+    data: List[SemanticSearchResult]
+
+
 class NoteRequestListResponse(BaseModel):
     data: Annotated[List[NoteRequest], PydanticField(description="ノートリクエストのリスト")]
     meta: PaginationMeta
@@ -408,7 +423,11 @@ def ensure_twitter_timestamp(t: Union[str, TwitterTimestamp]) -> TwitterTimestam
         raise OverflowError("Timestamp out of range")
 
 
-def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRouter:
+def gen_router(
+    storage: Storage,
+    export_api_key: Optional[str] = None,
+    semantic_search: Optional[SemanticSearchService] = None,
+) -> APIRouter:
     router = APIRouter()
 
     @router.get(
@@ -937,5 +956,59 @@ def gen_router(storage: Storage, export_api_key: Optional[str] = None) -> APIRou
                 "Cache-Control": "no-store",
             },
         )
+
+    def _build_semantic_response(hits: List[Tuple[NoteId, float]]) -> SemanticSearchResponse:
+        """note_id+scoreの一覧をPGからハイドレートしてスコア順のレスポンスを作る"""
+        note_ids = [note_id for note_id, _ in hits]
+        if not note_ids:
+            return SemanticSearchResponse(data=[])
+        notes_by_id = {note.note_id: note for note in storage.get_notes(note_ids=note_ids, limit=len(note_ids))}
+        # PGに存在しないnote_id(埋め込み先行の整合ズレ)は除外し、スコア順を維持する
+        return SemanticSearchResponse(
+            data=[
+                SemanticSearchResult(note=notes_by_id[note_id], score=score)
+                for note_id, score in hits
+                if note_id in notes_by_id
+            ]
+        )
+
+    @router.get(
+        "/search/semantic",
+        description=V1DataSearchSemanticDocs.description,
+        response_model=SemanticSearchResponse,
+    )
+    def search_semantic(
+        q: str = Query(min_length=1, max_length=1000, **V1DataSearchSemanticDocs.params["q"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchSemanticDocs.params["language"]),
+        limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSemanticDocs.params["limit"]),
+    ) -> SemanticSearchResponse:
+        if semantic_search is None:
+            raise HTTPException(status_code=503, detail="semantic search is not configured")
+        try:
+            vector = semantic_search.embed_query(q)
+            hits = semantic_search.knn_search(vector, limit=limit, language=language)
+        except SemanticSearchUnavailableError:
+            raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
+        return _build_semantic_response(hits)
+
+    @router.get(
+        "/search/similar/{note_id}",
+        description=V1DataSearchSimilarDocs.description,
+        response_model=SemanticSearchResponse,
+    )
+    def search_similar(
+        note_id: NoteId = Path(**V1DataSearchSimilarDocs.params["note_id"]),
+        limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSimilarDocs.params["limit"]),
+    ) -> SemanticSearchResponse:
+        if semantic_search is None:
+            raise HTTPException(status_code=503, detail="semantic search is not configured")
+        try:
+            vector = semantic_search.get_note_embedding(note_id)
+            if vector is None:
+                raise HTTPException(status_code=404, detail=f"note {note_id} is not indexed")
+            hits = semantic_search.knn_search(vector, limit=limit, exclude_note_id=note_id)
+        except SemanticSearchUnavailableError:
+            raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
+        return _build_semantic_response(hits)
 
     return router

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime, timezone
 from io import StringIO
+from logging import getLogger
 from typing import Any, Dict, Generator, List, Optional, Tuple, TypeAlias, Union
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode
@@ -51,6 +52,8 @@ from birdxplorer_common.models import (
     UserId,
 )
 from birdxplorer_common.storage import CsvExportRow, Storage
+
+logger = getLogger(__name__)
 
 _CSV_EXPORT_JST = ZoneInfo("Asia/Tokyo")
 _CSV_EXPORT_THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
@@ -987,7 +990,8 @@ def gen_router(
         try:
             vector = semantic_search.embed_query(q)
             hits = semantic_search.knn_search(vector, limit=limit, language=language)
-        except SemanticSearchUnavailableError:
+        except SemanticSearchUnavailableError as e:
+            logger.error(f"semantic search unavailable: {e}")
             raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
         return _build_semantic_response(hits)
 
@@ -1007,7 +1011,8 @@ def gen_router(
             if vector is None:
                 raise HTTPException(status_code=404, detail=f"note {note_id} is not indexed")
             hits = semantic_search.knn_search(vector, limit=limit, exclude_note_id=note_id)
-        except SemanticSearchUnavailableError:
+        except SemanticSearchUnavailableError as e:
+            logger.error(f"semantic search unavailable: {e}")
             raise HTTPException(status_code=503, detail="semantic search is temporarily unavailable")
         return _build_semantic_response(hits)
 

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -36,8 +36,15 @@ ALIAS_NAME = "notes"
 class SemanticSearchSettings(BaseSettings):
     """セマンティック検索の設定(env: BX_OPENSEARCH_ENDPOINT / BX_OPENAI_API_KEY)"""
 
+    # extra="ignore": .env にはGlobalSettings用のキー(bx_storage_settings__* 等)も
+    # 書かれるため、未知キーをエラーにしない(pydantic-settingsは.env内の未知キーを
+    # デフォルトのextra="forbid"でValidationErrorにする)
     model_config = SettingsConfigDict(
-        env_prefix="BX_", env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="__"
+        env_prefix="BX_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_nested_delimiter="__",
+        extra="ignore",
     )
 
     opensearch_endpoint: Optional[str] = None
@@ -120,11 +127,19 @@ class SemanticSearchService:
         return results[:limit]
 
 
-def gen_semantic_search_service(settings: SemanticSearchSettings) -> Optional[SemanticSearchService]:
-    """設定が揃っている場合のみサービスを生成する(ローカル開発等ではNone)"""
-    if not settings.opensearch_endpoint or not settings.openai_api_key:
-        return None
+def gen_semantic_search_service(
+    settings: Optional[SemanticSearchSettings] = None,
+) -> Optional[SemanticSearchService]:
+    """設定が揃っている場合のみサービスを生成する(ローカル開発等ではNone)
+
+    設定の読み込み自体の失敗も含め、いかなる初期化失敗もアプリ起動を
+    クラッシュさせず None(機能無効)に縮退させる。
+    """
     try:
+        if settings is None:
+            settings = SemanticSearchSettings()
+        if not settings.opensearch_endpoint or not settings.openai_api_key:
+            return None
         return SemanticSearchService(
             opensearch_endpoint=settings.opensearch_endpoint,
             openai_api_key=settings.openai_api_key,

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -66,7 +66,10 @@ class SemanticSearchService:
             use_ssl=True,
             verify_certs=True,
             connection_class=RequestsHttpConnection,
-            timeout=5,
+            # on_disk ベクトル検索はディスク読み込み + リスコアのぶん遅く、
+            # 索引書き込み(バックフィルやリアルタイム抽出)と重なると数秒に達する。
+            # 5秒では間欠的に ReadTimeout で 503 になるため 15秒に緩める。
+            timeout=15,
         )
 
     def embed_query(self, query: str) -> List[float]:

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -1,0 +1,108 @@
+"""
+セマンティック検索のためのOpenAI / OpenSearchクライアント。
+
+routers/data.py からは gen_router(semantic_search=...) で注入される
+(storage と同じDIパターン)。BX_OPENSEARCH_ENDPOINT / BX_OPENAI_API_KEY
+が未設定の場合はサービス自体が生成されず、エンドポイントは503を返す。
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3  # type: ignore[import-untyped]
+from openai import OpenAI
+from opensearchpy import (
+    AWSV4SignerAuth,
+    NotFoundError,
+    OpenSearch,
+    RequestsHttpConnection,
+)
+
+from birdxplorer_common.models import LanguageCode, NoteId
+from birdxplorer_common.settings import BaseSettings
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+ALIAS_NAME = "notes"
+
+
+class SemanticSearchSettings(BaseSettings):
+    """セマンティック検索の設定(env: BX_OPENSEARCH_ENDPOINT / BX_OPENAI_API_KEY)"""
+
+    opensearch_endpoint: Optional[str] = None
+    openai_api_key: Optional[str] = None
+
+
+class SemanticSearchUnavailableError(Exception):
+    """OpenSearch / OpenAI への接続・呼び出しに失敗した場合に送出される"""
+
+
+class SemanticSearchService:
+    def __init__(self, opensearch_endpoint: str, openai_api_key: str, region: str = "ap-northeast-1") -> None:
+        self._openai = OpenAI(api_key=openai_api_key)
+        credentials = boto3.Session().get_credentials()
+        auth = AWSV4SignerAuth(credentials, region, "es")
+        self._opensearch = OpenSearch(
+            hosts=[{"host": opensearch_endpoint, "port": 443}],
+            http_auth=auth,
+            use_ssl=True,
+            verify_certs=True,
+            connection_class=RequestsHttpConnection,
+            timeout=5,
+        )
+
+    def embed_query(self, query: str) -> List[float]:
+        """クエリ文をベクトル化する(失敗時は1回だけリトライ)"""
+        last_error: Optional[Exception] = None
+        for _ in range(2):
+            try:
+                response = self._openai.embeddings.create(model=EMBEDDING_MODEL, input=query)
+                return list(response.data[0].embedding)
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+        raise SemanticSearchUnavailableError(f"query embedding failed: {last_error}")
+
+    def get_note_embedding(self, note_id: NoteId) -> Optional[List[float]]:
+        """ノートの保存済みembeddingを取得する(未インデックスならNone)"""
+        try:
+            doc = self._opensearch.get(index=ALIAS_NAME, id=str(note_id), _source_includes=["embedding"])
+        except NotFoundError:
+            return None
+        except Exception as e:  # noqa: BLE001
+            raise SemanticSearchUnavailableError(f"failed to fetch note embedding: {e}") from e
+        embedding: List[float] = doc["_source"]["embedding"]
+        return embedding
+
+    def knn_search(
+        self,
+        vector: List[float],
+        limit: int,
+        language: Optional[LanguageCode] = None,
+        exclude_note_id: Optional[NoteId] = None,
+    ) -> List[Tuple[NoteId, float]]:
+        """k-NN検索でnote_idとスコアの一覧をスコア降順で返す"""
+        size = limit + 1 if exclude_note_id is not None else limit
+        knn: Dict[str, Any] = {"vector": vector, "k": size}
+        if language is not None:
+            knn["filter"] = {"term": {"language": str(language)}}
+        body: Dict[str, Any] = {"size": size, "_source": False, "query": {"knn": {"embedding": knn}}}
+
+        try:
+            response = self._opensearch.search(index=ALIAS_NAME, body=body)
+        except Exception as e:  # noqa: BLE001
+            raise SemanticSearchUnavailableError(f"knn search failed: {e}") from e
+
+        results: List[Tuple[NoteId, float]] = []
+        for hit in response["hits"]["hits"]:
+            if exclude_note_id is not None and hit["_id"] == str(exclude_note_id):
+                continue
+            results.append((NoteId(hit["_id"]), float(hit["_score"])))
+        return results[:limit]
+
+
+def gen_semantic_search_service(settings: SemanticSearchSettings) -> Optional[SemanticSearchService]:
+    """設定が揃っている場合のみサービスを生成する(ローカル開発等ではNone)"""
+    if not settings.opensearch_endpoint or not settings.openai_api_key:
+        return None
+    return SemanticSearchService(
+        opensearch_endpoint=settings.opensearch_endpoint,
+        openai_api_key=settings.openai_api_key,
+    )

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -6,6 +6,7 @@ routers/data.py からは gen_router(semantic_search=...) で注入される
 が未設定の場合はサービス自体が生成されず、エンドポイントは503を返す。
 """
 
+from logging import getLogger
 from typing import Any, Dict, List, Optional, Tuple
 
 import boto3  # type: ignore[import-untyped]
@@ -16,10 +17,18 @@ from opensearchpy import (
     OpenSearch,
     RequestsHttpConnection,
 )
+from pydantic import ValidationError
+from pydantic_settings import SettingsConfigDict
 
+from birdxplorer_common.exceptions import BaseError
 from birdxplorer_common.models import LanguageCode, NoteId
 from birdxplorer_common.settings import BaseSettings
 
+logger = getLogger(__name__)
+
+# 契約: この2定数は ETL 側と一致している必要がある
+# (etl/src/birdxplorer_etl/lib/lambda_handler/embedding_lambda.py の EMBEDDING_MODEL /
+#  search_index_writer_lambda.py の ALIAS_NAME)。変更時は両方を同時に更新すること。
 EMBEDDING_MODEL = "text-embedding-3-small"
 ALIAS_NAME = "notes"
 
@@ -27,11 +36,15 @@ ALIAS_NAME = "notes"
 class SemanticSearchSettings(BaseSettings):
     """セマンティック検索の設定(env: BX_OPENSEARCH_ENDPOINT / BX_OPENAI_API_KEY)"""
 
+    model_config = SettingsConfigDict(
+        env_prefix="BX_", env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="__"
+    )
+
     opensearch_endpoint: Optional[str] = None
     openai_api_key: Optional[str] = None
 
 
-class SemanticSearchUnavailableError(Exception):
+class SemanticSearchUnavailableError(BaseError):
     """OpenSearch / OpenAI への接続・呼び出しに失敗した場合に送出される"""
 
 
@@ -68,8 +81,11 @@ class SemanticSearchService:
             return None
         except Exception as e:  # noqa: BLE001
             raise SemanticSearchUnavailableError(f"failed to fetch note embedding: {e}") from e
-        embedding: List[float] = doc["_source"]["embedding"]
-        return embedding
+        # embeddingフィールドが存在しない場合は None を返す(インデックス移行期の整合ズレ対策)
+        embedding = doc.get("_source", {}).get("embedding")
+        if embedding is None:
+            return None
+        return list(embedding)
 
     def knn_search(
         self,
@@ -94,7 +110,13 @@ class SemanticSearchService:
         for hit in response["hits"]["hits"]:
             if exclude_note_id is not None and hit["_id"] == str(exclude_note_id):
                 continue
-            results.append((NoteId(hit["_id"]), float(hit["_score"])))
+            # 不正な _id はスキップして処理を継続する
+            try:
+                note_id = NoteId.from_str(hit["_id"])
+            except ValidationError:
+                logger.warning(f"skipping invalid note id from search index: {hit['_id']}")
+                continue
+            results.append((note_id, float(hit["_score"])))
         return results[:limit]
 
 
@@ -102,7 +124,11 @@ def gen_semantic_search_service(settings: SemanticSearchSettings) -> Optional[Se
     """設定が揃っている場合のみサービスを生成する(ローカル開発等ではNone)"""
     if not settings.opensearch_endpoint or not settings.openai_api_key:
         return None
-    return SemanticSearchService(
-        opensearch_endpoint=settings.opensearch_endpoint,
-        openai_api_key=settings.openai_api_key,
-    )
+    try:
+        return SemanticSearchService(
+            opensearch_endpoint=settings.opensearch_endpoint,
+            openai_api_key=settings.openai_api_key,
+        )
+    except Exception as e:
+        logger.error(f"semantic search service initialization failed: {e}")
+        return None

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "starlette",
     "python-dotenv",
     "uvicorn[standard]",
+    "openai",
+    "opensearch-py",
+    "boto3",
 ]
 
 [project.urls]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -755,10 +755,26 @@ def settings_for_test(
 
 
 @fixture
-def client(settings_for_test: GlobalSettings, mock_storage: MagicMock) -> Generator[TestClient, None, None]:
+def mock_semantic_search(note_samples: List[Note]) -> Generator[MagicMock, None, None]:
+    from birdxplorer_api.semantic_search import SemanticSearchService
+
+    mock = MagicMock(spec=SemanticSearchService)
+    mock.embed_query.return_value = [0.1] * 3
+    mock.knn_search.return_value = [(note_samples[0].note_id, 0.9), (note_samples[1].note_id, 0.8)]
+    mock.get_note_embedding.return_value = [0.2] * 3
+    yield mock
+
+
+@fixture
+def client(
+    settings_for_test: GlobalSettings, mock_storage: MagicMock, mock_semantic_search: MagicMock
+) -> Generator[TestClient, None, None]:
     from birdxplorer_api.app import gen_app
 
-    with patch("birdxplorer_api.app.gen_storage", return_value=mock_storage):
+    with (
+        patch("birdxplorer_api.app.gen_storage", return_value=mock_storage),
+        patch("birdxplorer_api.app.gen_semantic_search_service", return_value=mock_semantic_search),
+    ):
         app = gen_app(settings=settings_for_test)
         yield TestClient(app)
 

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -1,0 +1,97 @@
+"""セマンティック検索エンドポイントのテスト"""
+
+import json
+from typing import List
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from birdxplorer_api.semantic_search import SemanticSearchUnavailableError
+from birdxplorer_common.models import Note
+from birdxplorer_common.settings import GlobalSettings
+
+
+def test_semantic_search_returns_notes_with_scores(
+    client: TestClient, mock_semantic_search: MagicMock, note_samples: List[Note]
+) -> None:
+    response = client.get("/api/v1/data/search/semantic?q=test")
+    assert response.status_code == 200
+    res_json = response.json()
+    assert res_json == {
+        "data": [
+            {"note": json.loads(note_samples[0].model_dump_json()), "score": 0.9},
+            {"note": json.loads(note_samples[1].model_dump_json()), "score": 0.8},
+        ]
+    }
+    mock_semantic_search.embed_query.assert_called_once_with("test")
+
+
+def test_semantic_search_passes_language_and_limit(client: TestClient, mock_semantic_search: MagicMock) -> None:
+    response = client.get("/api/v1/data/search/semantic?q=test&language=ja&limit=5")
+    assert response.status_code == 200
+    kwargs = mock_semantic_search.knn_search.call_args.kwargs
+    assert kwargs["limit"] == 5
+    assert str(kwargs["language"]) == "ja"
+
+
+def test_semantic_search_drops_notes_missing_in_postgres(
+    client: TestClient, mock_semantic_search: MagicMock, note_samples: List[Note]
+) -> None:
+    """OpenSearchにあってPGにないnote_idは結果から落ちる"""
+    mock_semantic_search.knn_search.return_value = [
+        ("9999999999999999999", 0.95),  # PGに存在しないID
+        (note_samples[0].note_id, 0.9),
+    ]
+    response = client.get("/api/v1/data/search/semantic?q=test")
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["score"] == 0.9
+
+
+def test_semantic_search_validation_errors(client: TestClient) -> None:
+    assert client.get("/api/v1/data/search/semantic").status_code == 422  # q なし
+    assert client.get("/api/v1/data/search/semantic?q=").status_code == 422  # 空文字
+    assert client.get("/api/v1/data/search/semantic?q=test&limit=0").status_code == 422
+    assert client.get("/api/v1/data/search/semantic?q=test&limit=101").status_code == 422
+
+
+def test_semantic_search_returns_503_when_unavailable(client: TestClient, mock_semantic_search: MagicMock) -> None:
+    mock_semantic_search.embed_query.side_effect = SemanticSearchUnavailableError("down")
+    assert client.get("/api/v1/data/search/semantic?q=test").status_code == 503
+
+
+def test_similar_returns_notes(client: TestClient, mock_semantic_search: MagicMock, note_samples: List[Note]) -> None:
+    target_id = str(note_samples[2].note_id)
+    response = client.get(f"/api/v1/data/search/similar/{target_id}")
+    assert response.status_code == 200
+    mock_semantic_search.get_note_embedding.assert_called_once()
+    kwargs = mock_semantic_search.knn_search.call_args.kwargs
+    assert str(kwargs["exclude_note_id"]) == target_id
+    # embed_query(OpenAI)は呼ばれない
+    mock_semantic_search.embed_query.assert_not_called()
+
+
+def test_similar_returns_404_when_not_indexed(client: TestClient, mock_semantic_search: MagicMock) -> None:
+    mock_semantic_search.get_note_embedding.return_value = None
+    assert client.get("/api/v1/data/search/similar/1234567890123456789").status_code == 404
+
+
+def test_similar_returns_422_for_invalid_note_id(client: TestClient) -> None:
+    assert client.get("/api/v1/data/search/similar/not-a-note-id").status_code == 422
+
+
+def test_semantic_search_returns_503_when_not_configured(
+    settings_for_test: GlobalSettings, mock_storage: MagicMock
+) -> None:
+    from unittest.mock import patch
+
+    from birdxplorer_api.app import gen_app
+
+    with (
+        patch("birdxplorer_api.app.gen_storage", return_value=mock_storage),
+        patch("birdxplorer_api.app.gen_semantic_search_service", return_value=None),
+    ):
+        app = gen_app(settings=settings_for_test)
+        no_service_client = TestClient(app)
+    assert no_service_client.get("/api/v1/data/search/semantic?q=test").status_code == 503

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -1,9 +1,11 @@
 """セマンティック検索エンドポイントのテスト"""
 
 import json
+import logging
 from typing import List
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from birdxplorer_api.semantic_search import SemanticSearchUnavailableError
@@ -56,9 +58,13 @@ def test_semantic_search_validation_errors(client: TestClient) -> None:
     assert client.get("/api/v1/data/search/semantic?q=test&limit=101").status_code == 422
 
 
-def test_semantic_search_returns_503_when_unavailable(client: TestClient, mock_semantic_search: MagicMock) -> None:
+def test_semantic_search_returns_503_when_unavailable(
+    client: TestClient, mock_semantic_search: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     mock_semantic_search.embed_query.side_effect = SemanticSearchUnavailableError("down")
-    assert client.get("/api/v1/data/search/semantic?q=test").status_code == 503
+    with caplog.at_level(logging.ERROR):
+        assert client.get("/api/v1/data/search/semantic?q=test").status_code == 503
+    assert "semantic search unavailable" in caplog.text
 
 
 def test_similar_returns_notes(client: TestClient, mock_semantic_search: MagicMock, note_samples: List[Note]) -> None:

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -41,6 +41,20 @@ class TestGenService:
         ):
             assert gen_semantic_search_service(settings) is not None
 
+    def test_returns_none_and_logs_when_initialization_fails(self, caplog: pytest.LogCaptureFixture) -> None:
+        """F1: サービス生成中に例外が発生した場合は None を返しログを記録する"""
+        import logging
+
+        settings = SemanticSearchSettings(opensearch_endpoint="example.com", openai_api_key="key")
+        with (
+            patch("birdxplorer_api.semantic_search.AWSV4SignerAuth", side_effect=RuntimeError("cred error")),
+            patch("birdxplorer_api.semantic_search.boto3"),
+            caplog.at_level(logging.ERROR),
+        ):
+            result = gen_semantic_search_service(settings)
+        assert result is None
+        assert "semantic search service initialization failed" in caplog.text
+
 
 class TestEmbedQuery:
     def test_returns_embedding(self) -> None:
@@ -76,6 +90,13 @@ class TestGetNoteEmbedding:
 
         service, _, os_client = _service_with_mocks()
         os_client.get.side_effect = NotFoundError(404, "not_found", {})
+
+        assert service.get_note_embedding(NoteId.from_str("1" * 19)) is None
+
+    def test_returns_none_when_embedding_field_missing(self) -> None:
+        """F2: _source に embedding フィールドがない場合は KeyError でなく None を返す"""
+        service, _, os_client = _service_with_mocks()
+        os_client.get.return_value = {"_source": {}}
 
         assert service.get_note_embedding(NoteId.from_str("1" * 19)) is None
 
@@ -134,3 +155,19 @@ class TestKnnSearch:
 
         with pytest.raises(SemanticSearchUnavailableError):
             service.knn_search([0.1] * 3, limit=5)
+
+    def test_skips_invalid_note_id_and_returns_valid(self, caplog: pytest.LogCaptureFixture) -> None:
+        """F3: 不正な _id はスキップされ、有効な _id のみ返る"""
+        import logging
+
+        service, _, os_client = _service_with_mocks()
+        valid_id = "1" * 19
+        os_client.search.return_value = {"hits": {"hits": [_hit("abc", 0.99), _hit(valid_id, 0.85)]}}
+
+        with caplog.at_level(logging.WARNING):
+            result = service.knn_search([0.1] * 3, limit=5)
+
+        assert len(result) == 1
+        assert str(result[0][0]) == valid_id
+        assert result[0][1] == 0.85
+        assert "skipping invalid note id from search index: abc" in caplog.text

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -1,5 +1,6 @@
 """SemanticSearchService のテスト"""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -171,3 +172,25 @@ class TestKnnSearch:
         assert str(result[0][0]) == valid_id
         assert result[0][1] == 0.85
         assert "skipping invalid note id from search index: abc" in caplog.text
+
+
+class TestSettingsRobustness:
+    def test_env_file_with_unrelated_keys_does_not_raise(self, tmp_path: "Path") -> None:
+        """GlobalSettings用のキーが書かれた.envを読んでもValidationErrorにならない(extra=ignore)"""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "bx_storage_settings__password=birdxplorer\n"
+            "bx_storage_settings__host=localhost\n"
+            "bx_opensearch_endpoint=example.com\n",
+            encoding="utf-8",
+        )
+        settings = SemanticSearchSettings(_env_file=str(env_file))
+        assert settings.opensearch_endpoint == "example.com"
+
+    def test_factory_degrades_when_settings_load_fails(self) -> None:
+        """設定読み込み自体が失敗してもfactoryはNoneに縮退する(起動クラッシュしない)"""
+        with patch(
+            "birdxplorer_api.semantic_search.SemanticSearchSettings",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert gen_semantic_search_service() is None

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -1,0 +1,136 @@
+"""SemanticSearchService のテスト"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from birdxplorer_api.semantic_search import (
+    SemanticSearchService,
+    SemanticSearchSettings,
+    SemanticSearchUnavailableError,
+    gen_semantic_search_service,
+)
+from birdxplorer_common.models import LanguageCode, NoteId
+
+
+def _service_with_mocks() -> tuple[SemanticSearchService, MagicMock, MagicMock]:
+    """OpenAI / OpenSearch クライアントをモックに差し替えたサービスを返す"""
+    with (
+        patch("birdxplorer_api.semantic_search.OpenAI") as mock_openai_cls,
+        patch("birdxplorer_api.semantic_search.OpenSearch") as mock_os_cls,
+        patch("birdxplorer_api.semantic_search.boto3"),
+        patch("birdxplorer_api.semantic_search.AWSV4SignerAuth"),
+    ):
+        service = SemanticSearchService(opensearch_endpoint="example.com", openai_api_key="key")
+    return service, mock_openai_cls.return_value, mock_os_cls.return_value
+
+
+class TestGenService:
+    def test_returns_none_when_not_configured(self) -> None:
+        settings = SemanticSearchSettings(opensearch_endpoint=None, openai_api_key=None)
+        assert gen_semantic_search_service(settings) is None
+
+    def test_returns_service_when_configured(self) -> None:
+        settings = SemanticSearchSettings(opensearch_endpoint="example.com", openai_api_key="key")
+        with (
+            patch("birdxplorer_api.semantic_search.OpenAI"),
+            patch("birdxplorer_api.semantic_search.OpenSearch"),
+            patch("birdxplorer_api.semantic_search.boto3"),
+            patch("birdxplorer_api.semantic_search.AWSV4SignerAuth"),
+        ):
+            assert gen_semantic_search_service(settings) is not None
+
+
+class TestEmbedQuery:
+    def test_returns_embedding(self) -> None:
+        service, openai_client, _ = _service_with_mocks()
+        item = MagicMock()
+        item.embedding = [0.1, 0.2]
+        openai_client.embeddings.create.return_value.data = [item]
+
+        assert service.embed_query("テスト") == [0.1, 0.2]
+        openai_client.embeddings.create.assert_called_once_with(model="text-embedding-3-small", input="テスト")
+
+    def test_retries_once_then_raises(self) -> None:
+        service, openai_client, _ = _service_with_mocks()
+        openai_client.embeddings.create.side_effect = RuntimeError("down")
+
+        with pytest.raises(SemanticSearchUnavailableError):
+            service.embed_query("テスト")
+        assert openai_client.embeddings.create.call_count == 2
+
+
+class TestGetNoteEmbedding:
+    def test_returns_vector(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.get.return_value = {"_source": {"embedding": [0.5] * 3}}
+
+        assert service.get_note_embedding(NoteId.from_str("1" * 19)) == [0.5] * 3
+        kwargs = os_client.get.call_args.kwargs
+        assert kwargs["index"] == "notes"
+        assert kwargs["id"] == "1" * 19
+
+    def test_returns_none_when_not_indexed(self) -> None:
+        from opensearchpy import NotFoundError
+
+        service, _, os_client = _service_with_mocks()
+        os_client.get.side_effect = NotFoundError(404, "not_found", {})
+
+        assert service.get_note_embedding(NoteId.from_str("1" * 19)) is None
+
+    def test_wraps_connection_error(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.get.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(SemanticSearchUnavailableError):
+            service.get_note_embedding(NoteId.from_str("1" * 19))
+
+
+def _hit(note_id: str, score: float) -> dict[str, Any]:
+    return {"_id": note_id, "_score": score}
+
+
+class TestKnnSearch:
+    def test_builds_query_and_parses_hits(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": [_hit("1" * 19, 0.9), _hit("2" * 19, 0.8)]}}
+
+        result = service.knn_search([0.1] * 3, limit=2)
+
+        assert result == [("1" * 19, 0.9), ("2" * 19, 0.8)]
+        body = os_client.search.call_args.kwargs["body"]
+        assert body["size"] == 2
+        assert body["_source"] is False
+        assert body["query"]["knn"]["embedding"]["vector"] == [0.1] * 3
+        assert body["query"]["knn"]["embedding"]["k"] == 2
+        assert os_client.search.call_args.kwargs["index"] == "notes"
+
+    def test_language_filter(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search([0.1] * 3, limit=5, language=LanguageCode.from_str("ja"))
+
+        body = os_client.search.call_args.kwargs["body"]
+        assert body["query"]["knn"]["embedding"]["filter"] == {"term": {"language": "ja"}}
+
+    def test_excludes_self(self) -> None:
+        """exclude_note_id 指定時は k を1つ増やして取得し、自分自身を除外して limit 件に切り詰める"""
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {
+            "hits": {"hits": [_hit("1" * 19, 1.0), _hit("2" * 19, 0.9), _hit("3" * 19, 0.8)]}
+        }
+
+        result = service.knn_search([0.1] * 3, limit=2, exclude_note_id=NoteId.from_str("1" * 19))
+
+        assert result == [("2" * 19, 0.9), ("3" * 19, 0.8)]
+        body = os_client.search.call_args.kwargs["body"]
+        assert body["size"] == 3  # limit + 1
+
+    def test_wraps_connection_error(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.side_effect = RuntimeError("timeout")
+
+        with pytest.raises(SemanticSearchUnavailableError):
+            service.knn_search([0.1] * 3, limit=5)

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/embedding_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/embedding_lambda.py
@@ -21,6 +21,8 @@ from birdxplorer_etl.lib.lambda_handler.common.sqs_handler import SQSHandler
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# 契約: この定数は API 側と一致している必要がある
+# (api/birdxplorer_api/semantic_search.py の EMBEDDING_MODEL)。変更時は両方を同時に更新すること。
 EMBEDDING_MODEL = "text-embedding-3-small"
 
 _openai_client = None

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -23,6 +23,8 @@ logger.setLevel(logging.INFO)
 # v2: ディスクベースベクトル検索(mode: on_disk)に変更。
 # notesテーブルは約293万件あり、in-memoryのHNSW(約19GB)はm6g.largeに収まらないため。
 INDEX_NAME = "notes-v2"
+# 契約: この定数は API 側と一致している必要がある
+# (api/birdxplorer_api/semantic_search.py の ALIAS_NAME)。変更時は両方を同時に更新すること。
 ALIAS_NAME = "notes"
 
 # spec: 2026-07-08-opensearch-phase2-etl-design.md §7


### PR DESCRIPTION
## 概要

OpenSearch ベクトル検索を使った検索エンドポイント2本を追加する(フェーズ2後半)。

- `GET /api/v1/data/search/semantic?q=...&language=ja&limit=20` — 自然文クエリをOpenAI(`text-embedding-3-small`)でベクトル化し、意味的に近いノートを返す
- `GET /api/v1/data/search/similar/{note_id}?limit=20` — 対象ノートの保存済みembeddingを再利用して類似ノートを返す(OpenAI呼び出しなし・自分自身は除外)

## 設計

- レスポンスは `{"data": [{"note": {...}, "score": ...}]}`。**ノート本体はPostgreSQLからハイドレート**(current_status等の可変フィールドは常に最新 — 既存 `/search` と同じ思想)。OpenSearchにあってPGにないIDは除外
- ロジックは `semantic_search.py`(SigV4 + innerproduct k-NN)に分離し、`gen_router(semantic_search=...)` で既存のDIパターン通り注入
- **`BX_OPENSEARCH_ENDPOINT` / `BX_OPENAI_API_KEY` 未設定ならサービスは生成されず、新エンドポイントは503を返すだけ**(既存エンドポイントのコードパスは不変)。設定はBirdXplorer-cdk#25(マージ済み)がApiStackに配線する
- 補足: 設定は共通GlobalSettingsではなくapi内の独立Settingsにした(common変更を避けるため。common+api横断PRはDeploy API CIが構造的に失敗する既知問題)
- 既存 `/data/search`(LIKE横断検索)は無変更。offsetなし(k-NNはtop-k取得のためv1はlimitのみ)。BM25は将来 `/search/fulltext` 等で追加可能な構造

## 検証

- 新規テスト19本(サービス10 + ルーター9): リトライ回数、k-NNクエリ構造、スコア順維持、PG欠損除外、404/422/503、similarでOpenAI不使用、503時のログ出力
- tox全ゲート(black/isort/pytest 137/pflake8/mypy --strict ×2)通過
- **本PRのCIデプロイ時点では新エンドポイントは503**(CDK main反映は本PRマージ時のCIで同時に有効化される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)