### PR TITLE
feat(etl): search-index writer に一過性エラーの in-lambda リトライを追加

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/search_index_writer_lambda.py
@@ -11,7 +11,8 @@ bulk upsertするLambda(VPC内・IAM SigV4認証)。
 import json
 import logging
 import os
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, List, Tuple
 
 import boto3
 from opensearchpy import AWSV4SignerAuth, OpenSearch, RequestsHttpConnection
@@ -28,6 +29,11 @@ INDEX_NAME = "notes-v3"
 # 契約: この定数は API 側と一致している必要がある
 # (api/birdxplorer_api/semantic_search.py の ALIAS_NAME)。変更時は両方を同時に更新すること。
 ALIAS_NAME = "notes"
+
+# 一過性エラー(リトライで回復しうる)の分類。詳細は _is_transient_item_error 参照。
+TRANSIENT_STATUSES = {429, 503}
+MAX_BULK_RETRIES = 3
+BACKOFF_BASE_SECONDS = 0.5
 
 # spec: 2026-07-08-opensearch-phase2-etl-design.md §7
 INDEX_BODY = {
@@ -158,6 +164,71 @@ def _ensure_index(client: OpenSearch) -> None:
         _index_ensured = True
 
 
+def _is_transient_item_error(item_result: Dict[str, Any]) -> bool:
+    """bulk item のエラーが一過性(リトライで回復しうる)かを判定する。
+
+    - 429(too_many_requests) / 503(unavailable): 一時的 → 一過性
+    - 403 かつ cluster_block 系(ディスク枯渇による read-only ブロック等) → 一過性
+    - それ以外(400 mapping/parse 等) → 恒久
+    """
+    status = item_result.get("status")
+    if status in TRANSIENT_STATUSES:
+        return True
+    if status == 403:
+        error_type = (item_result.get("error") or {}).get("type", "") or ""
+        return "cluster_block" in error_type
+    return False
+
+
+def _bulk_index_docs(client: OpenSearch, docs: List[Tuple[str, str, Dict[str, Any]]]) -> List[str]:
+    """docs を bulk index し、恒久失敗した message_id を返す。
+
+    一過性エラーの item は指数バックオフで最大 MAX_BULK_RETRIES 回再送する。
+    リトライを使い切っても失敗する item・恒久エラーの item の message_id を返す
+    (呼び出し元が batchItemFailures として SQS 再配信させる)。
+    """
+    pending = docs
+    failed: List[str] = []
+
+    for attempt in range(MAX_BULK_RETRIES + 1):
+        bulk_body: List[Dict[str, Any]] = []
+        for _, note_id, doc in pending:
+            bulk_body.append({"index": {"_index": ALIAS_NAME, "_id": note_id}})
+            bulk_body.append(doc)
+
+        response = client.bulk(body=bulk_body)
+
+        if not response.get("errors"):
+            return failed
+
+        items = response.get("items", [])
+        if len(items) != len(pending):
+            # 想定外のbulkレスポンス: 対象全件をSQSに再配信させる
+            logger.error(f"Bulk items count mismatch: expected {len(pending)}, got {len(items)}")
+            failed.extend(message_id for message_id, _, _ in pending)
+            return failed
+
+        retryable: List[Tuple[str, str, Dict[str, Any]]] = []
+        for (message_id, note_id, doc), item in zip(pending, items):
+            result = item.get("index", {})
+            error = result.get("error")
+            if not error:
+                continue
+            if _is_transient_item_error(result) and attempt < MAX_BULK_RETRIES:
+                retryable.append((message_id, note_id, doc))
+            else:
+                logger.error(f"Bulk index error for note {note_id}: {error}")
+                failed.append(message_id)
+
+        if not retryable:
+            return failed
+
+        pending = retryable
+        time.sleep(BACKOFF_BASE_SECONDS * (2**attempt))
+
+    return failed
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     records = event.get("Records", [])
     if not records:
@@ -165,7 +236,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return {"batchItemFailures": []}
 
     batch_item_failures: List[Dict[str, str]] = []
-    docs: List[tuple] = []  # (message_id, note_id, doc)
+    docs: List[Tuple[str, str, Dict[str, Any]]] = []
 
     for record in records:
         message_id = record.get("messageId")
@@ -190,27 +261,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         client = _get_client()
         _ensure_index(client)
-
-        bulk_body: List[Dict[str, Any]] = []
-        for _, note_id, doc in docs:
-            bulk_body.append({"index": {"_index": ALIAS_NAME, "_id": note_id}})
-            bulk_body.append(doc)
-
-        response = client.bulk(body=bulk_body)
-
-        if response.get("errors"):
-            items = response.get("items", [])
-            if len(items) != len(docs):
-                # 想定外のbulkレスポンス: 全件をSQSに再配信させる
-                logger.error(f"Bulk items count mismatch: expected {len(docs)}, got {len(items)}")
-                batch_item_failures.extend({"itemIdentifier": message_id} for message_id, _, _ in docs)
-            else:
-                for (message_id, note_id, _), item in zip(docs, items):
-                    error = item.get("index", {}).get("error")
-                    if error:
-                        logger.error(f"Bulk index error for note {note_id}: {error}")
-                        batch_item_failures.append({"itemIdentifier": message_id})
-
+        batch_item_failures.extend({"itemIdentifier": message_id} for message_id in _bulk_index_docs(client, docs))
     except Exception as e:
         # 接続エラー等の全体失敗: 対象全件をSQSに再配信させる
         logger.error(f"OpenSearch bulk indexing failed: {e}")

--- a/etl/tests/test_search_index_writer_lambda.py
+++ b/etl/tests/test_search_index_writer_lambda.py
@@ -257,3 +257,91 @@ class TestLambdaHandler:
     def test_empty_event_returns_no_failures(self) -> None:
         result = writer.lambda_handler({"Records": []}, None)
         assert result == {"batchItemFailures": []}
+
+    @patch("birdxplorer_etl.lib.lambda_handler.search_index_writer_lambda.time.sleep")
+    @patch.object(writer, "_ensure_index")
+    @patch.object(writer, "_get_client")
+    def test_transient_429_is_retried_then_succeeds(
+        self, mock_get_client: MagicMock, mock_ensure: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """429 の item は再送され、2 回目で成功すれば失敗ゼロ"""
+        client = mock_get_client.return_value
+        client.bulk.side_effect = [
+            {
+                "errors": True,
+                "items": [{"index": {"_id": "n1", "status": 429, "error": {"type": "too_many_requests"}}}],
+            },
+            {"errors": False, "items": [{"index": {"_id": "n1", "status": 200}}]},
+        ]
+
+        result = writer.lambda_handler(_sqs_event([_doc_body("n1")]), None)
+
+        assert result == {"batchItemFailures": []}
+        assert client.bulk.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("birdxplorer_etl.lib.lambda_handler.search_index_writer_lambda.time.sleep")
+    @patch.object(writer, "_ensure_index")
+    @patch.object(writer, "_get_client")
+    def test_transient_503_exhausts_retries_then_fails(
+        self, mock_get_client: MagicMock, mock_ensure: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """503 が続く場合は MAX_BULK_RETRIES+1 回試行して最終的に失敗扱い"""
+        client = mock_get_client.return_value
+        client.bulk.return_value = {
+            "errors": True,
+            "items": [{"index": {"_id": "n1", "status": 503, "error": {"type": "unavailable"}}}],
+        }
+
+        result = writer.lambda_handler(_sqs_event([_doc_body("n1")]), None)
+
+        assert result == {"batchItemFailures": [{"itemIdentifier": "mid-0"}]}
+        assert client.bulk.call_count == writer.MAX_BULK_RETRIES + 1
+
+    @patch("birdxplorer_etl.lib.lambda_handler.search_index_writer_lambda.time.sleep")
+    @patch.object(writer, "_ensure_index")
+    @patch.object(writer, "_get_client")
+    def test_cluster_block_403_is_retried(
+        self, mock_get_client: MagicMock, mock_ensure: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """403 cluster_block(read-only ブロック)は一過性として再送される"""
+        client = mock_get_client.return_value
+        client.bulk.side_effect = [
+            {
+                "errors": True,
+                "items": [{"index": {"_id": "n1", "status": 403, "error": {"type": "cluster_block_exception"}}}],
+            },
+            {"errors": False, "items": [{"index": {"_id": "n1", "status": 200}}]},
+        ]
+
+        result = writer.lambda_handler(_sqs_event([_doc_body("n1")]), None)
+
+        assert result == {"batchItemFailures": []}
+        assert client.bulk.call_count == 2
+
+    @patch("birdxplorer_etl.lib.lambda_handler.search_index_writer_lambda.time.sleep")
+    @patch.object(writer, "_ensure_index")
+    @patch.object(writer, "_get_client")
+    def test_permanent_400_not_retried_only_transient_resent(
+        self, mock_get_client: MagicMock, mock_ensure: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """400(恒久)は即失敗、429(一過性)のみ再送。再送 bulk には n2 のみ含む"""
+        client = mock_get_client.return_value
+        client.bulk.side_effect = [
+            {
+                "errors": True,
+                "items": [
+                    {"index": {"_id": "n1", "status": 400, "error": {"type": "mapper_parsing_exception"}}},
+                    {"index": {"_id": "n2", "status": 429, "error": {"type": "too_many_requests"}}},
+                ],
+            },
+            {"errors": False, "items": [{"index": {"_id": "n2", "status": 200}}]},
+        ]
+
+        result = writer.lambda_handler(_sqs_event([_doc_body("n1"), _doc_body("n2")]), None)
+
+        assert result == {"batchItemFailures": [{"itemIdentifier": "mid-0"}]}
+        assert client.bulk.call_count == 2
+        second_bulk_body = client.bulk.call_args_list[1].kwargs["body"]
+        assert len(second_bulk_body) == 2  # 1 件分(action + doc)
+        assert second_bulk_body[0] == {"index": {"_index": "notes", "_id": "n2"}}


### PR DESCRIPTION
## 概要
notes-v3 切り替え Phase 1（安全網）の一環。`search_index_writer_lambda.py` の bulk per-item エラーを**一過性**と**恒久**に分類し、一過性エラーは単一 invocation 内で指数バックオフ再送する。2026-07-22 のディスク枯渇障害（クラスタ read-only ブロックで bulk 全失敗→DLQ 堆積）の再発被害を軽減する。

## 変更
- `_is_transient_item_error()`: bulk item の status を分類
  - `429`/`503`、および `403` かつ error type に `cluster_block` を含む → **一過性**
  - `400`（mapping/parse 等）など → **恒久**
- `_bulk_index_docs()`: 一過性 item のみ指数バックオフ（`BACKOFF_BASE_SECONDS=0.5` 基点）で最大 `MAX_BULK_RETRIES=3` 回再送。恒久 item は従来どおり即 `batchItemFailures`（SQS 再配信）。恒久/接続エラー/items 件数不一致の既存挙動は不変。

## テスト
- 新規4件（429 リトライ成功 / 503 リトライ枯渇 / 403 cluster_block 分類 / 400 は即失敗で 429 のみ再送）+ 既存全件 = 19/19 passing。black/isort/pflake8 クリーン。TDD（RED→GREEN）。

## 背景・関連
- CDK 側の SQS 再試行窓拡大（BirdXplorer-cdk #26）と容量アラーム（#27）とセットの三重防御。
- マージで CI が dev へ自動デプロイされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)