### PR TITLE
ci: common 変更時に API イメージが common@main を自動取得（cache-bust恒久対策）

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -53,6 +53,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            COMMON_CACHEBUST=${{ hashFiles('common/**') }}
 
   deploy-cdk:
     needs: build-and-push

--- a/.github/workflows/release-prd.yml
+++ b/.github/workflows/release-prd.yml
@@ -48,6 +48,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
+          build-args: |
+            COMMON_CACHEBUST=${{ hashFiles('common/**') }}
 
   build-push-etl:
     needs: release

--- a/api/Dockerfile.prd
+++ b/api/Dockerfile.prd
@@ -20,7 +20,12 @@ RUN if [ "${ENVIRONMENT}" = "prod" ]; then \
     && rm -rf /var/lib/apt/lists/*; \
     fi
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。
+# build-arg 未指定(ローカル等)ではデフォルト値のまま＝現状どおりのキャッシュ挙動。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e ".[${ENVIRONMENT}]"
 
 FROM python:${PYTHON_VERSION_CODE}-slim-bookworm AS runner


### PR DESCRIPTION
## 概要
`common` の変更が main にマージされても API イメージに反映されない問題の**恒久対策**。
common が変わった時だけ Docker の pip 層キャッシュを無効化し、`common@main` を自動で取り直す（dev・prod 両方）。

## 背景
API イメージは `common` を `pip install -e ".[prod]"` 層で **git+main** から取得するが、`deploy-api.yml` /
`release-prd.yml` の GHA レイヤキャッシュにより、`common/` だけ変わって `api/pyproject.toml` が不変だと
**pip 層がキャッシュヒットして古い common が残る**（ビルドログ `#12 CACHED`、dev の無フィルタソートが 504 のまま で実証）。
これまで PR #268 のように `api/pyproject.toml` を手動微変更して都度回避していた。

## 変更（3ファイル・9行追加のみ、アプリコード変更なし）
- `api/Dockerfile.prd`: pip install 層直前に `ARG COMMON_CACHEBUST=unset`、RUN 内で `echo` 参照して
  値が変わったら層キャッシュを無効化。build-arg 未指定（ローカル等）はデフォルトで現状挙動維持。
- `.github/workflows/deploy-api.yml`（dev）: `build-args: COMMON_CACHEBUST=${{ hashFiles('common/**') }}`。
- `.github/workflows/release-prd.yml`（prod）: 同上（prod も同じ Dockerfile.prd＋GHAキャッシュで同じ問題のため）。

## 効果
- **common 変更時のみ** pip 層を再実行 → common@main を取得。**api 単体変更はキャッシュヒットで従来どおり高速**。
- 手動 cache-bust が不要になる。
- **本PRのマージ自体が、直前にマージ済みの #269（エンゲージメントソート2セグメント高速化）を dev/prd に反映**する
  （Dockerfile.prd の RUN 行変更で層キャッシュキーが変わり、初回ビルドで現行 common@main を取得）。

## 検証（マージ後）
- Deploy API (dev) のビルドログで pip 層が `CACHED` でなく `Cloning …@main` になること。
- dev の無フィルタ `sort_field=impression_count&sort_order=desc` が **サブ秒**（504/60秒が解消）＝#269 反映。

## 補足
- `hashFiles('common/**')` は common 配下（tests 含む）の内容ハッシュ。テストのみの変更でも稀に再ビルドするが、
  「あらゆる common 変更で確実に取り直す」保守的で安全な選択。
