### PR TITLE
chore(api): cache-bust to deploy engagement-sort (common@main) to dev

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -63,6 +63,8 @@ dev=[
     "httpx2",
 ]
 prod=[
+    # cache-bust 2026-07-21: force Docker pip-layer rebuild to pull common@main
+    # (engagement-sort enum/storage in common; see Issue #131 / PR #267)
     "birdxplorer_common @ git+https://github.com/codeforjapan/BirdXplorer.git@main#subdirectory=common",
     "psycopg2",
     "gunicorn",


### PR DESCRIPTION
## 概要
engagement-sort（#267 / Issue #131）を **dev に反映させるための cache-bust**。

## 背景（なぜ必要か）
PR #267 は main にマージ済みだが、dev の API では新しい `sort_field`（impression_count 等）が
まだ 422 で拒否される。原因は **API イメージのビルドキャッシュ**:
- API は `common` を `git+…@main` の pip 依存として Docker の `pip install` 層で取得する（`api/Dockerfile`）。
- `deploy-api.yml` は GHA レイヤキャッシュ（`cache-from/to: type=gha`）を使用。
- #267 は `common/` を変えたが `api/pyproject.toml` は不変だったため、**該当 pip 層がキャッシュ再利用され
  （ビルドログで `#10 ... pip install … [prod]` → `CACHED` を確認）**、マージ後の common@main が
  イメージに取り込まれなかった。

## 変更内容
- `api/pyproject.toml` の `common` 依存の直前にコメント2行を追加するのみ（依存内容は不変）。
- これにより `COPY pyproject.toml` 層のハッシュが変わり、後続の pip 層キャッシュが無効化 →
  `common@main`（engagement-sort の enum/storage 入り）が再取得される。
- 新コミット＝新イメージタグとなり、`cdk deploy` が差分検知して ECS を再デプロイする。

## 影響
- 機能・挙動の変更なし（コメント追加のみ）。マージで dev の API が engagement-sort 対応版に更新される。

## フォローアップ（別途・推奨）
恒久対策として、`@main` をマージ SHA 固定にする / common install 層に `ARG CACHEBUST` を入れる /
dev 同様ローカル `common` を COPY する、のいずれかで「common 変更が cache により dev に届かない」問題を根絶する。
