### PR TITLE
feat(api): add /search/keyword endpoint (OpenSearch broad note search + Postgres fallback)

### DIFF
--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -25,7 +25,11 @@ from birdxplorer_api.openapi_doc import (
     V1DataTopicsDocs,
     V1DataUserEnrollmentsDocs,
 )
-from birdxplorer_api.semantic_search import SemanticSearchService
+from birdxplorer_api.semantic_search import (
+    SemanticSearchService,
+    SemanticSearchUnavailableError,
+)
+from birdxplorer_common.logger import get_logger
 from birdxplorer_common.models import (
     BaseModel,
     LanguageCode,
@@ -907,6 +911,88 @@ def gen_router(
         # include_total時はCOUNTベースで判定（従来互換）、それ以外はlimit+1ベース
         has_next = (offset + limit < total_count) if total_count is not None else page.has_next
         return _build_search_response(page.items, has_next, total_count, request, offset, limit)
+
+    @router.get("/search/keyword", description="広域 note テキスト検索（OpenSearch）", response_model=SearchResponse)
+    def search_keyword(
+        request: Request,
+        note_includes_text: List[str] = Query(..., **V1DataSearchDocs.params["note_includes_text"]),
+        note_excludes_text: Union[None, str] = Query(default=None, **V1DataSearchDocs.params["note_excludes_text"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataSearchDocs.params["language"]),
+        note_created_at_from: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataSearchDocs.params["note_created_at_from"]
+        ),
+        note_created_at_to: Union[None, TwitterTimestamp, str] = Query(
+            default=None, **V1DataSearchDocs.params["note_created_at_to"]
+        ),
+        sort_field: Union[SearchSortField, None] = Query(default=None, **V1DataSearchDocs.params["sort_field"]),
+        sort_order: SortOrder = Query(default=SortOrder.DESC, **V1DataSearchDocs.params["sort_order"]),
+        offset: int = Query(default=0, ge=0, **V1DataSearchDocs.params["offset"]),
+        limit: int = Query(default=100, gt=0, le=1000, **V1DataSearchDocs.params["limit"]),
+        include_total: bool = Query(default=True, **V1DataSearchDocs.params["include_total"]),
+        note_search_mode: TextSearchMode = Query(
+            default=TextSearchMode.OR, **V1DataSearchDocs.params["note_search_mode"]
+        ),
+    ) -> SearchResponse:
+        # sort_field はエンゲージメント系を拒否（note_created_at のみ許可）
+        if sort_field is not None and sort_field != SearchSortField.NOTE_CREATED_AT:
+            raise HTTPException(status_code=422, detail="sort_field must be note_created_at for keyword search")
+
+        try:
+            if note_created_at_from is not None and isinstance(note_created_at_from, str):
+                note_created_at_from = ensure_twitter_timestamp(note_created_at_from)
+            if note_created_at_to is not None and isinstance(note_created_at_to, str):
+                note_created_at_to = ensure_twitter_timestamp(note_created_at_to)
+        except OverflowError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        excludes = [note_excludes_text] if note_excludes_text else None
+
+        # OpenSearch 経路（未設定/失敗時は Postgres にフォールバック）
+        if semantic_search is not None:
+            try:
+                note_ids, total = semantic_search.keyword_search(
+                    includes=note_includes_text,
+                    search_mode=note_search_mode,
+                    excludes=excludes,
+                    language=language,
+                    created_at_from=int(note_created_at_from) if note_created_at_from is not None else None,
+                    created_at_to=int(note_created_at_to) if note_created_at_to is not None else None,
+                    sort_order=sort_order.value,
+                    offset=offset,
+                    limit=limit,
+                    track_total=include_total,
+                )
+                has_next = (offset + limit < total) if total is not None else (len(note_ids) > limit)
+                items = storage.hydrate_notes_with_posts(note_ids[:limit], sort_order=sort_order)
+                return _build_search_response(items, has_next, total, request, offset, limit)
+            except SemanticSearchUnavailableError:
+                get_logger().warning("keyword search fell back to postgres")
+
+        # フォールバック: Postgres LIKE
+        page = storage.search_notes_with_posts(
+            note_includes_texts=note_includes_text,
+            note_excludes_text=note_excludes_text,
+            language=language,
+            note_created_at_from=note_created_at_from,
+            note_created_at_to=note_created_at_to,
+            offset=offset,
+            limit=limit,
+            sort_field=sort_field,
+            sort_order=sort_order,
+            note_search_mode=note_search_mode,
+        )
+        total = None
+        if include_total:
+            total = storage.count_search_results(
+                note_includes_texts=note_includes_text,
+                note_excludes_text=note_excludes_text,
+                language=language,
+                note_created_at_from=note_created_at_from,
+                note_created_at_to=note_created_at_to,
+                note_search_mode=note_search_mode,
+            )
+        has_next = (offset + limit < total) if total is not None else page.has_next
+        return _build_search_response(page.items, has_next, total, request, offset, limit)
 
     @router.get(
         "/export/csv",

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -30,12 +30,18 @@ from birdxplorer_common.models import (
     BaseModel,
     LanguageCode,
     LongHttpUrl,
-    Note,
+)
+from birdxplorer_common.models import Note
+from birdxplorer_common.models import Note as NoteModel
+from birdxplorer_common.models import (
     NoteId,
     NoteRequest,
     PaginationMeta,
     ParticipantId,
-    Post,
+)
+from birdxplorer_common.models import Post
+from birdxplorer_common.models import Post as PostModel
+from birdxplorer_common.models import (
     PostId,
     SearchSortField,
     SortOrder,
@@ -418,6 +424,56 @@ def ensure_twitter_timestamp(t: Union[str, TwitterTimestamp]) -> TwitterTimestam
         return timestamp
     except OverflowError:
         raise OverflowError("Timestamp out of range")
+
+
+def _build_search_response(
+    items: List[Tuple[NoteModel, Optional[PostModel]]],
+    has_next: bool,
+    total: Optional[int],
+    request: Request,
+    offset: int,
+    limit: int,
+) -> SearchResponse:
+    results = []
+    for note, post in items:
+        results.append(
+            SearchedNote(
+                noteId=note.note_id,
+                noteAuthorParticipantId=note.note_author_participant_id,
+                language=note.language,
+                topics=note.topics,
+                postId=note.post_id,
+                summary=note.summary,
+                current_status=note.current_status,
+                created_at=note.created_at,
+                has_been_helpfuled=note.has_been_helpfuled,
+                rate_count=note.rate_count,
+                helpful_count=note.helpful_count,
+                not_helpful_count=note.not_helpful_count,
+                somewhat_helpful_count=note.somewhat_helpful_count,
+                current_status_history=[
+                    {"status": history.status, "date": history.date} for history in note.current_status_history
+                ],
+                post=post,
+            )
+        )
+
+    base_url = str(request.url).split("?")[0]
+    query_params = parse_query_string(request.url.query)
+
+    next_url = None
+    if has_next:
+        query_params["offset"] = [str(offset + limit)]
+        query_params["limit"] = [str(limit)]
+        next_url = f"{base_url}?{urlencode(query_params, doseq=True)}"
+
+    prev_url = None
+    if offset > 0:
+        query_params["offset"] = [str(max(offset - limit, 0))]
+        query_params["limit"] = [str(limit)]
+        prev_url = f"{base_url}?{urlencode(query_params, doseq=True)}"
+
+    return SearchResponse(data=results, meta=PaginationMeta(next=next_url, prev=prev_url, total=total))
 
 
 def gen_router(
@@ -824,30 +880,6 @@ def gen_router(
             post_search_mode=post_search_mode,
         )
 
-        results = []
-        for note, post in page.items:
-            results.append(
-                SearchedNote(
-                    noteId=note.note_id,
-                    noteAuthorParticipantId=note.note_author_participant_id,
-                    language=note.language,
-                    topics=note.topics,
-                    postId=note.post_id,
-                    summary=note.summary,
-                    current_status=note.current_status,
-                    created_at=note.created_at,
-                    has_been_helpfuled=note.has_been_helpfuled,
-                    rate_count=note.rate_count,
-                    helpful_count=note.helpful_count,
-                    not_helpful_count=note.not_helpful_count,
-                    somewhat_helpful_count=note.somewhat_helpful_count,
-                    current_status_history=[
-                        {"status": history.status, "date": history.date} for history in note.current_status_history
-                    ],
-                    post=post,
-                )
-            )
-
         # include_total=True のときはCOUNTクエリで総件数を取得（後方互換性のため）
         total_count = None
         if include_total:
@@ -872,28 +904,9 @@ def gen_router(
                 post_search_mode=post_search_mode,
             )
 
-        # ページネーションURL生成
-        base_url = str(request.url).split("?")[0]
-        raw_query = request.url.query
-        query_params = parse_query_string(raw_query)
-
-        next_url = None
         # include_total時はCOUNTベースで判定（従来互換）、それ以外はlimit+1ベース
         has_next = (offset + limit < total_count) if total_count is not None else page.has_next
-        if has_next:
-            next_offset = offset + limit
-            query_params["offset"] = [str(next_offset)]
-            query_params["limit"] = [str(limit)]
-            next_url = f"{base_url}?{urlencode(query_params, doseq=True)}"
-
-        prev_url = None
-        if offset > 0:
-            prev_offset = max(offset - limit, 0)
-            query_params["offset"] = [str(prev_offset)]
-            query_params["limit"] = [str(limit)]
-            prev_url = f"{base_url}?{urlencode(query_params, doseq=True)}"
-
-        return SearchResponse(data=results, meta=PaginationMeta(next=next_url, prev=prev_url, total=total_count))
+        return _build_search_response(page.items, has_next, total_count, request, offset, limit)
 
     @router.get(
         "/export/csv",

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -937,6 +937,10 @@ def gen_router(
         if sort_field is not None and sort_field != SearchSortField.NOTE_CREATED_AT:
             raise HTTPException(status_code=422, detail="sort_field must be note_created_at for keyword search")
 
+        # 空白のみ/空文字だけのキーワードは match_all 化してしまうため拒否する
+        if not any(t and t.strip() for t in note_includes_text):
+            raise HTTPException(status_code=422, detail="note_includes_text must contain at least one non-empty term")
+
         try:
             if note_created_at_from is not None and isinstance(note_created_at_from, str):
                 note_created_at_from = ensure_twitter_timestamp(note_created_at_from)
@@ -969,6 +973,8 @@ def gen_router(
                 get_logger().warning("keyword search fell back to postgres")
 
         # フォールバック: Postgres LIKE
+        # sort_field省略時もOpenSearch経路と同じcreated_at順になるよう明示的に指定する
+        # (Noneのままだとsearch_notes_with_postsは無ソート経路になり、ページネーションが不定順になる)
         page = storage.search_notes_with_posts(
             note_includes_texts=note_includes_text,
             note_excludes_text=note_excludes_text,
@@ -977,7 +983,7 @@ def gen_router(
             note_created_at_to=note_created_at_to,
             offset=offset,
             limit=limit,
-            sort_field=sort_field,
+            sort_field=sort_field if sort_field is not None else SearchSortField.NOTE_CREATED_AT,
             sort_order=sort_order,
             note_search_mode=note_search_mode,
         )

--- a/api/birdxplorer_api/semantic_search.py
+++ b/api/birdxplorer_api/semantic_search.py
@@ -224,6 +224,69 @@ class SemanticSearchService:
             results.append((note_id, float(hit["_score"])))
         return results[:limit]
 
+    def keyword_search(
+        self,
+        includes: List[str],
+        search_mode: TextSearchMode = TextSearchMode.OR,
+        excludes: Optional[List[str]] = None,
+        language: Optional[LanguageCode] = None,
+        created_at_from: Optional[int] = None,
+        created_at_to: Optional[int] = None,
+        sort_order: str = "desc",
+        offset: int = 0,
+        limit: int = 100,
+        track_total: bool = True,
+    ) -> Tuple[List[NoteId], Optional[int]]:
+        """OpenSearch のトークン一致で note_id を created_at, note_id 順に返す。"""
+        keyword_filter = _build_keyword_filter(includes, search_mode, excludes)
+        bool_body: Dict[str, Any] = dict(keyword_filter["bool"]) if keyword_filter else {}
+        filters: List[Dict[str, Any]] = list(bool_body.get("filter", []))
+        if language is not None:
+            filters.append({"term": {"language": str(language)}})
+        if created_at_from is not None or created_at_to is not None:
+            rng: Dict[str, int] = {}
+            if created_at_from is not None:
+                rng["gte"] = int(created_at_from)
+            if created_at_to is not None:
+                rng["lte"] = int(created_at_to)
+            filters.append({"range": {"created_at": rng}})
+        if filters:
+            bool_body["filter"] = filters
+
+        body: Dict[str, Any] = {
+            "size": limit + 1,
+            "from": offset,
+            "_source": False,
+            "track_total_hits": bool(track_total),
+            "query": {"bool": bool_body},
+            "sort": [{"created_at": {"order": sort_order}}, {"note_id": {"order": sort_order}}],
+        }
+
+        try:
+            response = self._run_with_retry(
+                lambda: self._opensearch.search(index=ALIAS_NAME, body=body),
+                "keyword search",
+            )
+        except Exception as e:  # noqa: BLE001
+            raise SemanticSearchUnavailableError(f"keyword search failed: {e}") from e
+
+        note_ids: List[NoteId] = []
+        for hit in response["hits"]["hits"]:
+            try:
+                note_ids.append(NoteId.from_str(hit["_id"]))
+            except ValidationError:
+                logger.warning(f"skipping invalid note id from search index: {hit['_id']}")
+                continue
+
+        total: Optional[int] = None
+        if track_total:
+            total_obj = response["hits"].get("total")
+            if isinstance(total_obj, dict):
+                total = int(total_obj.get("value", 0))
+            elif isinstance(total_obj, int):
+                total = int(total_obj)
+        return note_ids, total
+
 
 def gen_semantic_search_service(
     settings: Optional[SemanticSearchSettings] = None,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -684,6 +684,16 @@ def mock_storage(
 
     mock.get_number_of_note_requests.side_effect = _get_number_of_note_requests
 
+    def _hydrate_notes_with_posts(
+        note_ids: List[NoteId],
+        sort_order: Any = None,
+    ) -> List[Any]:
+        # note_samples から該当 note を (NoteModel, None) で返す簡易実装
+        by_id = {n.note_id: n for n in note_samples}
+        return [(by_id[nid], None) for nid in note_ids if nid in by_id]
+
+    mock.hydrate_notes_with_posts.side_effect = _hydrate_notes_with_posts
+
     yield mock
 
 
@@ -762,6 +772,7 @@ def mock_semantic_search(note_samples: List[Note]) -> Generator[MagicMock, None,
     mock.embed_query.return_value = [0.1] * 3
     mock.knn_search.return_value = [(note_samples[0].note_id, 0.9), (note_samples[1].note_id, 0.8)]
     mock.get_note_embedding.return_value = [0.2] * 3
+    mock.keyword_search.return_value = ([note_samples[0].note_id, note_samples[1].note_id], 2)
     yield mock
 
 

--- a/api/tests/routers/test_search.py
+++ b/api/tests/routers/test_search.py
@@ -6,7 +6,14 @@ from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 from polyfactory import Use
 
-from birdxplorer_common.models import Note, Post, Topic, TwitterTimestamp, XUser
+from birdxplorer_common.models import (
+    Note,
+    Post,
+    SearchSortField,
+    Topic,
+    TwitterTimestamp,
+    XUser,
+)
 from birdxplorer_common.storage import SearchResultPage
 
 
@@ -539,3 +546,53 @@ def test_search_keyword_falls_back_to_postgres_on_opensearch_error(
     res = client.get("/api/v1/data/search/keyword?note_includes_text=ワクチン&include_total=false")
     assert res.status_code == 200
     assert mock_storage.search_notes_with_posts.called  # Postgres 経路に落ちた
+
+
+def test_search_keyword_fallback_sorts_by_created_at_when_field_omitted(
+    client: TestClient, mock_semantic_search: MagicMock, mock_storage: MagicMock
+) -> None:
+    """OpenSearch障害時のPostgresフォールバックは、sort_field省略時もOpenSearch経路と同じ
+    created_at順になるよう明示的にNOTE_CREATED_ATを渡す（不定順によるページネーション破綻を防ぐ）。"""
+    from birdxplorer_api.semantic_search import SemanticSearchUnavailableError
+
+    mock_semantic_search.keyword_search.side_effect = SemanticSearchUnavailableError("boom")
+    mock_storage.search_notes_with_posts.return_value = SearchResultPage(items=[], has_next=False)
+
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=ワクチン&include_total=false")
+    assert res.status_code == 200
+
+    call_kwargs = mock_storage.search_notes_with_posts.call_args.kwargs
+    assert call_kwargs["sort_field"] == SearchSortField.NOTE_CREATED_AT
+
+
+def test_search_keyword_empty_text_returns_422(client: TestClient) -> None:
+    """note_includes_text= (空文字) は match_all 化を防ぐため422にする。"""
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=")
+    assert res.status_code == 422
+
+
+def test_search_keyword_blank_whitespace_text_returns_422(client: TestClient) -> None:
+    """空白のみのキーワードも同様に422にする。"""
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=%20%20")
+    assert res.status_code == 422
+
+
+def test_search_keyword_sort_field_engagement_returns_422(client: TestClient) -> None:
+    """keyword検索はnote_created_at以外のsort_field(エンゲージメント系)を拒否する。"""
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=test&sort_field=impression_count")
+    assert res.status_code == 422
+
+
+def test_search_keyword_has_next_via_limit_plus_one_sentinel(
+    client: TestClient, mock_semantic_search: MagicMock, mock_storage: MagicMock, note_samples: List[Note]
+) -> None:
+    """include_total=falseのとき、keyword_searchがlimit+1件のnote_idを返せばhas_next=Trueになる。"""
+    limit = 2
+    ids = [note_samples[0].note_id, note_samples[1].note_id, note_samples[2].note_id]  # limit+1件
+    mock_semantic_search.keyword_search.return_value = (ids, None)
+
+    res = client.get(f"/api/v1/data/search/keyword?note_includes_text=test&limit={limit}&include_total=false")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["meta"]["next"] is not None
+    assert len(body["data"]) == limit

--- a/api/tests/routers/test_search.py
+++ b/api/tests/routers/test_search.py
@@ -509,3 +509,33 @@ def test_search_returns_non_enum_language(client: TestClient, mock_storage: Magi
     assert response.status_code == 200
     result = response.json()["data"][0]
     assert result["language"] == "zh"
+
+
+def test_search_keyword_uses_opensearch(
+    client: TestClient, mock_semantic_search: MagicMock, mock_storage: MagicMock
+) -> None:
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=ワクチン&include_total=true")
+    assert res.status_code == 200
+    body = res.json()
+    assert mock_semantic_search.keyword_search.called
+    assert mock_storage.hydrate_notes_with_posts.called
+    assert not mock_storage.search_notes_with_posts.called  # フォールバックしていない
+    assert body["meta"]["total"] == 2
+    assert len(body["data"]) == 2
+
+
+def test_search_keyword_requires_note_text(client: TestClient) -> None:
+    res = client.get("/api/v1/data/search/keyword")
+    assert res.status_code == 422
+
+
+def test_search_keyword_falls_back_to_postgres_on_opensearch_error(
+    client: TestClient, mock_semantic_search: MagicMock, mock_storage: MagicMock
+) -> None:
+    from birdxplorer_api.semantic_search import SemanticSearchUnavailableError
+
+    mock_semantic_search.keyword_search.side_effect = SemanticSearchUnavailableError("boom")
+    mock_storage.search_notes_with_posts.return_value = SearchResultPage(items=[], has_next=False)
+    res = client.get("/api/v1/data/search/keyword?note_includes_text=ワクチン&include_total=false")
+    assert res.status_code == 200
+    assert mock_storage.search_notes_with_posts.called  # Postgres 経路に落ちた

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -184,3 +184,67 @@ def test_keyword_search_no_total_when_track_false(monkeypatch: pytest.MonkeyPatc
     note_ids, total = svc.keyword_search(includes=["x"], track_total=False)
     assert note_ids == []
     assert total is None
+
+
+def test_keyword_search_and_mode_uses_must_not_should(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AND モードでは should ではなく must 句を使う。"""
+    from birdxplorer_api.semantic_search import SemanticSearchService
+    from birdxplorer_common.models import TextSearchMode
+
+    captured: Dict[str, Any] = {}
+
+    class FakeOS:
+        def search(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+            captured["body"] = body
+            return {"hits": {"hits": []}}
+
+    svc = SemanticSearchService.__new__(SemanticSearchService)
+    svc._opensearch = FakeOS()  # type: ignore[assignment]
+    svc.keyword_search(includes=["ワクチン", "河川"], search_mode=TextSearchMode.AND)
+
+    bool_body = captured["body"]["query"]["bool"]
+    assert "must" in bool_body
+    assert len(bool_body["must"]) == 2
+    assert "should" not in bool_body
+    assert "minimum_should_match" not in bool_body
+
+
+def test_keyword_search_excludes_builds_must_not(monkeypatch: pytest.MonkeyPatch) -> None:
+    """excludes は常に must_not 句になる。"""
+    from birdxplorer_api.semantic_search import SemanticSearchService
+
+    captured: Dict[str, Any] = {}
+
+    class FakeOS:
+        def search(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+            captured["body"] = body
+            return {"hits": {"hits": []}}
+
+    svc = SemanticSearchService.__new__(SemanticSearchService)
+    svc._opensearch = FakeOS()  # type: ignore[assignment]
+    svc.keyword_search(includes=["ワクチン"], excludes=["デマ"])
+
+    bool_body = captured["body"]["query"]["bool"]
+    assert bool_body["must_not"] == [
+        {"multi_match": {"query": "デマ", "fields": ["text.ja", "text.en"], "operator": "and"}}
+    ]
+
+
+def test_keyword_search_language_builds_term_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """language を渡すと term フィルタが filter 句に入る。"""
+    from birdxplorer_api.semantic_search import SemanticSearchService
+    from birdxplorer_common.models import LanguageCode
+
+    captured: Dict[str, Any] = {}
+
+    class FakeOS:
+        def search(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+            captured["body"] = body
+            return {"hits": {"hits": []}}
+
+    svc = SemanticSearchService.__new__(SemanticSearchService)
+    svc._opensearch = FakeOS()  # type: ignore[assignment]
+    svc.keyword_search(includes=["ワクチン"], language=LanguageCode.from_str("ja"))
+
+    bool_body = captured["body"]["query"]["bool"]
+    assert {"term": {"language": "ja"}} in bool_body["filter"]

--- a/api/tests/routers/test_semantic_search.py
+++ b/api/tests/routers/test_semantic_search.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import List
+from typing import Any, Dict, List
 from unittest.mock import MagicMock
 
 import pytest
@@ -122,3 +122,65 @@ def test_semantic_search_returns_503_when_not_configured(
         app = gen_app(settings=settings_for_test)
         no_service_client = TestClient(app)
     assert no_service_client.get("/api/v1/data/search/semantic?q=test").status_code == 503
+
+
+def test_keyword_search_builds_query_and_parses_hits(monkeypatch: pytest.MonkeyPatch) -> None:
+    from birdxplorer_api.semantic_search import SemanticSearchService
+    from birdxplorer_common.models import TextSearchMode
+
+    captured: Dict[str, Any] = {}
+
+    class FakeOS:
+        def search(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+            captured["index"] = index
+            captured["body"] = body
+            return {
+                "hits": {
+                    "total": {"value": 42, "relation": "eq"},
+                    "hits": [
+                        {"_id": "1234567890123456789"},
+                    ],
+                }
+            }
+
+    svc = SemanticSearchService.__new__(SemanticSearchService)
+    svc._opensearch = FakeOS()  # type: ignore[assignment]
+    # _run_with_retry をそのまま使う（operation を1回実行するだけ）
+    note_ids, total = svc.keyword_search(
+        includes=["ワクチン", "河川"],
+        search_mode=TextSearchMode.OR,
+        language=None,
+        created_at_from=1000,
+        created_at_to=2000,
+        sort_order="desc",
+        offset=0,
+        limit=20,
+        track_total=True,
+    )
+    body = captured["body"]
+    assert body["from"] == 0
+    assert body["size"] == 21  # limit + 1
+    assert body["track_total_hits"] is True
+    assert body["_source"] is False
+    assert body["sort"] == [{"created_at": {"order": "desc"}}, {"note_id": {"order": "desc"}}]
+    # OR → should + minimum_should_match
+    assert body["query"]["bool"]["should"]
+    assert body["query"]["bool"]["minimum_should_match"] == 1
+    # created_at range が filter に入る
+    assert {"range": {"created_at": {"gte": 1000, "lte": 2000}}} in body["query"]["bool"]["filter"]
+    assert total == 42
+    assert len(note_ids) == 1
+
+
+def test_keyword_search_no_total_when_track_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    from birdxplorer_api.semantic_search import SemanticSearchService
+
+    class FakeOS:
+        def search(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+            return {"hits": {"hits": []}}
+
+    svc = SemanticSearchService.__new__(SemanticSearchService)
+    svc._opensearch = FakeOS()  # type: ignore[assignment]
+    note_ids, total = svc.keyword_search(includes=["x"], track_total=False)
+    assert note_ids == []
+    assert total is None


### PR DESCRIPTION
## 概要

広域 note テキスト検索を OpenSearch で処理する新規エンドポイント `GET /api/v1/data/search/keyword` を追加します。既存 `/api/v1/data/search`（Postgres）は**一切変更しません**（追加のみ）。

### 背景（解決する問題）

`/api/v1/data/search` の広域 note テキスト検索は `notes.summary` に全文検索インデックスが無く `LIKE '%kw%'` の全走査になるため、絞り込みの無いレアキーワード検索が **504（ALB idle timeout 60s）** になります（dev で実測）。一方 OpenSearch の `notes` インデックスは note 本文を kuromoji/ICU でトークン化済みで、同じ検索を ms で返せます。

### 対応方針（最小・ハイブリッド）

- OpenSearch 側は**変更なし**（既存インデックスの `text`/`language`/`created_at` を読むだけ。reindex/ETL 変更なし）。
- 新エンドポイントは「**note テキスト述語があり、topic_ids・note_status・post 系フィルタが無い**」広域検索だけを担当。topic 付き・post 検索・エンゲージメントソートは引き続き `/data/search`（Postgres・既に高速）。
- OpenSearch 障害時は既存 Postgres LIKE 経路に**フォールバック**。

## 変更内容

- `api/birdxplorer_api/semantic_search.py`: `SemanticSearchService.keyword_search()` を追加（OpenSearch トークン一致、`(note_ids, total)` を返す。`_build_keyword_filter` 再利用、`language` term / `created_at` range フィルタ、`created_at,note_id` ソート、`track_total_hits`）
- `api/birdxplorer_api/routers/data.py`: レスポンス構築を `_build_search_response()` に抽出（**挙動不変リファクタ**）し、新エンドポイント `search_keyword()` を追加（OpenSearch→Postgres フォールバック）
- テスト（`test_search.py` / `test_semantic_search.py` / `conftest.py`）

レスポンスは既存 `/data/search` と同じ `SearchResponse`（post 付き）。マッチ意味論は部分文字列一致→トークン一致に変わります（表記ゆらぎに強く、広域と topic 付きで結果集合が若干異なり得る点は仕様として許容）。

## 依存

- **前提 PR（マージ済み）: #276**（common に `hydrate_notes_with_posts` を追加）。api イメージは common を `git@main` から取得するため、common を先行マージ済み。

## テスト

`cd common && tox` / `cd api && tox` ともに `congratulations :)`（black/isort/pflake8/mypy --strict/pytest すべて緑）。新エンドポイントのテスト（OpenSearch 経路・必須パラメータ 422・Postgres フォールバック）を追加。

## follow-up（別対応）

- tsukkomi-search 側で「キーワードあり・topic なし」の広域検索を新エンドポイントに切替（別 PR）。
- #1（note∪post の OR 融合）、ALB idleTimeout 延長 / DB statement_timeout は別チケット。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
