### PR TITLE
feat(api): kNN検索のtransientタイムアウトをリトライで吸収

### DIFF
--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -133,6 +133,8 @@ class SemanticSearchService:
     def get_note_embedding(self, note_id: NoteId) -> Optional[List[float]]:
         """ノートの保存済みembeddingを取得する(未インデックスならNone)"""
         try:
+            # NOTE: 意図的にリトライしない。search_similar は get_note_embedding→knn_search を直列で呼ぶため、
+            # 両方リトライすると最悪~60秒となり ~30秒予算を超える。リトライするのは knn_search のみ。
             doc = self._opensearch.get(index=ALIAS_NAME, id=str(note_id), _source_includes=["embedding"])
         except NotFoundError:
             return None

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -49,6 +49,7 @@ class SemanticSearchSettings(BaseSettings):
 
     opensearch_endpoint: Optional[str] = None
     openai_api_key: Optional[str] = None
+    opensearch_timeout_seconds: int = 15
 
 
 class SemanticSearchUnavailableError(BaseError):
@@ -56,7 +57,13 @@ class SemanticSearchUnavailableError(BaseError):
 
 
 class SemanticSearchService:
-    def __init__(self, opensearch_endpoint: str, openai_api_key: str, region: str = "ap-northeast-1") -> None:
+    def __init__(
+        self,
+        opensearch_endpoint: str,
+        openai_api_key: str,
+        region: str = "ap-northeast-1",
+        timeout: int = 15,
+    ) -> None:
         self._openai = OpenAI(api_key=openai_api_key)
         credentials = boto3.Session().get_credentials()
         auth = AWSV4SignerAuth(credentials, region, "es")
@@ -66,10 +73,9 @@ class SemanticSearchService:
             use_ssl=True,
             verify_certs=True,
             connection_class=RequestsHttpConnection,
-            # on_disk ベクトル検索はディスク読み込み + リスコアのぶん遅く、
-            # 索引書き込み(バックフィルやリアルタイム抽出)と重なると数秒に達する。
-            # 5秒では間欠的に ReadTimeout で 503 になるため 15秒に緩める。
-            timeout=15,
+            # on_disk ベクトル検索はディスク読み込み + リスコアのぶん遅く、索引書き込みと
+            # 重なると数秒に達する。既定は15秒。ops は BX_OPENSEARCH_TIMEOUT_SECONDS で調整可能。
+            timeout=timeout,
         )
 
     def embed_query(self, query: str) -> List[float]:
@@ -146,6 +152,7 @@ def gen_semantic_search_service(
         return SemanticSearchService(
             opensearch_endpoint=settings.opensearch_endpoint,
             openai_api_key=settings.openai_api_key,
+            timeout=settings.opensearch_timeout_seconds,
         )
     except Exception as e:
         logger.error(f"semantic search service initialization failed: {e}")

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -6,8 +6,9 @@ routers/data.py からは gen_router(semantic_search=...) で注入される
 が未設定の場合はサービス自体が生成されず、エンドポイントは503を返す。
 """
 
+import time
 from logging import getLogger
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 import boto3  # type: ignore[import-untyped]
 from openai import OpenAI
@@ -17,6 +18,8 @@ from opensearchpy import (
     OpenSearch,
     RequestsHttpConnection,
 )
+from opensearchpy import ConnectionError as OpenSearchConnectionError
+from opensearchpy import TransportError
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
@@ -25,6 +28,25 @@ from birdxplorer_common.models import LanguageCode, NoteId
 from birdxplorer_common.settings import BaseSettings
 
 logger = getLogger(__name__)
+
+T = TypeVar("T")
+
+# transient エラー時にリトライする際の固定バックオフ(秒)
+_RETRY_BACKOFF_SECONDS = 0.5
+
+
+def _is_transient_opensearch_error(exc: Exception) -> bool:
+    """接続/読取タイムアウト・5xx を transient(再試行対象)とみなす。
+
+    4xx(NotFoundError の 404 を含む)など決定的なエラーは False。
+    """
+    if isinstance(exc, OpenSearchConnectionError):  # ConnectionTimeout を含む
+        return True
+    if isinstance(exc, TransportError):
+        status = exc.status_code
+        return isinstance(status, int) and 500 <= status < 600
+    return False
+
 
 # 契約: この2定数は ETL 側と一致している必要がある
 # (etl/src/birdxplorer_etl/lib/lambda_handler/embedding_lambda.py の EMBEDDING_MODEL /
@@ -78,6 +100,23 @@ class SemanticSearchService:
             timeout=timeout,
         )
 
+    def _run_with_retry(self, operation: Callable[[], T], description: str) -> T:
+        """OpenSearch 呼び出しを実行し、transient エラー時のみ1回だけ再試行する。
+
+        非 transient なエラーは即座に送出する(呼び出し側で
+        SemanticSearchUnavailableError に変換される)。
+        """
+        for attempt in range(2):
+            try:
+                return operation()
+            except Exception as e:  # noqa: BLE001
+                if attempt == 0 and _is_transient_opensearch_error(e):
+                    logger.warning(f"{description} attempt 1 failed, retrying: {e}")
+                    time.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise
+        raise AssertionError("unreachable")  # pragma: no cover
+
     def embed_query(self, query: str) -> List[float]:
         """クエリ文をベクトル化する(失敗時は1回だけリトライ)"""
         last_error: Optional[Exception] = None
@@ -118,7 +157,10 @@ class SemanticSearchService:
         body: Dict[str, Any] = {"size": size, "_source": False, "query": {"knn": {"embedding": knn}}}
 
         try:
-            response = self._opensearch.search(index=ALIAS_NAME, body=body)
+            response = self._run_with_retry(
+                lambda: self._opensearch.search(index=ALIAS_NAME, body=body),
+                "knn search",
+            )
         except Exception as e:  # noqa: BLE001
             raise SemanticSearchUnavailableError(f"knn search failed: {e}") from e
 

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -14,12 +14,14 @@ import boto3  # type: ignore[import-untyped]
 from openai import OpenAI
 from opensearchpy import (
     AWSV4SignerAuth,
+)
+from opensearchpy import ConnectionError as OpenSearchConnectionError
+from opensearchpy import (
     NotFoundError,
     OpenSearch,
     RequestsHttpConnection,
+    TransportError,
 )
-from opensearchpy import ConnectionError as OpenSearchConnectionError
-from opensearchpy import TransportError
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
@@ -32,7 +34,7 @@ logger = getLogger(__name__)
 T = TypeVar("T")
 
 # transient エラー時にリトライする際の固定バックオフ(秒)
-_RETRY_BACKOFF_SECONDS = 0.5
+_RETRY_BACKOFF_SECONDS: float = 0.5
 
 
 def _is_transient_opensearch_error(exc: Exception) -> bool:

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -108,6 +108,15 @@ class TestGetNoteEmbedding:
         with pytest.raises(SemanticSearchUnavailableError):
             service.get_note_embedding(NoteId.from_str("1" * 19))
 
+    def test_transient_error_is_not_retried(self) -> None:
+        from opensearchpy import ConnectionTimeout
+
+        service, _, os_client = _service_with_mocks()
+        os_client.get.side_effect = ConnectionTimeout("N/A", "read timed out", None)
+        with pytest.raises(SemanticSearchUnavailableError):
+            service.get_note_embedding(NoteId.from_str("1" * 19))
+        assert os_client.get.call_count == 1
+
 
 def _hit(note_id: str, score: float) -> dict[str, Any]:
     return {"_id": note_id, "_score": score}
@@ -172,6 +181,61 @@ class TestKnnSearch:
         assert str(result[0][0]) == valid_id
         assert result[0][1] == 0.85
         assert "skipping invalid note id from search index: abc" in caplog.text
+
+    def test_retries_once_on_transient_then_succeeds(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        from opensearchpy import ConnectionTimeout
+
+        service, _, os_client = _service_with_mocks()
+        os_client.search.side_effect = [
+            ConnectionTimeout("N/A", "read timed out", None),
+            {"hits": {"hits": [_hit("1" * 19, 0.9)]}},
+        ]
+        with (
+            patch("birdxplorer_api.semantic_search.time.sleep") as mock_sleep,
+            caplog.at_level(logging.WARNING),
+        ):
+            result = service.knn_search([0.1] * 3, limit=1)
+
+        assert result == [("1" * 19, 0.9)]
+        assert os_client.search.call_count == 2
+        mock_sleep.assert_called_once()
+        assert "knn search attempt 1 failed" in caplog.text
+
+    def test_retries_exhausted_then_raises(self) -> None:
+        from opensearchpy import ConnectionTimeout
+
+        service, _, os_client = _service_with_mocks()
+        os_client.search.side_effect = ConnectionTimeout("N/A", "read timed out", None)
+        with patch("birdxplorer_api.semantic_search.time.sleep"):
+            with pytest.raises(SemanticSearchUnavailableError):
+                service.knn_search([0.1] * 3, limit=5)
+        assert os_client.search.call_count == 2
+
+    def test_5xx_is_retried(self) -> None:
+        from opensearchpy import TransportError
+
+        service, _, os_client = _service_with_mocks()
+        os_client.search.side_effect = [
+            TransportError(503, "unavailable", {}),
+            {"hits": {"hits": []}},
+        ]
+        with patch("birdxplorer_api.semantic_search.time.sleep"):
+            result = service.knn_search([0.1] * 3, limit=5)
+        assert result == []
+        assert os_client.search.call_count == 2
+
+    def test_4xx_is_not_retried(self) -> None:
+        from opensearchpy import TransportError
+
+        service, _, os_client = _service_with_mocks()
+        os_client.search.side_effect = TransportError(400, "bad_request", {})
+        with patch("birdxplorer_api.semantic_search.time.sleep") as mock_sleep:
+            with pytest.raises(SemanticSearchUnavailableError):
+                service.knn_search([0.1] * 3, limit=5)
+        assert os_client.search.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 class TestSettingsRobustness:

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -194,3 +194,32 @@ class TestSettingsRobustness:
             side_effect=RuntimeError("boom"),
         ):
             assert gen_semantic_search_service() is None
+
+
+class TestTimeoutConfig:
+    def test_default_timeout_is_15(self) -> None:
+        settings = SemanticSearchSettings(opensearch_endpoint="example.com", openai_api_key="key")
+        assert settings.opensearch_timeout_seconds == 15
+
+    def test_timeout_passed_to_opensearch_client(self) -> None:
+        with (
+            patch("birdxplorer_api.semantic_search.OpenAI"),
+            patch("birdxplorer_api.semantic_search.OpenSearch") as mock_os_cls,
+            patch("birdxplorer_api.semantic_search.boto3"),
+            patch("birdxplorer_api.semantic_search.AWSV4SignerAuth"),
+        ):
+            SemanticSearchService(opensearch_endpoint="example.com", openai_api_key="key", timeout=25)
+        assert mock_os_cls.call_args.kwargs["timeout"] == 25
+
+    def test_factory_injects_configured_timeout(self) -> None:
+        settings = SemanticSearchSettings(
+            opensearch_endpoint="example.com", openai_api_key="key", opensearch_timeout_seconds=30
+        )
+        with (
+            patch("birdxplorer_api.semantic_search.OpenAI"),
+            patch("birdxplorer_api.semantic_search.OpenSearch") as mock_os_cls,
+            patch("birdxplorer_api.semantic_search.boto3"),
+            patch("birdxplorer_api.semantic_search.AWSV4SignerAuth"),
+        ):
+            gen_semantic_search_service(settings)
+        assert mock_os_cls.call_args.kwargs["timeout"] == 30

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from birdxplorer_api.semantic_search import (
+    _RETRY_BACKOFF_SECONDS,
     SemanticSearchService,
     SemanticSearchSettings,
     SemanticSearchUnavailableError,
@@ -200,7 +201,7 @@ class TestKnnSearch:
 
         assert result == [("1" * 19, 0.9)]
         assert os_client.search.call_count == 2
-        mock_sleep.assert_called_once()
+        mock_sleep.assert_called_once_with(_RETRY_BACKOFF_SECONDS)
         assert "knn search attempt 1 failed" in caplog.text
 
     def test_retries_exhausted_then_raises(self) -> None:


### PR DESCRIPTION
## 概要
dev環境で散発的に発生していたセマンティック検索(kNN)の `ReadTimeout` 失敗を、
transientエラー時の自動リトライで吸収する。

## 背景
kNNベクトル検索が索引書き込みと重なると15秒を超え、`ConnectionTimeout(ReadTimeout)`
→ API が "temporarily unavailable"(503) を返す事象が週数回発生。手動検証でも
1回目失敗→2回目即成功を確認しており、transientな遅延でリトライで回復する性質。

## 変更内容
- OpenSearchクライアントの `timeout` を env `BX_OPENSEARCH_TIMEOUT_SECONDS` で調整可能に
  （デフォルト15秒据え置き・挙動不変）
- `knn_search` に transient/5xx エラー時のみ1回リトライを追加（0.5秒バックオフ、初回失敗時に warning ログ、最悪≈30秒）
  - `get_note_embedding` は**リトライしない**（`search_similar` が両者を直列で呼ぶため
    両方リトライすると最悪~60秒となり ~30秒予算を超えるため。不変条件はコード内コメントに明記）
- 例外分類 `_is_transient_opensearch_error`: `ConnectionError`(ConnectionTimeout含む)/5xx のみ再試行、4xx・404は即失敗

## テスト
- `test_semantic_search_service.py` にリトライ挙動のテストを追加（回復/枯渇/5xx再試行/4xx非再試行/get_note_embedding非再試行/バックオフ値）
- `api` tox green（150 passed）、`common` tox green（126 passed）

## フォローアップ（任意・別リポ）
- `BirdXplorer-cdk` の API タスク定義に `BX_OPENSEARCH_TIMEOUT_SECONDS` を追加すれば
  再デプロイなしでops側からタイムアウト調整可能（未設定でもデフォルト15秒で動作）
