### PR TITLE
feat(api,etl): post の言語判定（判定パイプライン＋GET /posts 言語フィルタ＋バックフィル） (#275)

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -218,21 +218,6 @@ Post に紐づいた画像や動画などのメディア情報を取得するか
     },
 }
 
-V1DataPostsDocs = FastAPIEndpointDocs(
-    "Post のデータを取得するエンドポイント",
-    {
-        "post_id": v1_data_posts_post_id,
-        "note_id": v1_data_posts_note_id,
-        "created_at_from": v1_data_posts_created_at_from,
-        "created_at_to": v1_data_posts_created_at_to,
-        "offset": v1_data_posts_offset,
-        "limit": v1_data_posts_limit,
-        "search_text": v1_data_posts_search_text,
-        "search_url": v1_data_posts_search_url,
-        "media": v1_data_posts_media,
-    },
-)
-
 v1_data_notes_note_ids: FastAPIEndpointParamDocs = {
     "description": """
 データを取得する X のコミュニティノートの ID。
@@ -437,6 +422,22 @@ ISO 639-1 に準拠した 2 文字の言語コードを指定することで、�
         },
     },
 }
+
+V1DataPostsDocs = FastAPIEndpointDocs(
+    "Post のデータを取得するエンドポイント",
+    {
+        "post_id": v1_data_posts_post_id,
+        "note_id": v1_data_posts_note_id,
+        "created_at_from": v1_data_posts_created_at_from,
+        "created_at_to": v1_data_posts_created_at_to,
+        "offset": v1_data_posts_offset,
+        "limit": v1_data_posts_limit,
+        "search_text": v1_data_posts_search_text,
+        "search_url": v1_data_posts_search_url,
+        "media": v1_data_posts_media,
+        "language": v1_data_notes_language,
+    },
+)
 
 v1_data_notes_search_text: FastAPIEndpointParamDocs = {
     "description": """

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -588,6 +588,7 @@ def gen_router(
         search_text: Union[None, str] = Query(default=None, **V1DataPostsDocs.params["search_text"]),
         search_url: Union[None, LongHttpUrl] = Query(default=None, **V1DataPostsDocs.params["search_url"]),
         media: bool = Query(default=True, **V1DataPostsDocs.params["media"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataPostsDocs.params["language"]),
     ) -> PostListResponse:
         try:
             if created_at_from is not None and isinstance(created_at_from, str):
@@ -596,6 +597,8 @@ def gen_router(
                 created_at_to = ensure_twitter_timestamp(created_at_to)
         except OverflowError as e:
             raise HTTPException(status_code=422, detail=str(e))
+
+        language_filter: Union[List[str], None] = [language] if language is not None else None
 
         posts = list(
             storage.get_posts(
@@ -609,6 +612,7 @@ def gen_router(
                 offset=offset,
                 limit=limit,
                 with_media=media,
+                language_filter=language_filter,
             )
         )
 
@@ -620,6 +624,7 @@ def gen_router(
             end=created_at_to,
             search_text=search_text,
             search_url=search_url,
+            language_filter=language_filter,
         )
 
         base_url = str(request.url).split("?")[0]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -282,6 +282,7 @@ def post_samples(
 新しいプロジェクトがついに公開されました！詳細はこちら👉
 
 https://t.co/xxxxxxxxxxx/ #プロジェクト #新発売 #Tech""",
+            language="ja",
             media_details=[],
             created_at=1152921600000,
             aggregated_at=1152921600000,
@@ -476,6 +477,7 @@ def mock_storage(
         offset: Union[int, None] = None,
         limit: Union[int, None] = None,
         with_media: bool = True,
+        language_filter: Union[List[str], None] = None,
     ) -> Generator[Post, None, None]:
         gen_count = 0
         actual_gen_count = 0
@@ -503,6 +505,8 @@ def mock_storage(
                 continue
             if search_url is not None and url_id not in [link.link_id for link in post.links]:
                 continue
+            if language_filter is not None and post.language not in language_filter:
+                continue
             gen_count += 1
             if offset is not None and gen_count <= offset:
                 continue
@@ -523,8 +527,15 @@ def mock_storage(
         end: Union[TwitterTimestamp, None] = None,
         search_text: Union[str, None] = None,
         search_url: Union[LongHttpUrl, None] = None,
+        language_filter: Union[List[str], None] = None,
     ) -> int:
-        return len(list(_get_posts(post_ids, note_ids, user_ids, start, end, search_text, search_url)))
+        return len(
+            list(
+                _get_posts(
+                    post_ids, note_ids, user_ids, start, end, search_text, search_url, language_filter=language_filter
+                )
+            )
+        )
 
     mock.get_number_of_posts.side_effect = _get_number_of_posts
 

--- a/api/tests/routers/test_posts_language.py
+++ b/api/tests/routers/test_posts_language.py
@@ -17,4 +17,5 @@ def test_get_posts_filters_by_language(client: TestClient, post_samples: List[Po
 def test_get_posts_without_language_returns_all(client: TestClient, post_samples: List[Post]) -> None:
     resp = client.get("/api/v1/data/posts")
     assert resp.status_code == 200
-    assert resp.json()["meta"]["total"] >= 1
+    body = resp.json()
+    assert body["meta"]["total"] == len(post_samples)

--- a/api/tests/routers/test_posts_language.py
+++ b/api/tests/routers/test_posts_language.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from fastapi.testclient import TestClient
+
+from birdxplorer_common.models import Post
+
+
+def test_get_posts_filters_by_language(client: TestClient, post_samples: List[Post]) -> None:
+    resp = client.get("/api/v1/data/posts?language=ja")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert all(p["language"] == "ja" for p in body["data"])
+    assert body["meta"]["total"] == len(body["data"])
+    assert len(body["data"]) >= 1
+
+
+def test_get_posts_without_language_returns_all(client: TestClient, post_samples: List[Post]) -> None:
+    resp = client.get("/api/v1/data/posts")
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["total"] >= 1

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
@@ -218,12 +218,18 @@ def lambda_handler(event: dict, context: Any) -> dict:
         "Records": [{
             "messageId": "xxx",
             "body": "{
-                \"operation\": \"insert_note\" | \"update_language\" | \"update_topics\" | \"save_post_data\",
-                \"note_id\": \"xxx\",  # insert_note, update_language, update_topicsの場合
-                \"data\": { ... }
+                \"operation\": \"insert_note\" | \"update_language\" | \"update_topics\"
+                              | \"save_post_data\" | \"update_post_language\",
+                \"note_id\": \"xxx\",  # insert_note, update_language, update_topicsの場合に必須
+                \"post_id\": \"xxx\",  # update_post_languageの場合に必須
+                \"data\": { ... }      # update_post_languageの場合は {"language": "xxx"}
             }"
         }]
     }
+
+    save_post_data と update_post_language は note_id を必要としない
+    （save_post_data は data 内に post_id を含む。update_post_language は
+    上記の通り post_id をトップレベルで受け取る）。
     """
     logger.info("=" * 80)
     logger.info("DB Writer Lambda started (batch mode)")

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import insert
 
 from birdxplorer_common.storage import (
     NoteTopicAssociation,
+    PostRecord,
     RowNoteRecord,
     RowPostEmbedURLRecord,
     RowPostMediaRecord,
@@ -61,6 +62,17 @@ def process_update_language(postgresql: Any, note_id: str, data: dict) -> None:
     logger.info(f"[DB_UPDATE] Updating language to '{language}' for note {note_id}")
     postgresql.execute(update(RowNoteRecord).where(RowNoteRecord.note_id == note_id).values(language=language))
     logger.info(f"[STAGED] Language update for note {note_id} staged for commit")
+
+
+def process_update_post_language(postgresql: Any, post_id: str, data: dict) -> None:
+    """post言語更新処理"""
+    language = data.get("language")
+    if not language:
+        raise ValueError(f"Missing language in data: {data}")
+
+    logger.info(f"[DB_UPDATE] Updating language to '{language}' for post {post_id}")
+    postgresql.execute(update(PostRecord).where(PostRecord.post_id == post_id).values(language=language))
+    logger.info(f"[STAGED] Language update for post {post_id} staged for commit")
 
 
 def process_update_topics(postgresql: Any, note_id: str, data: dict) -> None:
@@ -236,6 +248,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
                 operation = message_body.get("operation")
                 note_id = message_body.get("note_id")
+                post_id = message_body.get("post_id")
                 data = message_body.get("data", {})
 
                 if not operation:
@@ -243,8 +256,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     batch_item_failures.append({"itemIdentifier": message_id})
                     continue
 
-                # save_post_data以外はnote_idが必須
-                if operation != "save_post_data" and not note_id:
+                # save_post_data と update_post_language 以外は note_id が必須
+                if operation not in ("save_post_data", "update_post_language") and not note_id:
                     logger.error(f"[ERROR] Missing note_id for operation {operation} in message {message_id}")
                     batch_item_failures.append({"itemIdentifier": message_id})
                     continue
@@ -258,6 +271,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     process_update_topics(postgresql, note_id, data)
                 elif operation == "save_post_data":
                     process_save_post_data(postgresql, data)
+                elif operation == "update_post_language":
+                    process_update_post_language(postgresql, post_id, data)
                 else:
                     logger.error(f"[ERROR] Unknown operation: {operation} in message {message_id}")
                     batch_item_failures.append({"itemIdentifier": message_id})

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/language_detect_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/language_detect_lambda.py
@@ -41,6 +41,9 @@ def lambda_handler(event, context):
         note_id = None
         summary = None
         existing_language = None
+        entity_type = "note"
+        post_id = None
+        text = None
 
         # SQSイベントの場合
         if "Records" in event:
@@ -55,6 +58,12 @@ def lambda_handler(event, context):
                     logger.info(f"Processing type: {processing_type}")
 
                     if processing_type == "language_detect":
+                        entity_type = message_body.get("entity_type", "note")
+                        if entity_type == "post":
+                            post_id = message_body.get("post_id")
+                            text = message_body.get("text")
+                            logger.info(f"Found language_detect message for post_id: {post_id}")
+                            break
                         note_id = message_body.get("note_id")
                         summary = message_body.get("summary")
                         existing_language = message_body.get("language")
@@ -72,6 +81,38 @@ def lambda_handler(event, context):
             note_id = event.get("note_id")
             summary = event.get("summary")
             logger.info(f"Direct invocation for note_id: {note_id}")
+
+        if entity_type == "post":
+            if not (post_id and text):
+                logger.info(f"[SKIP] Empty text or missing post_id for post {post_id}")
+                return {"statusCode": 200, "body": json.dumps({"skipped": True})}
+
+            fasttext_result = detect_language_fasttext(text)
+            if fasttext_result is not None:
+                logger.info(f"[FASTTEXT_HIT] post {post_id}: {fasttext_result} (skipped OpenAI)")
+                detected_language = fasttext_result
+            else:
+                ai_service = get_ai_service()
+                logger.info("[PROCESSING] Calling AI service for language detection...")
+                detected_language = call_ai_api_with_retry(
+                    ai_service.detect_language, text, max_retries=3, initial_delay=1.0
+                )
+
+            db_write_queue_url = os.getenv("DB_WRITE_QUEUE_URL")
+            if not db_write_queue_url:
+                raise Exception("DB_WRITE_QUEUE_URL not configured")
+            message_id = sqs_handler.send_message(
+                queue_url=db_write_queue_url,
+                message_body={
+                    "operation": "update_post_language",
+                    "post_id": post_id,
+                    "data": {"language": detected_language},
+                },
+            )
+            if not message_id:
+                raise Exception(f"Failed to send post language update for post {post_id}")
+            logger.info(f"[SQS_SUCCESS] Sent post language update to db-write queue, messageId={message_id}")
+            return {"statusCode": 200, "body": json.dumps({"post_id": post_id, "language": detected_language})}
 
         if note_id and summary:
             logger.info(f"[START] Detecting language for note: {note_id}")

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
@@ -288,36 +288,49 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 batch_item_failures.append({"itemIdentifier": message_id})
 
         # バッチ全体を1回でコミット
+        commit_ok = False
         try:
             postgresql.commit()
+            commit_ok = True
             success_count = len(event["Records"]) - len(batch_item_failures)
             logger.info(f"[COMMIT] Batch committed successfully: {success_count} messages")
-
-            lang_detect_queue_url = os.environ.get("LANG_DETECT_QUEUE_URL")
-            if lang_detect_queue_url and processed_post_ids:
-                rows = postgresql.execute(
-                    select(PostRecord.post_id, PostRecord.text).where(
-                        PostRecord.post_id.in_(processed_post_ids),
-                        PostRecord.language.is_(None),
-                    )
-                ).all()
-                for row_post_id, row_text in rows:
-                    if not row_text:
-                        continue
-                    sqs_handler.send_message(
-                        queue_url=lang_detect_queue_url,
-                        message_body={
-                            "processing_type": "language_detect",
-                            "entity_type": "post",
-                            "post_id": row_post_id,
-                            "text": row_text,
-                        },
-                    )
         except Exception as e:
             logger.error(f"[ERROR] Batch commit failed: {str(e)}")
             logger.error(traceback.format_exc())
             postgresql.rollback()
             batch_item_failures = [{"itemIdentifier": r.get("messageId", "unknown")} for r in event["Records"]]
+
+        # コミット成功後のlang-detect enqueueは副次処理。ここでの失敗はコミット済み
+        # バッチの再ドライブを引き起こしてはならない（missing languageはbackfillで回復可能）。
+        if commit_ok:
+            try:
+                lang_detect_queue_url = os.environ.get("LANG_DETECT_QUEUE_URL")
+                if lang_detect_queue_url and processed_post_ids:
+                    rows = postgresql.execute(
+                        select(PostRecord.post_id, PostRecord.text).where(
+                            PostRecord.post_id.in_(processed_post_ids),
+                            PostRecord.language.is_(None),
+                        )
+                    ).all()
+                    for row_post_id, row_text in rows:
+                        if not row_text:
+                            continue
+                        message_id = sqs_handler.send_message(
+                            queue_url=lang_detect_queue_url,
+                            message_body={
+                                "processing_type": "language_detect",
+                                "entity_type": "post",
+                                "post_id": row_post_id,
+                                "text": row_text,
+                            },
+                        )
+                        if not message_id:
+                            logger.warning(
+                                f"[LANG_DETECT_ENQUEUE_FAIL] post {row_post_id} not enqueued; "
+                                "recoverable via backfill"
+                            )
+            except Exception as e:
+                logger.warning(f"[LANG_DETECT_ENQUEUE_FAIL] enqueue phase raised, skipping: {str(e)}")
 
         logger.info("=" * 80)
         logger.info(

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/post_transform_lambda.py
@@ -243,6 +243,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
     sqs_handler = SQSHandler()
     queue_url = os.environ.get("POST_TRANSFORM_QUEUE_URL")
     batch_item_failures: list[dict[str, str]] = []
+    processed_post_ids: list[str] = []
 
     try:
         if "Records" not in event:
@@ -275,6 +276,9 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     # 再キュー済みなので正常終了扱い（コミット不要）
                     continue
 
+                if result["status"] == "success":
+                    processed_post_ids.append(post_id)
+
             except json.JSONDecodeError as e:
                 logger.error(f"[ERROR] Failed to parse message {message_id}: {e}")
                 batch_item_failures.append({"itemIdentifier": message_id})
@@ -288,6 +292,27 @@ def lambda_handler(event: dict, context: Any) -> dict:
             postgresql.commit()
             success_count = len(event["Records"]) - len(batch_item_failures)
             logger.info(f"[COMMIT] Batch committed successfully: {success_count} messages")
+
+            lang_detect_queue_url = os.environ.get("LANG_DETECT_QUEUE_URL")
+            if lang_detect_queue_url and processed_post_ids:
+                rows = postgresql.execute(
+                    select(PostRecord.post_id, PostRecord.text).where(
+                        PostRecord.post_id.in_(processed_post_ids),
+                        PostRecord.language.is_(None),
+                    )
+                ).all()
+                for row_post_id, row_text in rows:
+                    if not row_text:
+                        continue
+                    sqs_handler.send_message(
+                        queue_url=lang_detect_queue_url,
+                        message_body={
+                            "processing_type": "language_detect",
+                            "entity_type": "post",
+                            "post_id": row_post_id,
+                            "text": row_text,
+                        },
+                    )
         except Exception as e:
             logger.error(f"[ERROR] Batch commit failed: {str(e)}")
             logger.error(traceback.format_exc())

--- a/etl/src/birdxplorer_etl/run_backfill_post_language.py
+++ b/etl/src/birdxplorer_etl/run_backfill_post_language.py
@@ -1,0 +1,94 @@
+"""既存 posts のうち language 未設定のものを lang-detect-queue へ投入するバックフィルスクリプト。
+
+実行方法 (ECS run-task の containerOverrides で実行する想定):
+    python run_backfill_post_language.py [--limit N] [--offset N] [--sleep SECONDS]
+
+必要な環境変数:
+    LANG_DETECT_QUEUE_URL, DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME
+
+posts.language IS NULL のみを対象とするため、同じ範囲を複数回実行しても安全 (冪等)。
+--sleep でバッチ間に待機し、OpenAI フォールバックのレート制限による DLQ 堆積を防ぐ。
+"""
+
+import argparse
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import select
+
+from birdxplorer_common.storage import PostRecord
+from birdxplorer_etl import settings
+from birdxplorer_etl.lib.lambda_handler.common.sqs_handler import SQSHandler
+from birdxplorer_etl.lib.sqlite.init import init_postgresql
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+FLUSH_SIZE = 100
+
+
+def _build_message(post_id: str, text: str) -> Dict[str, Any]:
+    return {
+        "processing_type": "language_detect",
+        "entity_type": "post",
+        "post_id": post_id,
+        "text": text,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill posts into lang-detect queue")
+    parser.add_argument("--limit", type=int, default=None, help="投入する post 数の上限 (省略時は全件)")
+    parser.add_argument("--offset", type=int, default=None, help="スキップする post 数")
+    parser.add_argument("--sleep", type=float, default=1.0, help="バッチ送信間の待機秒数 (レート制御)")
+    args = parser.parse_args(argv)
+
+    if not settings.LANG_DETECT_QUEUE_URL:
+        logger.error("LANG_DETECT_QUEUE_URL is not set")
+        return 1
+
+    session = init_postgresql(use_pool=True)
+    sqs_handler = SQSHandler()
+
+    query = (
+        select(PostRecord.post_id, PostRecord.text).where(PostRecord.language.is_(None)).order_by(PostRecord.post_id)
+    )
+    if args.offset is not None:
+        query = query.offset(args.offset)
+    if args.limit is not None:
+        query = query.limit(args.limit)
+
+    total_success = 0
+    total_failure = 0
+    buffer: List[Dict[str, Any]] = []
+
+    def _flush() -> None:
+        nonlocal total_success, total_failure, buffer
+        if not buffer:
+            return
+        success, failure = sqs_handler.send_message_batch(settings.LANG_DETECT_QUEUE_URL, buffer)
+        total_success += success
+        total_failure += failure
+        logger.info(f"Progress: {total_success} enqueued, {total_failure} failed")
+        buffer = []
+        if args.sleep > 0:
+            time.sleep(args.sleep)
+
+    try:
+        for post_id, text in session.execute(query.execution_options(yield_per=1000)):
+            if not text:
+                continue
+            buffer.append(_build_message(post_id, text))
+            if len(buffer) >= FLUSH_SIZE:
+                _flush()
+        _flush()
+    finally:
+        session.close()
+
+    logger.info(f"Done: {total_success} enqueued, {total_failure} failed")
+    return 0 if total_failure == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/etl/tests/test_db_writer_lambda.py
+++ b/etl/tests/test_db_writer_lambda.py
@@ -1,7 +1,12 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from birdxplorer_etl.lib.lambda_handler.db_writer_lambda import lambda_handler
+import pytest
+
+from birdxplorer_etl.lib.lambda_handler.db_writer_lambda import (
+    lambda_handler,
+    process_update_post_language,
+)
 
 
 def _make_post_data(
@@ -152,3 +157,44 @@ class TestMediaAndUrlCombined:
 
         # user UPSERT(1) + post UPSERT(1) + media bulk(1) + URL bulk(1) = 4
         assert mock_session.execute.call_count == 4
+
+
+class TestProcessUpdatePostLanguage:
+    """process_update_post_language が posts.language を更新することを検証"""
+
+    def test_process_update_post_language_executes_update(self) -> None:
+        mock_session = MagicMock()
+
+        process_update_post_language(mock_session, "1234567890", {"language": "ja"})
+
+        assert mock_session.execute.call_count == 1
+
+    def test_process_update_post_language_missing_language_raises(self) -> None:
+        mock_session = MagicMock()
+
+        with pytest.raises(ValueError):
+            process_update_post_language(mock_session, "1234567890", {})
+
+
+class TestUpdatePostLanguageDispatch:
+    """update_post_language 操作が note_id なしで拒否されないことを検証"""
+
+    @patch("birdxplorer_etl.lib.lambda_handler.db_writer_lambda.init_postgresql")
+    def test_update_post_language_not_rejected_without_note_id(self, mock_init_pg: MagicMock) -> None:
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        event = {
+            "Records": [
+                {
+                    "messageId": "m1",
+                    "body": json.dumps(
+                        {"operation": "update_post_language", "post_id": "1234567890", "data": {"language": "en"}}
+                    ),
+                }
+            ]
+        }
+        result = lambda_handler(event, {})
+
+        assert result["batchItemFailures"] == []
+        assert mock_session.execute.call_count == 1

--- a/etl/tests/test_language_detect_lambda.py
+++ b/etl/tests/test_language_detect_lambda.py
@@ -49,6 +49,25 @@ def test_post_path_sends_update_post_language(mock_sqs_cls, _mock_ft, monkeypatc
     assert all(m.get("processing_type") != "note_transform" for m in sent)
 
 
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.get_ai_service")
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.detect_language_fasttext", return_value=None)
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.SQSHandler")
+def test_post_path_falls_back_to_ai_service_when_fasttext_misses(
+    mock_sqs_cls, _mock_ft, mock_get_ai_service, monkeypatch
+):
+    monkeypatch.setenv("DB_WRITE_QUEUE_URL", "http://queue/db-write")
+    sqs = mock_sqs_cls.return_value
+    sqs.send_message.return_value = "msg-1"
+    mock_ai_service = mock_get_ai_service.return_value
+    mock_ai_service.detect_language.return_value = "en"
+
+    lambda_handler(_post_event("some text fasttext can't classify"), {})
+
+    mock_ai_service.detect_language.assert_called_once()
+    sent = [c.kwargs["message_body"] for c in sqs.send_message.call_args_list]
+    assert {"operation": "update_post_language", "post_id": "42", "data": {"language": "en"}} in sent
+
+
 @patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.detect_language_fasttext", return_value="ja")
 @patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.SQSHandler")
 def test_post_path_skips_empty_text(mock_sqs_cls, _mock_ft, monkeypatch):

--- a/etl/tests/test_language_detect_lambda.py
+++ b/etl/tests/test_language_detect_lambda.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import patch
+
+from birdxplorer_etl.lib.lambda_handler.language_detect_lambda import lambda_handler
+
+
+def _post_event(text):
+    return {
+        "Records": [
+            {
+                "messageId": "m1",
+                "body": json.dumps(
+                    {"processing_type": "language_detect", "entity_type": "post", "post_id": "42", "text": text}
+                ),
+            }
+        ]
+    }
+
+
+def _note_event():
+    return {
+        "Records": [
+            {
+                "messageId": "m1",
+                "body": json.dumps(
+                    {
+                        "processing_type": "language_detect",
+                        "note_id": "N1",
+                        "summary": "これはノートです",
+                    }
+                ),
+            }
+        ]
+    }
+
+
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.detect_language_fasttext", return_value="ja")
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.SQSHandler")
+def test_post_path_sends_update_post_language(mock_sqs_cls, _mock_ft, monkeypatch):
+    monkeypatch.setenv("DB_WRITE_QUEUE_URL", "http://queue/db-write")
+    sqs = mock_sqs_cls.return_value
+    sqs.send_message.return_value = "msg-1"
+
+    lambda_handler(_post_event("これは日本語のポストです"), {})
+
+    sent = [c.kwargs["message_body"] for c in sqs.send_message.call_args_list]
+    assert {"operation": "update_post_language", "post_id": "42", "data": {"language": "ja"}} in sent
+    # post path must NOT trigger note-transform
+    assert all(m.get("processing_type") != "note_transform" for m in sent)
+
+
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.detect_language_fasttext", return_value="ja")
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.SQSHandler")
+def test_post_path_skips_empty_text(mock_sqs_cls, _mock_ft, monkeypatch):
+    monkeypatch.setenv("DB_WRITE_QUEUE_URL", "http://queue/db-write")
+    sqs = mock_sqs_cls.return_value
+    lambda_handler(_post_event(""), {})
+    sqs.send_message.assert_not_called()
+
+
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.settings")
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.detect_language_fasttext", return_value="ja")
+@patch("birdxplorer_etl.lib.lambda_handler.language_detect_lambda.SQSHandler")
+def test_note_path_still_works_without_entity_type(mock_sqs_cls, _mock_ft, mock_settings, monkeypatch):
+    monkeypatch.setenv("DB_WRITE_QUEUE_URL", "http://queue/db-write")
+    mock_settings.NOTE_TRANSFORM_QUEUE_URL = "http://queue/note-transform"
+    sqs = mock_sqs_cls.return_value
+    sqs.send_message.return_value = "msg-1"
+
+    result = lambda_handler(_note_event(), {})
+
+    assert result["statusCode"] == 200
+    sent = [c.kwargs["message_body"] for c in sqs.send_message.call_args_list]
+    assert {"operation": "update_language", "note_id": "N1", "data": {"language": "ja"}} in sent
+    assert any(m.get("processing_type") == "note_transform" for m in sent)

--- a/etl/tests/test_post_transform_lambda.py
+++ b/etl/tests/test_post_transform_lambda.py
@@ -1,10 +1,24 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from birdxplorer_etl.lib.lambda_handler.post_transform_lambda import (
     lambda_handler,
     select_valid_link_url,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_lang_detect_queue_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """birdxplorer_etl.settings の load_dotenv() が etl/.env から実プロセスへ
+
+    LANG_DETECT_QUEUE_URL を注入してしまうため、既存テストの execute呼び出し回数の
+    前提（post-commitのlang-detect用SELECTが走らないこと）を守るためテスト側で
+    デフォルト未設定状態にリセットする。lang-detect enqueueを検証するテストは
+    自身でmonkeypatch.setenvして明示的に有効化する。
+    """
+    monkeypatch.delenv("LANG_DETECT_QUEUE_URL", raising=False)
 
 
 def _make_row_post(post_id: str = "post_001", author_id: str = "author_001") -> MagicMock:
@@ -69,6 +83,59 @@ def _make_sqs_event(post_id: str = "post_001", retry_count: int = 0) -> dict:
             }
         ]
     }
+
+
+def _transform_event(post_ids: list) -> dict:
+    """複数post_idぶんのtransform_postイベントを生成"""
+    return {
+        "Records": [
+            {
+                "messageId": f"msg-{post_id}",
+                "body": json.dumps(
+                    {
+                        "operation": "transform_post",
+                        "post_id": post_id,
+                        "retry_count": 0,
+                    }
+                ),
+            }
+            for post_id in post_ids
+        ]
+    }
+
+
+@pytest.fixture
+def pg_with_one_null_and_one_set_post():
+    """postA(language NULL)とpostB(language既存)を変換するモックセッション
+
+    process_post_transform を postA→postB の順で2回実行させ、
+    コミット後のlang-detect用SELECTはpostAのみを返す（language IS NULLフィルタを模擬）。
+    """
+    with patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.init_postgresql") as mock_init_pg:
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        row_post_a = _make_row_post(post_id="A", author_id="author_A")
+        row_post_a.text = "text of A"
+        row_user_a = _make_row_user(user_id="author_A")
+        row_post_b = _make_row_post(post_id="B", author_id="author_B")
+        row_post_b.text = "text of B"
+        row_user_b = _make_row_user(user_id="author_B")
+
+        mock_session.execute.return_value.scalar_one_or_none.side_effect = [
+            row_post_a,
+            row_user_a,
+            row_post_b,
+            row_user_b,
+        ]
+        mock_scalars = MagicMock()
+        mock_scalars.all.side_effect = [[], [], [], []]  # postAのmedia/url, postBのmedia/url（すべて空）
+        mock_session.execute.return_value.scalars.return_value = mock_scalars
+
+        # コミット後のlang-detect対象SELECT: languageがNULLのpostAのみ返る
+        mock_session.execute.return_value.all.return_value = [("A", "text of A")]
+
+        yield mock_session
 
 
 class TestMediaBulkInsert:
@@ -291,3 +358,27 @@ class TestInvalidUrlSkipped:
         assert result["batchItemFailures"] == []
         # 有効URLが1件あるので link insert + link assoc insert は実行される = 8 calls
         assert mock_session.execute.call_count == 8
+
+
+class TestLangDetectEnqueue:
+    """コミット後、language IS NULL のpostのみlang-detectキューに積まれることを検証"""
+
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.SQSHandler")
+    def test_enqueues_lang_detect_only_for_null_language(
+        self, mock_sqs_cls: MagicMock, monkeypatch: pytest.MonkeyPatch, pg_with_one_null_and_one_set_post: MagicMock
+    ) -> None:
+        monkeypatch.setenv("LANG_DETECT_QUEUE_URL", "http://queue/lang-detect")
+        sqs = mock_sqs_cls.return_value
+
+        event = _transform_event(["A", "B"])
+        result = lambda_handler(event, {})
+
+        assert result["batchItemFailures"] == []
+        lang_msgs = [
+            c.kwargs["message_body"]
+            for c in sqs.send_message.call_args_list
+            if c.kwargs["message_body"].get("entity_type") == "post"
+        ]
+        assert [m["post_id"] for m in lang_msgs] == ["A"]
+        assert lang_msgs[0]["processing_type"] == "language_detect"
+        assert "text" in lang_msgs[0]

--- a/etl/tests/test_post_transform_lambda.py
+++ b/etl/tests/test_post_transform_lambda.py
@@ -382,3 +382,66 @@ class TestLangDetectEnqueue:
         assert [m["post_id"] for m in lang_msgs] == ["A"]
         assert lang_msgs[0]["processing_type"] == "language_detect"
         assert "text" in lang_msgs[0]
+
+
+class TestLangDetectEnqueueFailureDoesNotReDriveCommittedBatch:
+    """post-commit後のenqueue失敗は、既にコミット済みのバッチを再ドライブしないことを検証
+
+    enqueueはコミット成功後の副次処理であり、失敗してもpostsは既にコミット済み。
+    missing languageはbackfillスクリプトで回復可能なため、batch_item_failuresに
+    積んで全件再ドライブしてはならない。
+    """
+
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.SQSHandler")
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.init_postgresql")
+    def test_enqueue_exception_after_commit_does_not_fail_batch(
+        self, mock_init_pg: MagicMock, mock_sqs_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LANG_DETECT_QUEUE_URL", "http://queue/lang-detect")
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        row_post = _make_row_post(post_id="A", author_id="author_A")
+        row_user = _make_row_user(user_id="author_A")
+        mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
+        mock_scalars = MagicMock()
+        mock_scalars.all.side_effect = [[], []]
+        mock_session.execute.return_value.scalars.return_value = mock_scalars
+        mock_session.execute.return_value.all.return_value = [("A", "text of A")]
+
+        sqs = mock_sqs_cls.return_value
+        sqs.send_message.side_effect = Exception("boom")
+
+        event = _transform_event(["A"])
+        result = lambda_handler(event, {})
+
+        assert result["batchItemFailures"] == []
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()
+
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.SQSHandler")
+    @patch("birdxplorer_etl.lib.lambda_handler.post_transform_lambda.init_postgresql")
+    def test_enqueue_returns_none_does_not_fail_batch(
+        self, mock_init_pg: MagicMock, mock_sqs_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LANG_DETECT_QUEUE_URL", "http://queue/lang-detect")
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        row_post = _make_row_post(post_id="A", author_id="author_A")
+        row_user = _make_row_user(user_id="author_A")
+        mock_session.execute.return_value.scalar_one_or_none.side_effect = [row_post, row_user]
+        mock_scalars = MagicMock()
+        mock_scalars.all.side_effect = [[], []]
+        mock_session.execute.return_value.scalars.return_value = mock_scalars
+        mock_session.execute.return_value.all.return_value = [("A", "text of A")]
+
+        sqs = mock_sqs_cls.return_value
+        sqs.send_message.return_value = None
+
+        event = _transform_event(["A"])
+        result = lambda_handler(event, {})
+
+        assert result["batchItemFailures"] == []
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()

--- a/etl/tests/test_run_backfill_post_language.py
+++ b/etl/tests/test_run_backfill_post_language.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+
+
+@patch("birdxplorer_etl.run_backfill_post_language.SQSHandler")
+@patch("birdxplorer_etl.run_backfill_post_language.init_postgresql")
+def test_enqueues_only_null_language_posts(mock_init, mock_sqs_cls, monkeypatch):
+    monkeypatch.setattr("birdxplorer_etl.run_backfill_post_language.settings.LANG_DETECT_QUEUE_URL", "http://q")
+    session = MagicMock()
+    session.execute.return_value = [("A", "text a"), ("C", "text c")]  # already-NULL rows only
+    mock_init.return_value = session
+    sqs = mock_sqs_cls.return_value
+    sqs.send_message_batch.return_value = (2, 0)
+
+    from birdxplorer_etl.run_backfill_post_language import main
+
+    rc = main(["--sleep", "0"])
+    assert rc == 0
+    batch = sqs.send_message_batch.call_args.args[1]
+    assert [m["post_id"] for m in batch] == ["A", "C"]
+    assert all(m["entity_type"] == "post" and m["processing_type"] == "language_detect" for m in batch)
+
+
+@patch("birdxplorer_etl.run_backfill_post_language.init_postgresql")
+def test_returns_error_when_queue_unset(mock_init, monkeypatch):
+    monkeypatch.setattr("birdxplorer_etl.run_backfill_post_language.settings.LANG_DETECT_QUEUE_URL", None)
+    from birdxplorer_etl.run_backfill_post_language import main
+
+    assert main([]) == 1


### PR DESCRIPTION
## 概要

issue #275「postに言語判定を追加」の **api + etl 部分**です。先行マージ済みの #279（common + migrate）の上に、post 言語判定の判定ロジック・パイプライン配線と API フィルタを追加します。

## データフロー

```
post_transform_lambda : row_posts → posts 変換（commit 成功後）
   └─ language IS NULL の post を lang-detect-queue へ enqueue
        {processing_type:"language_detect", entity_type:"post", post_id, text}
        → language_detect_lambda（VPC外）: fasttext→OpenAI
             → db-write-queue {operation:"update_post_language", post_id, data:{language}}
                  → db_writer_lambda : UPDATE posts SET language
全件バックフィル: run_backfill_post_language.py → 同じ lang-detect-queue へ投入
```

## 変更内容

- **api**: `GET /posts` に `language` クエリ param を追加（既存 `GET /notes` の `language` を踏襲、`common` の `language_filter` に委譲）。
- **etl / db_writer**: `update_post_language` オペレーション追加（`posts.language` を更新）。post_id で引くため note_id ガードを最小限だけ拡張。
- **etl / language_detect_lambda**: `entity_type`（既定 `"note"` で後方互換）で分岐。post 経路は fasttext→OpenAI、空テキストはスキップ、note-transform はトリガしない。note 経路は不変。
- **etl / post_transform_lambda**: 変換 commit 成功後に、`language IS NULL` の post だけを lang-detect-queue へ enqueue。enqueue は commit の外で実行し、送信失敗時は warning ログのみ（バッチ再実行は起こさない。取りこぼしは backfill で回復）。
- **etl / バックフィル**: `run_backfill_post_language.py`（`--limit` / `--offset` / `--sleep`）。`language IS NULL` を対象に冪等、`--sleep` でレート制御。

言語コードは既存 `LanguageCode` 型に委譲（invalid は `"other"` に正規化、notes と同挙動）。

## デプロイ順・依存

- 依存する CDK 変更（post-transform Lambda への `LANG_DETECT_QUEUE_URL` 付与）は #29（BirdXplorer-cdk）で **マージ済み**。
- 反映順は migration → common/api → ETL イメージ → CDK。全件バックフィルは ETL デプロイ後に、小さい `--limit` ＋ 保守的な `--sleep` で開始し、lang-detect / db-write の DLQ を監視しながら広げてください（post と note は lang-detect-queue を共用）。

## テスト

- `cd api && tox` → 174 passed、`congratulations :)`（mypy --strict クリーン）。
- `cd etl && tox` → 249 passed / 4 skipped（既存の X API 資格情報 skip、無関係）、`congratulations :)`。

## レビュー

- api+etl 差分に対する whole-branch レビュー実施 → Ready to merge。指摘された Minor（enqueue を commit 外へ移動＋送信結果チェック、OpenAI フォールバックのテスト追加、db_writer docstring、API テスト強化）は本 PR 内で全て対応済み。

## 関連

- issue #275
- #279（common + migrate、先行マージ済み）
- #29（CDK env、マージ済み）
