### PR TITLE
fix: エンゲージメントソートの seg0 から NULLS LAST を外し索引駆動に（サブ秒化, #131）

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1971,10 +1971,12 @@ class Storage:
             if sort_field is not None:
                 # Two-phase query: collect note_ids first (lightweight), then fetch full data
                 column = self._SEARCH_SORT_FIELD_MAP[sort_field]()
-                order_expr = column.asc() if sort_order == SortOrder.ASC else column.desc()
+                seg0_order_expr = column.asc() if sort_order == SortOrder.ASC else column.desc()
+                order_expr = seg0_order_expr
                 if sort_field in self._POST_SORT_FIELDS:
-                    # Notes with no linked post (NULL engagement) must not float to the top on DESC
-                    order_expr = order_expr.nullslast()
+                    # Phase 2 outer-joins posts: post-less (NULL engagement) notes must sort last
+                    # seg0 is INNER JOIN so NULLs are impossible there — do not use nullslast on seg0
+                    order_expr = seg0_order_expr.nullslast()
                 # Deterministic secondary sort key to stabilise pagination on tied values
                 tiebreak = NoteRecord.note_id.asc() if sort_order == SortOrder.ASC else NoteRecord.note_id.desc()
 
@@ -1982,7 +1984,7 @@ class Storage:
                     # 2セグメント: seg0(ポスト有り・索引駆動 INNER JOIN) + seg1(ポスト無し・末尾)
                     seg0_ordered, seg0_for_count, seg1_ordered = self._build_post_sort_segments(
                         sess,
-                        order_expr,
+                        seg0_order_expr,
                         tiebreak,
                         has_post_filters,
                         note_includes_texts,

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.engine import Engine
@@ -969,3 +969,52 @@ def test_deep_page_count_branch_end_to_end(
     assert returned_ids.isdisjoint(
         _SEG_WITH_POST_IDS
     ), f"With-post note_ids must not appear at deep offset; found {returned_ids & _SEG_WITH_POST_IDS}"
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: seg0 order_expr must NOT contain NULLS LAST
+# Bug: search_notes_with_posts was passing nullslast() order_expr to
+# _build_post_sort_segments, preventing Postgres from using ix_posts_* btree
+# index (DESC scan is NULLS FIRST, so NULLS LAST forces Seq Scan + Sort).
+# seg0 is an INNER JOIN so NULLs are impossible; nullslast is both wrong and
+# harmful there.  Phase 2 outer-join MUST still use nullslast (to sort
+# post-less notes last), which is NOT tested here but verified by the
+# behavioral tests above (test_engagement_sort_with_post_desc_then_postless_last,
+# test_sort_nulls_last, etc.).
+# ---------------------------------------------------------------------------
+
+
+def test_seg0_order_expr_has_no_nulls_last(
+    engine_for_test: Engine,
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Regression guard: the order_expr passed to _build_post_sort_segments must NOT
+    contain NULLS LAST, so Postgres can use the ix_posts_* btree index on seg0.
+
+    Intercepts the call to _build_post_sort_segments, captures order_expr, compiles
+    it to SQL, and asserts 'NULLS LAST' is absent.  RED before the fix (caller was
+    passing the nullslast()-annotated expr); GREEN after (caller passes the plain
+    desc()/asc() expr, reserving nullslast for Phase 2 only).
+    """
+    storage = Storage(engine=engine_for_test)
+    captured: list[Any] = []
+
+    real_build = storage._build_post_sort_segments
+
+    def capturing_build(sess: Any, order_expr: Any, *args: Any, **kwargs: Any) -> Any:
+        captured.append(order_expr)
+        return real_build(sess, order_expr, *args, **kwargs)
+
+    with patch.object(storage, "_build_post_sort_segments", side_effect=capturing_build):
+        storage.search_notes_with_posts(
+            sort_field=SearchSortField.IMPRESSION_COUNT,
+            sort_order=SortOrder.DESC,
+            limit=10,
+        )
+
+    assert len(captured) == 1, "Expected _build_post_sort_segments to be called exactly once"
+    compiled_sql = str(captured[0].compile()).upper()
+    assert "NULLS LAST" not in compiled_sql, (
+        f"seg0 order_expr must NOT contain NULLS LAST (prevents ix_posts_* index use); " f"got: {compiled_sql}"
+    )


### PR DESCRIPTION
## 概要
エンゲージメント順ソート（#269 の2セグメント方式）が**目標のサブ秒に達していなかった**バグの修正。
seg0 のソートに付いていた `NULLS LAST` が `ix_posts_impression_count` 索引を無効化していたのを外す。

## 原因（dev の EXPLAIN ANALYZE で確定）
#269 は seg0（`notes INNER JOIN posts`）のソートに `.nullslast()` を適用していた。btree 索引の DESC スキャンは
NULLS FIRST 順のため、`ORDER BY impression_count DESC NULLS LAST` では**索引順を使えず全 posts を Seq Scan + Sort** に
落ちていた（dev 実測: 無フィルタで ~28〜60秒）。
- `... DESC NULLS LAST` → Seq Scan + external-merge Sort
- `... DESC`（NULLS LAST 無し）→ `Index Scan Backward using ix_posts_impression_count` = **0.13ms**

seg0 は INNER join なのでメトリクスは NULL にならず、`nullslast` は不要かつ有害だった。

## 修正
- `search_notes_with_posts` のソートを2式に分離:
  - `seg0_order_expr`（プレーン `desc()/asc()`・NULLS LAST 無し）→ seg0 のPhase1順（索引駆動に戻る）。
  - `order_expr = seg0_order_expr.nullslast()` → **Phase 2 用**（outer-join で post無し=NULL を末尾に置くため維持）。
- `note_created_at` / ノーソート経路は不変。
- **結果（並び順）は同一**（seg0 は NULL 無し）。純粋な実行計画/性能の修正。

## テスト
- 回帰ガード `test_seg0_order_expr_has_no_nulls_last`: seg0 に渡るソート式の SQL に `NULLS LAST` が無いことを検証
  （現行コードで RED → 修正で GREEN）。
- 既存の挙動テスト（post無し末尾・境界跨ぎ・昇順・フィルタ）は緑のまま。
- `common` tox green（143 passed）。
- 既知の Minor: ガードテストは DESC のみ（ASC は挙動テストでカバー。ASC の nullslast は inner join では無害）。

## デプロイ
`common` 変更。#270（API cache-bust）がマージ済みのため、本PRのマージで **API イメージが自動で新 common を取り込み dev/prd 反映**される見込み。マージ後に dev で無フィルタソートがサブ秒になることを確認予定。

Fixes: #131 の性能目標（#269 の未達分）。
