### PR TITLE
ci: common 変更時に ETL イメージが common@main を自動取得（cache-bust）

### DIFF
--- a/.github/workflows/deploy-etl-lambda.yml
+++ b/.github/workflows/deploy-etl-lambda.yml
@@ -71,6 +71,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            COMMON_CACHEBUST=${{ hashFiles('common/**') }}
           provenance: false
 
   deploy-cdk:

--- a/.github/workflows/release-prd.yml
+++ b/.github/workflows/release-prd.yml
@@ -88,6 +88,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            COMMON_CACHEBUST=${{ hashFiles('common/**') }}
           provenance: false
 
   deploy-cdk-prd:

--- a/etl/Dockerfile.db_writer
+++ b/etl/Dockerfile.db_writer
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.embedding
+++ b/etl/Dockerfile.embedding
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.extract
+++ b/etl/Dockerfile.extract
@@ -4,6 +4,10 @@ FROM python:3.12
 
 WORKDIR /app
 
+# build-arg COMMON_CACHEBUST を consume して未使用警告を抑止する（このイメージは COPY で
+# common をローカル取り込みするため機能的には不要。RUN では参照せず挙動不変）。
+ARG COMMON_CACHEBUST=unset
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        gcc \

--- a/etl/Dockerfile.language_detect
+++ b/etl/Dockerfile.language_detect
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 RUN curl -Lo ${LAMBDA_TASK_ROOT}/lid.176.ftz \

--- a/etl/Dockerfile.note_status_update
+++ b/etl/Dockerfile.note_status_update
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.note_transform
+++ b/etl/Dockerfile.note_transform
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.post_transform
+++ b/etl/Dockerfile.post_transform
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.postlookup
+++ b/etl/Dockerfile.postlookup
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.realtime_notes_extraction
+++ b/etl/Dockerfile.realtime_notes_extraction
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.report_generator
+++ b/etl/Dockerfile.report_generator
@@ -2,6 +2,10 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# build-arg COMMON_CACHEBUST を consume して未使用警告を抑止する（このイメージは COPY で
+# common をローカル取り込みするため機能的には不要。RUN では参照せず挙動不変）。
+ARG COMMON_CACHEBUST=unset
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev gcc \
     && rm -rf /var/lib/apt/lists/*

--- a/etl/Dockerfile.search_index_writer
+++ b/etl/Dockerfile.search_index_writer
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー

--- a/etl/Dockerfile.topic_detect
+++ b/etl/Dockerfile.topic_detect
@@ -10,7 +10,11 @@ RUN dnf update -y && \
 
 COPY etl/. .
 
+# common@main を確実に取り込むためのキャッシュバスト。CI が common/ の内容ハッシュを
+# COMMON_CACHEBUST に注入し、common が変わった時だけこの層を再実行する。未指定時は現状どおり。
+ARG COMMON_CACHEBUST=unset
 RUN python -m pip install --no-cache-dir --upgrade pip && \
+    echo "common-cachebust: ${COMMON_CACHEBUST}" && \
     pip install --no-cache-dir -e .[prod]
 
 # Lambda関数のコードをコピー


### PR DESCRIPTION
## 概要
ETL の Lambda イメージ（git+main で common を取り込む10個）が、`common` 変更時に `common@main` を
自動で取り直すようにする **cache-bust 恒久対策**。API 側の PR #270 の ETL 版。

## 背景
ETL イメージのうち以下10個は `pip install -e .[prod]` 経由で `birdxplorer_common @ git+…@main`
（`etl/pyproject.toml` の `[prod]`）を取得するが、`deploy-etl-lambda.yml` / `release-prd.yml`(build-push-etl)
の GHA レイヤキャッシュにより、`common` だけ変わって `etl/pyproject.toml` が不変だと **pip 層がキャッシュヒットして
古い common が残る**（API #270 と同じ機構）:
`embedding` / `note_transform` / `db_writer` / `language_detect` / `topic_detect` / `postlookup` /
`post_transform` / `note_status_update` / `realtime_notes_extraction` / `search_index_writer`。
（`extract` / `report_generator` は `COPY common` でローカル取り込みのため元々問題なし。）

## 緊急度
直近の common 変更（#267/#269 の検索）は API 側で、ETL の挙動には影響しない＝**現状 ETL に実害なし（latent）**。
将来 ETL が使う common（models/storage 等）を変えた時のための恒久対策。

## 変更（14ファイル・設定のみ、アプリコード/テスト/pyproject 変更なし）
- git+main 型 10 Dockerfile: pip install 層直前に `ARG COMMON_CACHEBUST=unset`、RUN 内で `echo` 参照。
- COPY 型 2 Dockerfile（extract / report_generator）: `ARG COMMON_CACHEBUST=unset` 宣言のみ（未使用 build-arg 警告抑止・挙動不変）。
- `.github/workflows/deploy-etl-lambda.yml`（dev）/ `.github/workflows/release-prd.yml`（build-push-etl）:
  `build-args: COMMON_CACHEBUST=${{ hashFiles('common/**') }}`。

## 効果
- 10イメージが **common 変更時のみ** `.[prod]` の @main を再取得。common 不変ならキャッシュヒットで従来どおり高速。
- 手動 cache-bust が不要に。API(#270)＋本PR で dev/prd 全イメージが common 追従。

## 検証（マージ後）
- Deploy ETL Lambda のビルドログで、common 変更を含むデプロイ時に該当層が `CACHED` でなく common 再取得になること。
- common 不変デプロイではキャッシュヒット維持。

## 関連
- API 側: #270（同機構・独立・並行）。
- 将来の根絶案（B: `etl/pyproject` から `@main` を廃し全 ETL を COPY 統一）は別タスク候補。
