### PR TITLE
feat(common): add hydrate_notes_with_posts for note_id hydration

### DIFF
--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1930,6 +1930,59 @@ class Storage:
         seg1_offset = max(offset - c0, 0)
         return [r[0] for r in seg1_ordered.offset(seg1_offset).limit(want).all()]
 
+    def _note_record_to_model(self, note_record: NoteRecord) -> NoteModel:
+        return NoteModel(
+            note_id=note_record.note_id,
+            note_author_participant_id=note_record.note_author_participant_id,
+            post_id=_normalize_post_id(note_record.post_id),
+            topics=[
+                TopicModel(topic_id=topic.topic_id, label=topic.topic.label, reference_count=0)
+                for topic in note_record.topics
+            ],
+            language=(LanguageCode(note_record.language) if note_record.language else LanguageCode("other")),
+            summary=note_record.summary,
+            current_status=note_record.current_status,
+            created_at=note_record.created_at,
+            has_been_helpfuled=(
+                note_record.has_been_helpfuled if note_record.has_been_helpfuled is not None else False
+            ),
+            rate_count=note_record.rate_count if note_record.rate_count is not None else 0,
+            helpful_count=note_record.helpful_count if note_record.helpful_count is not None else 0,
+            not_helpful_count=(note_record.not_helpful_count if note_record.not_helpful_count is not None else 0),
+            somewhat_helpful_count=(
+                note_record.somewhat_helpful_count if note_record.somewhat_helpful_count is not None else 0
+            ),
+            current_status_history=self._parse_status_history(note_record.current_status_history),
+        )
+
+    def hydrate_notes_with_posts(
+        self,
+        note_ids: List[NoteId],
+        sort_order: SortOrder = SortOrder.DESC,
+    ) -> List[Tuple[NoteModel, Optional[PostModel]]]:
+        """note_id 群を (NoteModel, PostModel) に本体化する。created_at, note_id で並べる。"""
+        if not note_ids:
+            return []
+        with Session(self.engine) as sess:
+            order_expr = NoteRecord.created_at.asc() if sort_order == SortOrder.ASC else NoteRecord.created_at.desc()
+            tiebreak = NoteRecord.note_id.asc() if sort_order == SortOrder.ASC else NoteRecord.note_id.desc()
+            query = (
+                sess.query(NoteRecord, PostRecord)
+                .outerjoin(PostRecord, NoteRecord.post_id == PostRecord.post_id)
+                .filter(NoteRecord.note_id.in_(note_ids))
+                .order_by(order_expr, tiebreak)
+            )
+            items: List[Tuple[NoteModel, Optional[PostModel]]] = []
+            for note_record, post_record in query.all():
+                try:
+                    note = self._note_record_to_model(note_record)
+                    post = self._post_record_to_model(post_record, with_media=None) if post_record else None
+                    items.append((note, post))
+                except Exception as e:  # noqa: BLE001
+                    get_logger().warning(f"Skipping invalid note/post record (note_id={note_record.note_id}): {str(e)}")
+                    continue
+            return items
+
     def search_notes_with_posts(
         self,
         note_includes_texts: Union[List[str], None] = None,
@@ -2108,37 +2161,7 @@ class Storage:
             items: List[Tuple[NoteModel, Optional[PostModel]]] = []
             for note_record, post_record in results[:limit]:
                 try:
-                    note = NoteModel(
-                        note_id=note_record.note_id,
-                        note_author_participant_id=note_record.note_author_participant_id,
-                        post_id=_normalize_post_id(note_record.post_id),
-                        topics=[
-                            TopicModel(
-                                topic_id=topic.topic_id,
-                                label=topic.topic.label,
-                                reference_count=0,
-                            )
-                            for topic in note_record.topics
-                        ],
-                        language=(
-                            LanguageCode(note_record.language) if note_record.language else LanguageCode("other")
-                        ),
-                        summary=note_record.summary,
-                        current_status=note_record.current_status,
-                        created_at=note_record.created_at,
-                        has_been_helpfuled=(
-                            note_record.has_been_helpfuled if note_record.has_been_helpfuled is not None else False
-                        ),
-                        rate_count=note_record.rate_count if note_record.rate_count is not None else 0,
-                        helpful_count=note_record.helpful_count if note_record.helpful_count is not None else 0,
-                        not_helpful_count=(
-                            note_record.not_helpful_count if note_record.not_helpful_count is not None else 0
-                        ),
-                        somewhat_helpful_count=(
-                            note_record.somewhat_helpful_count if note_record.somewhat_helpful_count is not None else 0
-                        ),
-                        current_status_history=self._parse_status_history(note_record.current_status_history),
-                    )
+                    note = self._note_record_to_model(note_record)
 
                     post = (
                         self._post_record_to_model(post_record, with_media=post_includes_media) if post_record else None

--- a/common/tests/test_search.py
+++ b/common/tests/test_search.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import text
 from birdxplorer_common.models import (
     LanguageCode,
     Note,
+    NoteId,
     Post,
     SearchSortField,
     SortOrder,
@@ -982,6 +983,49 @@ def test_deep_page_count_branch_end_to_end(
 # behavioral tests above (test_engagement_sort_with_post_desc_then_postless_last,
 # test_sort_nulls_last, etc.).
 # ---------------------------------------------------------------------------
+
+
+def test_hydrate_notes_with_posts_empty_input_returns_empty_list(
+    engine_for_test: Engine,
+    note_samples: List[Note],
+    post_samples: List[Post],
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Empty note_ids input must short-circuit to an empty list without querying the DB."""
+    storage = Storage(engine=engine_for_test)
+    result = storage.hydrate_notes_with_posts([], sort_order=SortOrder.DESC)
+    assert result == []
+
+
+def test_hydrate_notes_with_posts_returns_requested_ids_ordered_desc(
+    engine_for_test: Engine,
+    note_samples: List[Note],
+    post_samples: List[Post],
+    note_records_sample: List[NoteRecord],
+    post_records_sample: List[PostRecord],
+) -> None:
+    """Hydrating a set of seeded note_ids returns them as (NoteModel, Optional[PostModel]) pairs,
+    ordered by created_at desc then note_id desc."""
+    storage = Storage(engine=engine_for_test)
+    # note_samples seeds notes with distinct created_at values (see conftest note_samples);
+    # use them all so we can assert full-set membership and ordering.
+    note_ids = [NoteId(note.note_id) for note in note_samples]
+
+    items = storage.hydrate_notes_with_posts(note_ids, sort_order=SortOrder.DESC)
+
+    got_ids = [note.note_id for note, _ in items]
+    assert set(got_ids) == {str(nid) for nid in note_ids}
+
+    keys = [(note.created_at, note.note_id) for note, _ in items]
+    assert keys == sorted(keys, reverse=True)
+
+    # Notes with a valid linked post_id must be hydrated with a PostModel
+    post_ids_with_posts = {post.post_id for post in post_samples}
+    posts_by_note_id = {note.note_id: post for note, post in items}
+    for note in note_samples:
+        if note.post_id in post_ids_with_posts:
+            assert posts_by_note_id[note.note_id] is not None
 
 
 def test_seg0_order_expr_has_no_nulls_last(


### PR DESCRIPTION
## 概要

storage 層に `Storage.hydrate_notes_with_posts(note_ids, sort_order=SortOrder.DESC)` を追加します。note_id の集合を `(NoteModel, Optional[PostModel])` に本体化し、`created_at, note_id` 順に並べて返すメソッドです。

これは後続の API PR（新エンドポイント `GET /api/v1/data/search/keyword` = 広域 note テキスト検索の OpenSearch 化）が呼び出す基盤です。

## なぜ common を先に出すか

`api/pyproject.toml` は `birdxplorer_common` を **git の `main` から** インストールします（`@main#subdirectory=common`）。そのため common と api を1つの PR にまとめると、API の dev デプロイイメージが「このメソッドを持たない main の common」を引いてしまい、新エンドポイントが実行時に失敗します。common をこの PR で先に `main` にマージしてから api PR を出す、という順序にしています。

## 変更内容

- `common/birdxplorer_common/storage.py`
  - `Storage._note_record_to_model()` を抽出（`search_notes_with_posts` のインライン NoteModel 構築と同一。**挙動不変リファクタ**）
  - `Storage.hydrate_notes_with_posts()` を追加（空入力は `[]`、post 無しノートは `post=None`）
- `common/tests/test_search.py`
  - 新メソッドのテスト（空入力・要求 id の返却・`created_at`/`note_id` 降順）

## テスト

`cd common && tox` → `congratulations :)`（black / isort / pflake8 / mypy --strict / pytest すべて緑。既存の `test_search.py` も全緑＝抽出リファクタが挙動不変であることを確認）

## 関連

- 後続: api PR（`keyword_search` + `/search/keyword` エンドポイント）
- 背景: `/api/v1/data/search` の広域 note テキスト検索が Postgres の全走査で 504（ALB idle timeout 60s）になる問題の対策

🤖 Generated with [Claude Code](https://claude.com/claude-code)
