### PR TITLE
feat(api): セマンティック検索にAND/ORキーワードのハードフィルタを追加

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -692,11 +692,15 @@ v1_data_search_similar_note_id: FastAPIEndpointParamDocs = {"description": "起�
 
 # Get /api/v1/data/search/semantic の OpenAPI ドキュメント
 V1DataSearchSemanticDocs = FastAPIEndpointDocs(
-    "自然文クエリによるセマンティック検索。クエリをベクトル化し、意味的に近いノートを返します。",
+    "自然文クエリによるセマンティック検索。クエリをベクトル化し、意味的に近いノートを返します。"
+    "note_includes_text/note_excludes_text で語単位のキーワード絞り込み(ハードフィルタ)を併用できます。",
     {
         "q": v1_data_search_semantic_q,
         "language": v1_data_search_semantic_language,
         "limit": v1_data_search_semantic_limit,
+        "note_includes_text": v1_data_notes_search_text,
+        "note_excludes_text": v1_data_notes_search_text,
+        "note_search_mode": v1_data_search_note_search_mode,
     },
 )
 

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -984,9 +984,7 @@ def gen_router(
         q: str = Query(min_length=1, max_length=1000, **V1DataSearchSemanticDocs.params["q"]),
         language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchSemanticDocs.params["language"]),
         limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSemanticDocs.params["limit"]),
-        note_includes_text: List[str] = Query(
-            default=[], **V1DataSearchSemanticDocs.params["note_includes_text"]
-        ),
+        note_includes_text: List[str] = Query(default=[], **V1DataSearchSemanticDocs.params["note_includes_text"]),
         note_search_mode: TextSearchMode = Query(
             default=TextSearchMode.OR, **V1DataSearchSemanticDocs.params["note_search_mode"]
         ),

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -984,7 +984,9 @@ def gen_router(
         q: str = Query(min_length=1, max_length=1000, **V1DataSearchSemanticDocs.params["q"]),
         language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchSemanticDocs.params["language"]),
         limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSemanticDocs.params["limit"]),
-        note_includes_text: List[str] = Query(default=[], **V1DataSearchSemanticDocs.params["note_includes_text"]),
+        note_includes_text: Union[None, List[str]] = Query(
+            default=None, **V1DataSearchSemanticDocs.params["note_includes_text"]
+        ),
         note_search_mode: TextSearchMode = Query(
             default=TextSearchMode.OR, **V1DataSearchSemanticDocs.params["note_search_mode"]
         ),

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -984,10 +984,26 @@ def gen_router(
         q: str = Query(min_length=1, max_length=1000, **V1DataSearchSemanticDocs.params["q"]),
         language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchSemanticDocs.params["language"]),
         limit: int = Query(default=20, ge=1, le=100, **V1DataSearchSemanticDocs.params["limit"]),
+        note_includes_text: List[str] = Query(
+            default=[], **V1DataSearchSemanticDocs.params["note_includes_text"]
+        ),
+        note_search_mode: TextSearchMode = Query(
+            default=TextSearchMode.OR, **V1DataSearchSemanticDocs.params["note_search_mode"]
+        ),
+        note_excludes_text: Union[str, None] = Query(
+            default=None, **V1DataSearchSemanticDocs.params["note_excludes_text"]
+        ),
     ) -> SemanticSearchResponse:
         service = _require_semantic_search()
         vector = service.embed_query(q)
-        hits = service.knn_search(vector, limit=limit, language=language)
+        hits = service.knn_search(
+            vector,
+            limit=limit,
+            language=language,
+            includes=note_includes_text or None,
+            search_mode=note_search_mode,
+            excludes=[note_excludes_text] if note_excludes_text else None,
+        )
         return _build_semantic_response(hits)
 
     @router.get(

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -62,7 +62,7 @@ def _build_keyword_filter(
     """
 
     def _clause(keyword: str) -> Dict[str, Any]:
-        return {"multi_match": {"query": keyword, "fields": ["text.ja", "text.en"]}}
+        return {"multi_match": {"query": keyword, "fields": ["text.ja", "text.en"], "operator": "and"}}
 
     include_terms = [k for k in (includes or []) if k and k.strip()]
     exclude_terms = [k for k in (excludes or []) if k and k.strip()]

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -26,7 +26,7 @@ from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
 from birdxplorer_common.exceptions import BaseError
-from birdxplorer_common.models import LanguageCode, NoteId
+from birdxplorer_common.models import LanguageCode, NoteId, TextSearchMode
 from birdxplorer_common.settings import BaseSettings
 
 logger = getLogger(__name__)
@@ -48,6 +48,38 @@ def _is_transient_opensearch_error(exc: Exception) -> bool:
         status = exc.status_code
         return isinstance(status, int) and 500 <= status < 600
     return False
+
+
+def _build_keyword_filter(
+    includes: Optional[List[str]],
+    search_mode: TextSearchMode,
+    excludes: Optional[List[str]],
+) -> Optional[Dict[str, Any]]:
+    """AND/OR キーワードを OpenSearch の bool フィルタ句に変換する(全て空なら None)。
+
+    各キーワードは text.ja(kuromoji)/text.en への語単位 multi_match。
+    includes: AND → must / OR → should + minimum_should_match=1。excludes: 常に must_not。
+    """
+
+    def _clause(keyword: str) -> Dict[str, Any]:
+        return {"multi_match": {"query": keyword, "fields": ["text.ja", "text.en"]}}
+
+    include_terms = [k for k in (includes or []) if k and k.strip()]
+    exclude_terms = [k for k in (excludes or []) if k and k.strip()]
+    if not include_terms and not exclude_terms:
+        return None
+
+    bool_body: Dict[str, Any] = {}
+    if include_terms:
+        clauses = [_clause(k) for k in include_terms]
+        if search_mode == TextSearchMode.AND:
+            bool_body["must"] = clauses
+        else:
+            bool_body["should"] = clauses
+            bool_body["minimum_should_match"] = 1
+    if exclude_terms:
+        bool_body["must_not"] = [_clause(k) for k in exclude_terms]
+    return {"bool": bool_body}
 
 
 # 契約: この2定数は ETL 側と一致している必要がある
@@ -152,12 +184,23 @@ class SemanticSearchService:
         limit: int,
         language: Optional[LanguageCode] = None,
         exclude_note_id: Optional[NoteId] = None,
+        includes: Optional[List[str]] = None,
+        search_mode: TextSearchMode = TextSearchMode.OR,
+        excludes: Optional[List[str]] = None,
     ) -> List[Tuple[NoteId, float]]:
         """k-NN検索でnote_idとスコアの一覧をスコア降順で返す"""
         size = limit + 1 if exclude_note_id is not None else limit
         knn: Dict[str, Any] = {"vector": vector, "k": size}
+
+        filter_clauses: List[Dict[str, Any]] = []
         if language is not None:
-            knn["filter"] = {"term": {"language": str(language)}}
+            filter_clauses.append({"term": {"language": str(language)}})
+        keyword_filter = _build_keyword_filter(includes, search_mode, excludes)
+        if keyword_filter is not None:
+            filter_clauses.append(keyword_filter)
+        if filter_clauses:
+            knn["filter"] = {"bool": {"filter": filter_clauses}}
+
         body: Dict[str, Any] = {"size": size, "_source": False, "query": {"knn": {"embedding": knn}}}
 
         try:

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from birdxplorer_api.semantic_search import SemanticSearchUnavailableError
-from birdxplorer_common.models import Note
+from birdxplorer_common.models import Note, TextSearchMode
 from birdxplorer_common.settings import GlobalSettings
 
 
@@ -85,6 +85,27 @@ def test_similar_returns_404_when_not_indexed(client: TestClient, mock_semantic_
 
 def test_similar_returns_422_for_invalid_note_id(client: TestClient) -> None:
     assert client.get("/api/v1/data/search/similar/not-a-note-id").status_code == 422
+
+
+def test_semantic_search_passes_keyword_filters(client: TestClient, mock_semantic_search: MagicMock) -> None:
+    response = client.get(
+        "/api/v1/data/search/semantic?q=test"
+        "&note_includes_text=%E5%8C%BB%E7%99%82&note_includes_text=%E6%94%BF%E6%B2%BB"
+        "&note_search_mode=and&note_excludes_text=%E3%83%87%E3%83%9E"
+    )
+    assert response.status_code == 200
+    kwargs = mock_semantic_search.knn_search.call_args.kwargs
+    assert kwargs["includes"] == ["医療", "政治"]
+    assert kwargs["search_mode"].value == "and"
+    assert kwargs["excludes"] == ["デマ"]
+
+
+def test_semantic_search_defaults_no_keywords(client: TestClient, mock_semantic_search: MagicMock) -> None:
+    client.get("/api/v1/data/search/semantic?q=test")
+    kwargs = mock_semantic_search.knn_search.call_args.kwargs
+    assert kwargs["includes"] is None
+    assert kwargs["excludes"] is None
+    assert kwargs["search_mode"] == TextSearchMode.OR
 
 
 def test_semantic_search_returns_503_when_not_configured(

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -96,7 +96,7 @@ def test_semantic_search_passes_keyword_filters(client: TestClient, mock_semanti
     assert response.status_code == 200
     kwargs = mock_semantic_search.knn_search.call_args.kwargs
     assert kwargs["includes"] == ["医療", "政治"]
-    assert kwargs["search_mode"].value == "and"
+    assert kwargs["search_mode"] == TextSearchMode.AND
     assert kwargs["excludes"] == ["デマ"]
 
 

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -157,7 +157,9 @@ class TestKnnSearch:
         kw_bool = flt["bool"]["filter"][0]["bool"]
         assert "should" not in kw_bool
         assert len(kw_bool["must"]) == 2
-        assert kw_bool["must"][0] == {"multi_match": {"query": "医療", "fields": ["text.ja", "text.en"]}}
+        assert kw_bool["must"][0] == {
+            "multi_match": {"query": "医療", "fields": ["text.ja", "text.en"], "operator": "and"}
+        }
 
     def test_includes_or_mode_builds_should_with_msm(self) -> None:
         service, _, os_client = _service_with_mocks()
@@ -181,7 +183,9 @@ class TestKnnSearch:
         kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][0][
             "bool"
         ]
-        assert kw_bool["must_not"] == [{"multi_match": {"query": "デマ", "fields": ["text.ja", "text.en"]}}]
+        assert kw_bool["must_not"] == [
+            {"multi_match": {"query": "デマ", "fields": ["text.ja", "text.en"], "operator": "and"}}
+        ]
 
     def test_language_and_includes_combined(self) -> None:
         service, _, os_client = _service_with_mocks()

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -13,7 +13,7 @@ from birdxplorer_api.semantic_search import (
     SemanticSearchUnavailableError,
     gen_semantic_search_service,
 )
-from birdxplorer_common.models import LanguageCode, NoteId
+from birdxplorer_common.models import LanguageCode, NoteId, TextSearchMode
 
 
 def _service_with_mocks() -> tuple[SemanticSearchService, MagicMock, MagicMock]:
@@ -145,7 +145,63 @@ class TestKnnSearch:
         service.knn_search([0.1] * 3, limit=5, language=LanguageCode.from_str("ja"))
 
         body = os_client.search.call_args.kwargs["body"]
-        assert body["query"]["knn"]["embedding"]["filter"] == {"term": {"language": "ja"}}
+        assert body["query"]["knn"]["embedding"]["filter"] == {"bool": {"filter": [{"term": {"language": "ja"}}]}}
+
+    def test_includes_and_mode_builds_must(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search([0.1] * 3, limit=5, includes=["医療", "政治"], search_mode=TextSearchMode.AND)
+
+        flt = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]
+        kw_bool = flt["bool"]["filter"][0]["bool"]
+        assert "should" not in kw_bool
+        assert len(kw_bool["must"]) == 2
+        assert kw_bool["must"][0] == {"multi_match": {"query": "医療", "fields": ["text.ja", "text.en"]}}
+
+    def test_includes_or_mode_builds_should_with_msm(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search([0.1] * 3, limit=5, includes=["医療", "政治"], search_mode=TextSearchMode.OR)
+
+        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][
+            0
+        ]["bool"]
+        assert len(kw_bool["should"]) == 2
+        assert kw_bool["minimum_should_match"] == 1
+        assert "must" not in kw_bool
+
+    def test_excludes_builds_must_not(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search([0.1] * 3, limit=5, excludes=["デマ"])
+
+        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][
+            0
+        ]["bool"]
+        assert kw_bool["must_not"] == [{"multi_match": {"query": "デマ", "fields": ["text.ja", "text.en"]}}]
+
+    def test_language_and_includes_combined(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search(
+            [0.1] * 3, limit=5, language=LanguageCode.from_str("ja"), includes=["医療"], search_mode=TextSearchMode.OR
+        )
+
+        clauses = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"]
+        assert {"term": {"language": "ja"}} in clauses
+        assert any("bool" in c for c in clauses)
+
+    def test_empty_keywords_ignored(self) -> None:
+        service, _, os_client = _service_with_mocks()
+        os_client.search.return_value = {"hits": {"hits": []}}
+
+        service.knn_search([0.1] * 3, limit=5, includes=["", "  "], excludes=[""])
+
+        assert "filter" not in os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]
 
     def test_excludes_self(self) -> None:
         """exclude_note_id 指定時は k を1つ増やして取得し、自分自身を除外して limit 件に切り詰める"""

--- a/api/tests/test_semantic_search_service.py
+++ b/api/tests/test_semantic_search_service.py
@@ -165,9 +165,9 @@ class TestKnnSearch:
 
         service.knn_search([0.1] * 3, limit=5, includes=["医療", "政治"], search_mode=TextSearchMode.OR)
 
-        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][
-            0
-        ]["bool"]
+        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][0][
+            "bool"
+        ]
         assert len(kw_bool["should"]) == 2
         assert kw_bool["minimum_should_match"] == 1
         assert "must" not in kw_bool
@@ -178,9 +178,9 @@ class TestKnnSearch:
 
         service.knn_search([0.1] * 3, limit=5, excludes=["デマ"])
 
-        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][
-            0
-        ]["bool"]
+        kw_bool = os_client.search.call_args.kwargs["body"]["query"]["knn"]["embedding"]["filter"]["bool"]["filter"][0][
+            "bool"
+        ]
         assert kw_bool["must_not"] == [{"multi_match": {"query": "デマ", "fields": ["text.ja", "text.en"]}}]
 
     def test_language_and_includes_combined(self) -> None:


### PR DESCRIPTION
## 概要
OpenSearch のセマンティック（ベクトル/曖昧）検索 `/search/semantic` に、検索フォームと同じ
**AND/OR キーワードのハードフィルタ**を追加する。ベクトル類似度による並び順は維持したまま、
「必ず含む/除外する」キーワードで絞り込めるようにする（ハイブリッド検索）。

## 背景
- セマンティック検索は純粋な kNN ベクトル検索のみで、キーワード指定ができなかった。
- OpenSearch `notes` インデックスには既に kuromoji(ja)/english(en) アナライザ付きの全文検索用
  `text` フィールドがあり、**再インデックス不要**で語単位の全文検索が可能。

## 変更内容
- `SemanticSearchService.knn_search` に `includes` / `search_mode`(or/and) / `excludes` を追加。
  kNN の `filter` に「言語 term ＋ キーワード bool」を結合（AND=must / OR=should+minimum_should_match / 除外=must_not）。
  マッチは `text.ja`/`text.en` への語単位 `multi_match`。**スコアはベクトル類似度のみ**（キーワードはハードフィルタ）。
- `/search/semantic` に `note_includes_text`(繰り返し) / `note_search_mode` / `note_excludes_text` を追加。
  パラメータ名・型は既存 `/search` に統一。`q` は引き続き必須。
- `openapi_doc.py` を更新（既存の doc 変数を流用）。

## 後方互換性
- キーワード未指定時は**従来と完全に同一挙動**（`filter` を付けない）。`/search/similar` も不変。
- 唯一の内部変更: 言語のみ指定時のフィルタ形状が `{"term":...}` → `{"bool":{"filter":[{"term":...}]}}` に変化（**機能等価**、既存テストを新形状に更新）。
- DBスキーマ変更・マイグレーション・再インデックス・依存追加は**なし**。

## テスト
- `test_semantic_search_service.py` / `tests/routers/test_semantic_search.py` にAND/OR/除外/言語併用/空キーワード/パラメータ伝播のテストを追加。
- `api` tox green（157 passed）、`common` tox green（126 passed）。

## 関連
- MCP 側 `bx_semantic_search` の対応 PR を別途作成（BirdXplorer_mcp）。
- フロント（BirdXplorer_Viewer）の検索フォーム対応と orval 再生成は別途フォローアップ。
