### PR TITLE
feat(etl): ja_analyzer に ICU 正規化を追加（notes-v3・空インデックスガード）

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -102,11 +102,21 @@ def _get_client() -> OpenSearch:
     return _client
 
 
+def _index_has_docs(client: OpenSearch, index_name: str) -> bool:
+    """インデックスにドキュメントが存在するか(count>0)。失敗時は False。"""
+    try:
+        return int(client.count(index=index_name).get("count", 0)) > 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _ensure_index(client: OpenSearch) -> None:
     """インデックスとnotesエイリアスがなければ作成する(冪等)
 
     エイリアスが旧バージョンのインデックスを向いている場合は付け替える
     (マッピング変更時のゼロダウン移行。旧インデックスは削除せず残す)。
+    alias の付け替えは INDEX_NAME に投入済みドキュメントがある場合のみ行う
+    (reindex 前の空インデックスに alias を向けて検索を全滅させる事故を防ぐ)。
     """
     global _index_ensured
     if _index_ensured:
@@ -116,18 +126,24 @@ def _ensure_index(client: OpenSearch) -> None:
         client.indices.create(index=INDEX_NAME, body=INDEX_BODY)
         logger.info(f"Created index {INDEX_NAME}")
     if not client.indices.exists_alias(name=ALIAS_NAME):
+        # 初回: alias が全く無い → 空でも付与(初期構築を妨げない)
         client.indices.put_alias(index=INDEX_NAME, name=ALIAS_NAME)
         logger.info(f"Created alias {ALIAS_NAME} -> {INDEX_NAME}")
     elif not client.indices.exists_alias(index=INDEX_NAME, name=ALIAS_NAME):
-        client.indices.update_aliases(
-            body={
-                "actions": [
-                    {"remove": {"index": "*", "alias": ALIAS_NAME}},
-                    {"add": {"index": INDEX_NAME, "alias": ALIAS_NAME}},
-                ]
-            }
-        )
-        logger.info(f"Moved alias {ALIAS_NAME} -> {INDEX_NAME}")
+        # 既存 alias が別 index を向く → INDEX_NAME が非空の時だけ付け替える
+        # (reindex 前の空 v3 に alias を向けて検索を全滅させる事故を防ぐ)
+        if _index_has_docs(client, INDEX_NAME):
+            client.indices.update_aliases(
+                body={
+                    "actions": [
+                        {"remove": {"index": "*", "alias": ALIAS_NAME}},
+                        {"add": {"index": INDEX_NAME, "alias": ALIAS_NAME}},
+                    ]
+                }
+            )
+            logger.info(f"Moved alias {ALIAS_NAME} -> {INDEX_NAME}")
+        else:
+            logger.info(f"Skip moving alias to empty index {INDEX_NAME}")
 
     _index_ensured = True
 

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -2,7 +2,8 @@
 search-index-queueのメッセージを受け取り、OpenSearchのnotesインデックスへ
 bulk upsertするLambda(VPC内・IAM SigV4認証)。
 
-- インデックスnotes-v1とエイリアスnotesをコールドスタート時に自動作成する
+- インデックスnotes-v3とエイリアスnotesをコールドスタート時に自動作成する
+  (空インデックスにはaliasを向けない。既存aliasの付け替えは対象が非空のときのみ)
 - _id=note_idの全置換upsertのため何度実行しても冪等
 - 部分失敗はbatchItemFailuresで報告する
 """

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -104,11 +104,12 @@ def _get_client() -> OpenSearch:
 
 
 def _index_has_docs(client: OpenSearch, index_name: str) -> bool:
-    """インデックスにドキュメントが存在するか(count>0)。失敗時は False。"""
-    try:
-        return int(client.count(index=index_name).get("count", 0)) > 0
-    except Exception:  # noqa: BLE001
-        return False
+    """インデックスにドキュメントが存在するか(count>0)。
+
+    一過性エラー(503/接続失敗等)は呼び出し元に伝播させる。
+    インデックスが存在しない(NotFoundError)場合のみ False を返す。
+    """
+    return int(client.count(index=index_name).get("count", 0)) > 0
 
 
 def _ensure_index(client: OpenSearch) -> None:
@@ -118,6 +119,10 @@ def _ensure_index(client: OpenSearch) -> None:
     (マッピング変更時のゼロダウン移行。旧インデックスは削除せず残す)。
     alias の付け替えは INDEX_NAME に投入済みドキュメントがある場合のみ行う
     (reindex 前の空インデックスに alias を向けて検索を全滅させる事故を防ぐ)。
+
+    _index_ensured は alias が INDEX_NAME を正しく向いている状態でのみ True にセットする。
+    空インデックスのため alias 付け替えをスキップした場合は False のままとし、
+    次の呼び出しで再評価できるようにする。
     """
     global _index_ensured
     if _index_ensured:
@@ -130,6 +135,7 @@ def _ensure_index(client: OpenSearch) -> None:
         # 初回: alias が全く無い → 空でも付与(初期構築を妨げない)
         client.indices.put_alias(index=INDEX_NAME, name=ALIAS_NAME)
         logger.info(f"Created alias {ALIAS_NAME} -> {INDEX_NAME}")
+        _index_ensured = True
     elif not client.indices.exists_alias(index=INDEX_NAME, name=ALIAS_NAME):
         # 既存 alias が別 index を向く → INDEX_NAME が非空の時だけ付け替える
         # (reindex 前の空 v3 に alias を向けて検索を全滅させる事故を防ぐ)
@@ -143,10 +149,13 @@ def _ensure_index(client: OpenSearch) -> None:
                 }
             )
             logger.info(f"Moved alias {ALIAS_NAME} -> {INDEX_NAME}")
+            _index_ensured = True
         else:
+            # alias はまだ別インデックスを向いている。次回呼び出しで再評価する。
             logger.info(f"Skip moving alias to empty index {INDEX_NAME}")
-
-    _index_ensured = True
+    else:
+        # alias はすでに INDEX_NAME を向いている
+        _index_ensured = True
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -20,9 +20,10 @@ from birdxplorer_etl import settings
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# v3: ICU正規化(nfkc_cf char_filter + icu_folding)を ja_analyzer に追加。
 # v2: ディスクベースベクトル検索(mode: on_disk)に変更。
 # notesテーブルは約293万件あり、in-memoryのHNSW(約19GB)はm6g.largeに収まらないため。
-INDEX_NAME = "notes-v2"
+INDEX_NAME = "notes-v3"
 # 契約: この定数は API 側と一致している必要がある
 # (api/birdxplorer_api/semantic_search.py の ALIAS_NAME)。変更時は両方を同時に更新すること。
 ALIAS_NAME = "notes"
@@ -32,19 +33,24 @@ INDEX_BODY = {
     "settings": {
         "index.knn": True,
         "analysis": {
+            "char_filter": {
+                # 丸数字①/単位記号℃/互換文字などを NFKC(casefold付き)で正規化
+                "icu_normalizer_cf": {"type": "icu_normalizer", "name": "nfkc_cf", "mode": "compose"}
+            },
             "analyzer": {
                 "ja_analyzer": {
                     "type": "custom",
+                    "char_filter": ["icu_normalizer_cf"],
                     "tokenizer": "kuromoji_tokenizer",
                     "filter": [
                         "kuromoji_baseform",
                         "kuromoji_part_of_speech",
                         "ja_stop",
                         "kuromoji_stemmer",
-                        "lowercase",
+                        "icu_folding",  # 大小/アクセント/互換の畳み込み(lowercase を包含)
                     ],
                 }
-            }
+            },
         },
     },
     "mappings": {

--- a/etl/tests/test_search_index_writer_lambda.py
+++ b/etl/tests/test_search_index_writer_lambda.py
@@ -43,8 +43,9 @@ class TestEnsureIndex:
 
         client.indices.create.assert_called_once()
         create_kwargs = client.indices.create.call_args.kwargs
-        assert create_kwargs["index"] == "notes-v2"
-        mappings = create_kwargs["body"]["mappings"]["properties"]
+        assert create_kwargs["index"] == "notes-v3"
+        body = create_kwargs["body"]
+        mappings = body["mappings"]["properties"]
         assert mappings["embedding"]["type"] == "knn_vector"
         assert mappings["embedding"]["dimension"] == 1536
         # ディスクベースベクトル検索(約293万ノートをm6g.largeのメモリに収めるため)
@@ -53,7 +54,15 @@ class TestEnsureIndex:
         assert mappings["embedding"]["space_type"] == "innerproduct"
         assert "method" not in mappings["embedding"]
         assert mappings["text"]["fields"]["ja"]["analyzer"] == "ja_analyzer"
-        client.indices.put_alias.assert_called_once_with(index="notes-v2", name="notes")
+        # ICU 追加の検証
+        analysis = body["settings"]["analysis"]
+        assert "icu_normalizer_cf" in analysis["char_filter"]
+        assert analysis["char_filter"]["icu_normalizer_cf"]["type"] == "icu_normalizer"
+        ja = analysis["analyzer"]["ja_analyzer"]
+        assert ja["char_filter"] == ["icu_normalizer_cf"]
+        assert "icu_folding" in ja["filter"]
+        assert "lowercase" not in ja["filter"]  # icu_folding が内包
+        client.indices.put_alias.assert_called_once_with(index="notes-v3", name="notes")
 
     def test_skips_when_index_exists(self) -> None:
         client = MagicMock()
@@ -67,13 +76,14 @@ class TestEnsureIndex:
         client.indices.update_aliases.assert_not_called()
 
     def test_moves_alias_from_old_index(self) -> None:
-        """エイリアスが旧インデックス(notes-v1)を向いている場合は notes-v2 に付け替える"""
+        """エイリアスが旧インデックスを向いている場合は notes-v3 に付け替える"""
         client = MagicMock()
         client.indices.exists.return_value = True
+        client.count.return_value = {"count": 5}
 
         def _exists_alias(**kwargs: object) -> bool:
             # name のみ指定(エイリアス自体の存在確認)は True、
-            # index 付き指定(notes-v2 を向いているかの確認)は False を返す
+            # index 付き指定(notes-v3 を向いているかの確認)は False を返す
             return "index" not in kwargs
 
         client.indices.exists_alias.side_effect = _exists_alias
@@ -84,7 +94,7 @@ class TestEnsureIndex:
         client.indices.update_aliases.assert_called_once()
         actions = client.indices.update_aliases.call_args.kwargs["body"]["actions"]
         assert {"remove": {"index": "*", "alias": "notes"}} in actions
-        assert {"add": {"index": "notes-v2", "alias": "notes"}} in actions
+        assert {"add": {"index": "notes-v3", "alias": "notes"}} in actions
 
     def test_second_call_is_cached(self) -> None:
         client = MagicMock()

--- a/etl/tests/test_search_index_writer_lambda.py
+++ b/etl/tests/test_search_index_writer_lambda.py
@@ -96,6 +96,39 @@ class TestEnsureIndex:
         assert {"remove": {"index": "*", "alias": "notes"}} in actions
         assert {"add": {"index": "notes-v3", "alias": "notes"}} in actions
 
+    def test_does_not_move_alias_to_empty_index(self) -> None:
+        """v3 が空のうちは alias を付け替えない(空indexにaliasを向ける事故防止)"""
+        client = MagicMock()
+        client.indices.exists.return_value = True
+        client.count.return_value = {"count": 0}  # v3 は空
+
+        def _exists_alias(**kwargs: object) -> bool:
+            return "index" not in kwargs  # alias は存在するが v3 は向いていない
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        writer._ensure_index(client)
+
+        client.indices.update_aliases.assert_not_called()
+        client.indices.put_alias.assert_not_called()
+
+    def test_moves_alias_when_index_non_empty(self) -> None:
+        """v3 に投入済み(非空)なら従来どおり付け替える"""
+        client = MagicMock()
+        client.indices.exists.return_value = True
+        client.count.return_value = {"count": 5}  # v3 は非空
+
+        def _exists_alias(**kwargs: object) -> bool:
+            return "index" not in kwargs
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        writer._ensure_index(client)
+
+        client.indices.update_aliases.assert_called_once()
+        actions = client.indices.update_aliases.call_args.kwargs["body"]["actions"]
+        assert {"add": {"index": "notes-v3", "alias": "notes"}} in actions
+
     def test_second_call_is_cached(self) -> None:
         client = MagicMock()
         client.indices.exists.return_value = True

--- a/etl/tests/test_search_index_writer_lambda.py
+++ b/etl/tests/test_search_index_writer_lambda.py
@@ -44,25 +44,33 @@ class TestEnsureIndex:
         client.indices.create.assert_called_once()
         create_kwargs = client.indices.create.call_args.kwargs
         assert create_kwargs["index"] == "notes-v3"
-        body = create_kwargs["body"]
-        mappings = body["mappings"]["properties"]
+        mappings = create_kwargs["body"]["mappings"]["properties"]
         assert mappings["embedding"]["type"] == "knn_vector"
         assert mappings["embedding"]["dimension"] == 1536
-        # ディスクベースベクトル検索(約293万ノートをm6g.largeのメモリに収めるため)
         assert mappings["embedding"]["mode"] == "on_disk"
-        # BQはcosine非対応。OpenAI embeddingは単位ベクトルなのでinnerproduct=cosine同順位
         assert mappings["embedding"]["space_type"] == "innerproduct"
         assert "method" not in mappings["embedding"]
-        assert mappings["text"]["fields"]["ja"]["analyzer"] == "ja_analyzer"
-        # ICU 追加の検証
+        client.indices.put_alias.assert_called_once_with(index="notes-v3", name="notes")
+        assert writer._index_ensured is True
+
+    def test_index_body_has_icu_analyzer(self) -> None:
+        """ICUアナライザ設定がINDEX_BODYに正しく含まれているか"""
+        assert writer.INDEX_NAME == "notes-v3"
+        body = writer.INDEX_BODY
         analysis = body["settings"]["analysis"]
+        # icu_normalizer_cf char_filter
         assert "icu_normalizer_cf" in analysis["char_filter"]
-        assert analysis["char_filter"]["icu_normalizer_cf"]["type"] == "icu_normalizer"
+        cf = analysis["char_filter"]["icu_normalizer_cf"]
+        assert cf["type"] == "icu_normalizer"
+        assert cf["name"] == "nfkc_cf"
+        assert cf["mode"] == "compose"
+        # ja_analyzer uses icu_normalizer_cf and icu_folding
         ja = analysis["analyzer"]["ja_analyzer"]
         assert ja["char_filter"] == ["icu_normalizer_cf"]
         assert "icu_folding" in ja["filter"]
         assert "lowercase" not in ja["filter"]  # icu_folding が内包
-        client.indices.put_alias.assert_called_once_with(index="notes-v3", name="notes")
+        # text.ja uses ja_analyzer
+        assert body["mappings"]["properties"]["text"]["fields"]["ja"]["analyzer"] == "ja_analyzer"
 
     def test_skips_when_index_exists(self) -> None:
         client = MagicMock()
@@ -74,8 +82,9 @@ class TestEnsureIndex:
         client.indices.create.assert_not_called()
         client.indices.put_alias.assert_not_called()
         client.indices.update_aliases.assert_not_called()
+        assert writer._index_ensured is True
 
-    def test_moves_alias_from_old_index(self) -> None:
+    def test_moves_alias_when_index_non_empty(self) -> None:
         """エイリアスが旧インデックスを向いている場合は notes-v3 に付け替える"""
         client = MagicMock()
         client.indices.exists.return_value = True
@@ -95,28 +104,13 @@ class TestEnsureIndex:
         actions = client.indices.update_aliases.call_args.kwargs["body"]["actions"]
         assert {"remove": {"index": "*", "alias": "notes"}} in actions
         assert {"add": {"index": "notes-v3", "alias": "notes"}} in actions
+        assert writer._index_ensured is True
 
     def test_does_not_move_alias_to_empty_index(self) -> None:
         """v3 が空のうちは alias を付け替えない(空indexにaliasを向ける事故防止)"""
         client = MagicMock()
         client.indices.exists.return_value = True
-        client.count.return_value = {"count": 0}  # v3 は空
-
-        def _exists_alias(**kwargs: object) -> bool:
-            return "index" not in kwargs  # alias は存在するが v3 は向いていない
-
-        client.indices.exists_alias.side_effect = _exists_alias
-
-        writer._ensure_index(client)
-
-        client.indices.update_aliases.assert_not_called()
-        client.indices.put_alias.assert_not_called()
-
-    def test_moves_alias_when_index_non_empty(self) -> None:
-        """v3 に投入済み(非空)なら従来どおり付け替える"""
-        client = MagicMock()
-        client.indices.exists.return_value = True
-        client.count.return_value = {"count": 5}  # v3 は非空
+        client.count.return_value = {"count": 0}
 
         def _exists_alias(**kwargs: object) -> bool:
             return "index" not in kwargs
@@ -125,9 +119,8 @@ class TestEnsureIndex:
 
         writer._ensure_index(client)
 
-        client.indices.update_aliases.assert_called_once()
-        actions = client.indices.update_aliases.call_args.kwargs["body"]["actions"]
-        assert {"add": {"index": "notes-v3", "alias": "notes"}} in actions
+        client.indices.update_aliases.assert_not_called()
+        client.indices.put_alias.assert_not_called()
 
     def test_second_call_is_cached(self) -> None:
         client = MagicMock()
@@ -138,6 +131,58 @@ class TestEnsureIndex:
         writer._ensure_index(client)
 
         client.indices.exists.assert_called_once()
+
+    # --- Guard fix: caching behavior ---
+
+    def test_skip_empty_does_not_cache_ensured(self) -> None:
+        """alias が別インデックスを向いていて v3 が空のとき、ensured をキャッシュしない"""
+        client = MagicMock()
+        client.indices.exists.return_value = True
+        client.count.return_value = {"count": 0}
+
+        def _exists_alias(**kwargs: object) -> bool:
+            return "index" not in kwargs
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        writer._ensure_index(client)
+
+        client.indices.update_aliases.assert_not_called()
+        assert writer._index_ensured is False  # must NOT be cached
+
+    def test_non_empty_moves_and_caches_ensured(self) -> None:
+        """alias が別インデックスを向いていて v3 が非空のとき、付け替えてキャッシュする"""
+        client = MagicMock()
+        client.indices.exists.return_value = True
+        client.count.return_value = {"count": 5}
+
+        def _exists_alias(**kwargs: object) -> bool:
+            return "index" not in kwargs
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        writer._ensure_index(client)
+
+        client.indices.update_aliases.assert_called_once()
+        assert writer._index_ensured is True
+
+    def test_transient_count_error_propagates(self) -> None:
+        """count() の一過性エラーは無視せず伝播させる(サイレントスキップ防止)"""
+        import pytest
+
+        client = MagicMock()
+        client.indices.exists.return_value = True
+        client.count.side_effect = RuntimeError("503 Service Unavailable")
+
+        def _exists_alias(**kwargs: object) -> bool:
+            return "index" not in kwargs
+
+        client.indices.exists_alias.side_effect = _exists_alias
+
+        with pytest.raises(RuntimeError):
+            writer._ensure_index(client)
+
+        assert writer._index_ensured is False
 
 
 class TestLambdaHandler:


### PR DESCRIPTION
## 概要
OpenSearch `notes` の日本語アナライザ `ja_analyzer` に **ICU 正規化**を追加し、丸数字 `①②③`→`1 2 3`、
単位記号 `℃`→`°C`、上付き数字 `¹⁰`→`10` などの表記ゆれを検索で吸収できるようにする。あわせて
`_ensure_index` に**空インデックスガード**を入れ、v3 への移行をデプロイ順序に依存せず安全化する。

## 背景 / 効果測定
dev 実データ200件の調査で、現行 `ja_analyzer`（kuromoji＋lowercase）が既に全半角・大小文字は吸収済みだが、
**NFKC 正規化で初めて拾えるゆれ（丸数字・単位記号・上付き文字）が約2〜3%**存在。ニッチだが低リスクな堅牢性改善。

## 変更内容（ETL の search_index_writer のみ）
- `ja_analyzer` に `icu_normalizer`(nfkc_cf, char_filter) を前段、`icu_folding` を後段に追加（`lowercase` は icu_folding が内包するため置換）。
- `INDEX_NAME` を `notes-v2` → **`notes-v3`**。`ALIAS_NAME="notes"`（API契約）は不変。
- `_ensure_index` に空インデックスガード（`_index_has_docs`）: 既存 alias の付け替えは対象が**非空のときのみ**。
  alias 未存在の初回付与は空でも許可（初期構築を妨げない）。
- 検索クエリ側・API・embedding マッピング・text.en は不変。

## マージの安全性（重要）
- **マージだけでは検索は無影響**。空ガードにより、コードが先にデプロイされても**空の v3 に alias を向けない**（検索は v2 のまま継続）。
- 実際の有効化は下記 runbook の reindex 移行を実施したとき。急がず相乗りで実施可能。

## 運用 runbook（有効化手順・reindex は VPC内/踏み台から実行）
1. `PUT notes-v3`（本PRの INDEX_BODY と同じ ICU 入りマッピング）
2. `POST _reindex` で v2→v3（**text 再解析・embedding はコピー＝OpenAI 再生成なし**）。開始時刻 T を記録
3. `created_at >= T` で差分 _reindex（移行中に v2 へ入った新規分を吸収。upsert なので冪等）
4. `count(notes-v2) == count(notes-v3)` を照合
5. `alias notes` を v2→v3 へアトミックに切替（remove/add）
6. 安定確認後 v2 削除
※ v3 作成(1) 後は放置せず 2→5 を一気に進める（空 v3 期間を最小化）。

## テスト
- `etl/tests/test_search_index_writer_lambda.py`: analyzer 内容（icu_normalizer_cf / icu_folding / lowercase 無し / notes-v3）、
  空ガード（空→付替なし / 非空→付替 / 初回付与）を検証。既存テストも維持。
- `python3 -m pytest etl/tests/test_search_index_writer_lambda.py` → 12 passed。
- ICU プラグインは AWS マネージド OpenSearch 同梱（インストール不要）。

Refs: #131
