### PR TITLE
feat: エンゲージメント指標(インプレッション/いいね/リポスト)でのソートを追加

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -568,11 +568,24 @@ v1_data_post_includes_media = FastAPIEndpointParamDocs(
 )
 
 v1_data_search_sort_field = FastAPIEndpointParamDocs(
-    description="ソート対象のフィールド。",
+    description="ソート対象のフィールド。note_created_at のほか、"
+    "impression_count / like_count / repost_count（エンゲージメント降順で注目度順に取得）が指定可能。",
     openapi_examples={
         "note_created_at": {
             "summary": "ノート作成日時でソート",
             "value": "note_created_at",
+        },
+        "impression_count": {
+            "summary": "インプレッション数でソート（注目度順）",
+            "value": "impression_count",
+        },
+        "like_count": {
+            "summary": "いいね数でソート",
+            "value": "like_count",
+        },
+        "repost_count": {
+            "summary": "リポスト数でソート",
+            "value": "repost_count",
         },
     },
 )

--- a/api/tests/routers/test_search.py
+++ b/api/tests/routers/test_search.py
@@ -455,8 +455,8 @@ def test_search_sort_by_impression(client: TestClient, mock_storage: MagicMock) 
     response = client.get("/api/v1/data/search?sort_field=impression_count&sort_order=desc")
     assert response.status_code == 200
     kwargs = mock_storage.search_notes_with_posts.call_args.kwargs
-    assert str(kwargs["sort_field"].value) == "impression_count"
-    assert str(kwargs["sort_order"].value) == "desc"
+    assert kwargs["sort_field"].value == "impression_count"
+    assert kwargs["sort_order"].value == "desc"
 
 
 def test_search_invalid_sort_field_422(client: TestClient) -> None:

--- a/api/tests/routers/test_search.py
+++ b/api/tests/routers/test_search.py
@@ -448,6 +448,21 @@ def test_search_count_accepts_non_enum_language(client: TestClient, mock_storage
     assert call_kwargs.kwargs["language"] == "zh"
 
 
+def test_search_sort_by_impression(client: TestClient, mock_storage: MagicMock) -> None:
+    mock_storage.search_notes_with_posts.return_value = SearchResultPage(items=[], has_next=False)
+    mock_storage.count_search_results.return_value = 0
+
+    response = client.get("/api/v1/data/search?sort_field=impression_count&sort_order=desc")
+    assert response.status_code == 200
+    kwargs = mock_storage.search_notes_with_posts.call_args.kwargs
+    assert str(kwargs["sort_field"].value) == "impression_count"
+    assert str(kwargs["sort_order"].value) == "desc"
+
+
+def test_search_invalid_sort_field_422(client: TestClient) -> None:
+    assert client.get("/api/v1/data/search?sort_field=not_a_field").status_code == 422
+
+
 def test_search_returns_non_enum_language(client: TestClient, mock_storage: MagicMock) -> None:
     """検索結果に enum 外の言語コード(zh)が含まれていてもシリアライズできる。"""
     timestamp = TwitterTimestamp.from_int(int(datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp() * 1000))

--- a/common/birdxplorer_common/models.py
+++ b/common/birdxplorer_common/models.py
@@ -748,6 +748,9 @@ class SearchSortField(str, Enum):
     """Fields available for sorting search results"""
 
     NOTE_CREATED_AT = "note_created_at"
+    IMPRESSION_COUNT = "impression_count"
+    LIKE_COUNT = "like_count"
+    REPOST_COUNT = "repost_count"
 
 
 class TextSearchMode(str, Enum):

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Generator, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, Generator, List, NamedTuple, Optional, Tuple, Union
 
 from psycopg2.extensions import AsIs, register_adapter
 from pydantic import AnyUrl, HttpUrl
@@ -1720,9 +1720,20 @@ class Storage:
 
         return query
 
-    _SEARCH_SORT_FIELD_MAP = {
+    _SEARCH_SORT_FIELD_MAP: dict[SearchSortField, Callable[[], Any]] = {
         SearchSortField.NOTE_CREATED_AT: lambda: NoteRecord.created_at,
+        SearchSortField.IMPRESSION_COUNT: lambda: PostRecord.impression_count,
+        SearchSortField.LIKE_COUNT: lambda: PostRecord.like_count,
+        SearchSortField.REPOST_COUNT: lambda: PostRecord.repost_count,
     }
+
+    _POST_SORT_FIELDS: frozenset[SearchSortField] = frozenset(
+        {
+            SearchSortField.IMPRESSION_COUNT,
+            SearchSortField.LIKE_COUNT,
+            SearchSortField.REPOST_COUNT,
+        }
+    )
 
     @staticmethod
     def _has_post_filters(
@@ -1832,6 +1843,11 @@ class Storage:
                 # Two-phase query: collect note_ids first (lightweight), then fetch full data
                 column = self._SEARCH_SORT_FIELD_MAP[sort_field]()
                 order_expr = column.asc() if sort_order == SortOrder.ASC else column.desc()
+                if sort_field in self._POST_SORT_FIELDS:
+                    # Notes with no linked post (NULL engagement) must not float to the top on DESC
+                    order_expr = order_expr.nullslast()
+                # Deterministic secondary sort key to stabilise pagination on tied values
+                tiebreak = NoteRecord.note_id.asc() if sort_order == SortOrder.ASC else NoteRecord.note_id.desc()
 
                 if has_post_filters:
                     # Phase 1: note_id only with full JOINs for filtering
@@ -1862,8 +1878,10 @@ class Storage:
                         post_search_mode,
                     )
                 else:
-                    # Phase 1: note_id only, no JOINs needed
+                    # Phase 1: note_id only. Post-based sort fields require a PostRecord join even without filters.
                     id_query = sess.query(NoteRecord.note_id).select_from(NoteRecord)
+                    if sort_field in self._POST_SORT_FIELDS:
+                        id_query = id_query.outerjoin(PostRecord, NoteRecord.post_id == PostRecord.post_id)
                     id_query = self._apply_note_only_filters(
                         id_query,
                         note_includes_texts,
@@ -1876,14 +1894,14 @@ class Storage:
                         note_search_mode,
                     )
 
-                note_subq = id_query.order_by(order_expr).offset(offset).limit(limit + 1).subquery()
+                note_subq = id_query.order_by(order_expr, tiebreak).offset(offset).limit(limit + 1).subquery()
 
                 # Phase 2: fetch full data for matched note_ids only
                 query = (
                     sess.query(NoteRecord, PostRecord)
                     .join(note_subq, NoteRecord.note_id == note_subq.c.note_id)
                     .outerjoin(PostRecord, NoteRecord.post_id == PostRecord.post_id)
-                    .order_by(order_expr)
+                    .order_by(order_expr, tiebreak)
                 )
             else:
                 # No sorting: standard path

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -5,7 +5,14 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
-from birdxplorer_common.models import LanguageCode, Note, Post, SearchSortField, SortOrder, TopicId
+from birdxplorer_common.models import (
+    LanguageCode,
+    Note,
+    Post,
+    SearchSortField,
+    SortOrder,
+    TopicId,
+)
 from birdxplorer_common.storage import (
     NoteRecord,
     PostRecord,

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -486,19 +486,64 @@ def test_sort_tiebreak_stability(
     note_records_sample: List[NoteRecord],
     post_records_sample: List[PostRecord],
 ) -> None:
-    """Tiebreak: paging over tied impression values must not duplicate or lose note_ids."""
-    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    """Tiebreak: paging over tied impression values must produce exact deterministic order.
+
+    Seeds 4 notes that ALL share impression_count=77 (value absent from fixture data).
+    For IMPRESSION DESC + note_id DESC tiebreak the expected order is:
+        6300000000000000004, 6300000000000000003, 6300000000000000002, 6300000000000000001
+    Paging with limit=2 must yield exactly that split across two pages with no duplicates
+    or omissions.  If the note_id tiebreak were absent the DB is free to return any order
+    for equal impressions, so the exact-order assertion would fail non-deterministically.
+    """
+    # 4 notes all with identical impression=77 (unique: fixture posts have impression=30)
+    # note_ids chosen so DESC tiebreak order is 004 > 003 > 002 > 001
+    _TIEBREAK_SPECS: List[tuple[str, str, Optional[int], Optional[int], Optional[int], bool]] = [
+        ("6300000000000000001", "6400000000000000001", 77, 1, 1, True),
+        ("6300000000000000002", "6400000000000000002", 77, 1, 1, True),
+        ("6300000000000000003", "6400000000000000003", 77, 1, 1, True),
+        ("6300000000000000004", "6400000000000000004", 77, 1, 1, True),
+    ]
+    _seed_engagement_data(engine_for_test, _TIEBREAK_SPECS)
+
+    _TIEBREAK_IDS = {s[0] for s in _TIEBREAK_SPECS}
+    # Expected note_id order: impression DESC ties broken by note_id DESC
+    expected_order = [
+        "6300000000000000004",
+        "6300000000000000003",
+        "6300000000000000002",
+        "6300000000000000001",
+    ]
+
     storage = Storage(engine=engine_for_test)
-    # impression=50 appears twice (note 002 and 003); use a narrow window to force pagination
-    page1 = storage.search_notes_with_posts(
+
+    # Fetch with a large limit and filter to the seeded ids to isolate from fixture noise
+    all_results = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=200
+    ).items
+    seeded_ids_in_order = [note.note_id for note, _ in all_results if note.note_id in _TIEBREAK_IDS]
+    assert (
+        seeded_ids_in_order == expected_order
+    ), f"Full-page order mismatch.\n  expected: {expected_order}\n  got:      {seeded_ids_in_order}"
+
+    # Now verify pagination stability: page across the tie boundary with limit=2
+    # page1 must be the first 2 expected ids, page2 must be the remaining 2
+    page1_results = storage.search_notes_with_posts(
         sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=2, offset=0
     ).items
-    page2 = storage.search_notes_with_posts(
+    page1_seeded = [note.note_id for note, _ in page1_results if note.note_id in _TIEBREAK_IDS]
+
+    page2_results = storage.search_notes_with_posts(
         sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=2, offset=2
     ).items
-    page1_ids = {note.note_id for note, _ in page1}
-    page2_ids = {note.note_id for note, _ in page2}
-    assert page1_ids.isdisjoint(page2_ids), f"Duplicate note_ids across pages: {page1_ids & page2_ids}"
+    page2_seeded = [note.note_id for note, _ in page2_results if note.note_id in _TIEBREAK_IDS]
+
+    combined = page1_seeded + page2_seeded
+    assert (
+        set(combined) == _TIEBREAK_IDS
+    ), f"Duplicate or missing note_ids across pages.\n  page1: {page1_seeded}\n  page2: {page2_seeded}"
+    assert (
+        combined == expected_order
+    ), f"Paginated order mismatch.\n  expected: {expected_order}\n  got:      {combined}"
 
 
 def test_sort_without_post_filters(

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -1,11 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 import pytest
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
-from birdxplorer_common.models import LanguageCode, Note, Post, TopicId
+from birdxplorer_common.models import LanguageCode, Note, Post, SearchSortField, SortOrder, TopicId
 from birdxplorer_common.storage import (
     NoteRecord,
     PostRecord,
@@ -336,3 +336,176 @@ def test_search_notes_language_normalization(
     assert len(results) == 1
     note, _ = results[0]
     assert note.language == expected_language
+
+
+# ---------------------------------------------------------------------------
+# Engagement-sort helpers and tests
+# ---------------------------------------------------------------------------
+
+_ENGAGEMENT_USER_ID = "8888888888888888881"
+
+
+def _seed_engagement_data(
+    engine: Engine,
+    specs: List[tuple[str, str, Optional[int], Optional[int], Optional[int], bool]],
+) -> None:
+    """Seed notes and posts with varying engagement values.
+
+    specs = [(note_id, post_id, impression, like, repost, with_post), ...]
+    If with_post is False the PostRecord is omitted so engagement is NULL for that note.
+    An x_user row with _ENGAGEMENT_USER_ID is inserted once as required FK for PostRecord.
+    """
+    with Session(engine) as sess:
+        # Insert a dedicated x_user for these posts (ignore conflict if already exists)
+        sess.execute(
+            text(
+                "INSERT INTO x_users (user_id, name, profile_image, followers_count, following_count) "
+                "VALUES (:user_id, :name, :profile_image, :followers_count, :following_count) "
+                "ON CONFLICT (user_id) DO NOTHING"
+            ),
+            {
+                "user_id": _ENGAGEMENT_USER_ID,
+                "name": "EngagementTestUser",
+                "profile_image": "https://pbs.twimg.com/profile_images/engagement_test/img_normal.jpg",
+                "followers_count": 0,
+                "following_count": 0,
+            },
+        )
+        sess.commit()
+
+    with Session(engine) as sess:
+        for note_id, post_id, impression, like, repost, with_post in specs:
+            if with_post:
+                sess.execute(
+                    text(
+                        "INSERT INTO posts (post_id, user_id, text, created_at, aggregated_at, "
+                        "like_count, repost_count, impression_count) "
+                        "VALUES (:post_id, :user_id, :text, :created_at, :aggregated_at, "
+                        ":like_count, :repost_count, :impression_count) "
+                        "ON CONFLICT (post_id) DO NOTHING"
+                    ),
+                    {
+                        "post_id": post_id,
+                        "user_id": _ENGAGEMENT_USER_ID,
+                        "text": f"engagement test post {post_id}",
+                        "created_at": 1152921600000,
+                        "aggregated_at": 1152921600000,
+                        "like_count": like if like is not None else 0,
+                        "repost_count": repost if repost is not None else 0,
+                        "impression_count": impression if impression is not None else 0,
+                    },
+                )
+            sess.execute(
+                text(
+                    "INSERT INTO notes (note_id, post_id, summary, language, created_at) "
+                    "VALUES (:note_id, :post_id, :summary, :language, :created_at) "
+                    "ON CONFLICT (note_id) DO NOTHING"
+                ),
+                {
+                    "note_id": note_id,
+                    "post_id": post_id if with_post else "9999999999999999000",
+                    "summary": f"engagement sort test note {note_id}",
+                    "language": "en",
+                    "created_at": 1152921600000,
+                },
+            )
+        sess.commit()
+
+
+# Specs shared across several tests:
+# impression=[100, 50, 50, 10, None], like=[5, 20, 20, 1, None], repost=[3, 1, 1, 2, None]
+# note_id ordering chosen so ties are distinguishable: note A < B < C < D, and E has no post
+_ENGAGEMENT_SPECS: List[tuple[str, str, Optional[int], Optional[int], Optional[int], bool]] = [
+    ("6100000000000000001", "6200000000000000001", 100, 5, 3, True),
+    ("6100000000000000002", "6200000000000000002", 50, 20, 1, True),
+    ("6100000000000000003", "6200000000000000003", 50, 20, 1, True),
+    ("6100000000000000004", "6200000000000000004", 10, 1, 2, True),
+    ("6100000000000000005", "6200000000000000005", 0, 0, 0, False),  # no post → NULL engagement
+]
+
+
+def test_sort_by_impression_desc(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Impression DESC: posts with known data should appear in descending order."""
+    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    storage = Storage(engine=engine_for_test)
+    results = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=100
+    ).items
+    impressions = [post.impression_count for _, post in results if post is not None]
+    assert impressions == sorted(impressions, reverse=True)
+
+
+def test_sort_by_like_asc(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Like ASC: posts with known data should appear in ascending order."""
+    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    storage = Storage(engine=engine_for_test)
+    results = storage.search_notes_with_posts(
+        sort_field=SearchSortField.LIKE_COUNT, sort_order=SortOrder.ASC, limit=100
+    ).items
+    likes = [post.like_count for _, post in results if post is not None]
+    assert likes == sorted(likes)
+
+
+def test_sort_nulls_last(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Notes with no linked post (NULL impression) must appear at the end on DESC sort."""
+    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    storage = Storage(engine=engine_for_test)
+    results = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=100
+    ).items
+    # The note with no post should be last among the seeded notes
+    seeded_note_ids = {s[0] for s in _ENGAGEMENT_SPECS}
+    seeded_results = [(note, post) for note, post in results if note.note_id in seeded_note_ids]
+    assert len(seeded_results) == len(_ENGAGEMENT_SPECS)
+    # The last seeded result must be the one with no post
+    last_note, last_post = seeded_results[-1]
+    assert last_post is None, f"Expected NULL-post note last, got post with impression {last_post}"
+
+
+def test_sort_tiebreak_stability(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Tiebreak: paging over tied impression values must not duplicate or lose note_ids."""
+    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    storage = Storage(engine=engine_for_test)
+    # impression=50 appears twice (note 002 and 003); use a narrow window to force pagination
+    page1 = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=2, offset=0
+    ).items
+    page2 = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=2, offset=2
+    ).items
+    page1_ids = {note.note_id for note, _ in page1}
+    page2_ids = {note.note_id for note, _ in page2}
+    assert page1_ids.isdisjoint(page2_ids), f"Duplicate note_ids across pages: {page1_ids & page2_ids}"
+
+
+def test_sort_without_post_filters(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Post-sort without post-side filters must not raise and must return DESC order."""
+    _seed_engagement_data(engine_for_test, _ENGAGEMENT_SPECS)
+    storage = Storage(engine=engine_for_test)
+    # No post filter params supplied → exercises the else-branch with post join
+    results = storage.search_notes_with_posts(
+        sort_field=SearchSortField.IMPRESSION_COUNT, sort_order=SortOrder.DESC, limit=100
+    ).items
+    # Should not raise; impressions of non-null posts must be non-increasing
+    impressions = [post.impression_count for _, post in results if post is not None]
+    assert impressions == sorted(impressions, reverse=True)


### PR DESCRIPTION
## 概要
`/search` の `sort_field` に **`impression_count` / `like_count` / `repost_count`** を追加し、
エンゲージメント降順（＝注目度順）でノートを収集できるようにする（Issue #131）。

Closes #131

## 背景
エンゲージメントの閾値フィルタ（`post_impression_count_from` 等）は既に実装済みだったが、
それらで並べ替えることができず「注目度の高い順トップN」が取得できなかった。
`SearchSortField` は `note_created_at` のみだったため、エンゲージメント指標を追加する。

## 変更内容
- `SearchSortField` に `impression_count`/`like_count`/`repost_count` を追加（common）。
- storage `search_notes_with_posts`:
  - `_SEARCH_SORT_FIELD_MAP` に `PostRecord.impression_count`/`like_count`/`repost_count` を対応付け。
  - post系ソート時は Phase1 でも `PostRecord` を outerjoin（フィルタ無しでもソート可能に）。
  - **NULLS LAST**: ポスト未紐付け（NULLエンゲージメント）ノートが降順で上位に紛れないよう末尾へ。
  - **`note_id` を第2ソートキー**に追加（同値時のページング安定化・両フェーズ同一order）。
- `/search` ルーター本体は変更なし（enum拡張で自動対応）。`openapi_doc` に選択肢の説明/examples追記。
- `/search/count` は変更なし。

## 使用例
```
/search?post_impression_count_from=10000&sort_field=impression_count&sort_order=desc&limit=20
→ 「インプレッション1万以上」を多い順にトップ20
```

## 後方互換性
- `sort_field` 未指定の既存検索は**完全に不変**。返るデータ・件数に影響なし。
- 唯一の可視差分: 既存 `sort_field=note_created_at` に `note_id` タイブレークが付き、
  **作成日時が同値の行の並び順が決定的になる**（結果セットは同一・ページング安定化の改善）。
- DBスキーマ変更・マイグレーション・再インデックス・依存追加は**なし**。

## テスト
- storage: 各指標の降順/昇順、NULLS LAST、タイブレーク安定性（跨ページで正確なID順序を固定検証／
  タイブレークを外すと失敗することを確認）、post未フィルタでのソートを追加。
- `common` tox green（131）、`api` tox green（159）。

## フォローアップ（別リポ）
- MCP `bx_search` の `sort_field` enum 拡張（BirdXplorer_mcp 側で別途対応）。
