### PR TITLE
feat(common): DB クエリに statement_timeout を設定（既定 30 秒） (#278)

### DIFF
--- a/common/birdxplorer_common/settings.py
+++ b/common/birdxplorer_common/settings.py
@@ -19,6 +19,10 @@ class PostgresStorageSettings(BaseSettings):
     password: str
     port: int = 5432
     database: str = "postgres"
+    # 1 クエリの上限時間。ここを超えると PostgreSQL 側でクエリが打ち切られる。
+    # 応答を返したあともクエリが走り続けて CPU とコネクションを占有するのを防ぐ。
+    # 0 を指定すると無制限（PostgreSQL の既定の扱い）。
+    statement_timeout_ms: int = Field(default=30000, ge=0)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/common/birdxplorer_common/settings.py
+++ b/common/birdxplorer_common/settings.py
@@ -23,6 +23,12 @@ class PostgresStorageSettings(BaseSettings):
     # 応答を返したあともクエリが走り続けて CPU とコネクションを占有するのを防ぐ。
     # 0 を指定すると無制限（PostgreSQL の既定の扱い）。
     statement_timeout_ms: int = Field(default=30000, ge=0)
+    # CSV エクスポートだけは上の既定では足りないことがある。前方ワイルドカードの
+    # LIKE + JOIN でインデックスが効かず、仕様上の目標（5,000 件を 10 秒以内、
+    # specs/002-csv-export-api/spec.md SC-001）を大きく外れる可能性があるため。
+    # この経路のトランザクションでだけ statement_timeout を差し替える。
+    # 0 を指定すると無制限だが、公開エンドポイントなので既定は有限値にしている。
+    csv_export_statement_timeout_ms: int = Field(default=120000, ge=0)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -2337,6 +2337,21 @@ class Storage:
             sess.commit()
 
 
-def gen_storage(settings: GlobalSettings) -> Storage:
-    engine = create_engine(settings.storage_settings.sqlalchemy_database_url)
+def gen_storage(settings: GlobalSettings, statement_timeout_ms: Optional[int] = None) -> Storage:
+    """Storage を生成する。
+
+    statement_timeout_ms を省略すると設定値を使う。マイグレーションのように
+    時間のかかる処理では 0 を渡して打ち切りを無効にする。
+    """
+    timeout_ms = (
+        settings.storage_settings.statement_timeout_ms if statement_timeout_ms is None else statement_timeout_ms
+    )
+    if timeout_ms < 0:
+        # 負の値は PostgreSQL が接続時に弾く（FATAL: ... is outside the valid range）ので、
+        # 分かりやすい例外にして接続前に落とす。
+        raise ValueError(f"statement_timeout_ms must be 0 or greater, got {timeout_ms}")
+    engine = create_engine(
+        settings.storage_settings.sqlalchemy_database_url,
+        connect_args={"options": f"-c statement_timeout={timeout_ms}"},
+    )
     return Storage(engine=engine)

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -400,12 +400,17 @@ class CsvExportRow(NamedTuple):
 
 
 class Storage:
-    def __init__(self, engine: Engine) -> None:
+    def __init__(self, engine: Engine, csv_export_statement_timeout_ms: Optional[int] = None) -> None:
         self._engine = engine
+        self._csv_export_statement_timeout_ms = csv_export_statement_timeout_ms
 
     @property
     def engine(self) -> Engine:
         return self._engine
+
+    @property
+    def csv_export_statement_timeout_ms(self) -> Optional[int]:
+        return self._csv_export_statement_timeout_ms
 
     @classmethod
     def _parse_status_history(cls, status_history_json: str) -> List[NoteStatusHistory]:
@@ -2234,6 +2239,27 @@ class Storage:
 
             return query.scalar() or 0
 
+    def _apply_csv_export_statement_timeout(self, sess: Session) -> None:
+        """CSV エクスポートのトランザクションだけ statement_timeout を差し替える。
+
+        `set_config(..., is_local => true)` は `SET LOCAL` と同じ意味で、
+        **そのトランザクションの間だけ**有効。コミット / ロールバックで元に戻るので、
+        コネクションプールへ返したあと別のリクエストが同じコネクションを掴んでも
+        設定は残らない（`SET` を使うと残ってしまう）。
+
+        `SET` 文はバインド変数を取れないため、値を SQL に埋め込まずに渡せる
+        `set_config()` を使っている。
+
+        なお engine を AUTOCOMMIT で作ると 1 文ごとにトランザクションが閉じるため、
+        この差し替えは本体の SELECT へ届かない。`gen_storage` はそうしていない。
+        """
+        if self._csv_export_statement_timeout_ms is None:
+            return
+        sess.execute(
+            text("SELECT set_config('statement_timeout', :timeout_ms, true)"),
+            {"timeout_ms": str(self._csv_export_statement_timeout_ms)},
+        )
+
     def search_notes_with_posts_for_csv(
         self,
         keywords: List[str],
@@ -2263,6 +2289,7 @@ class Storage:
         )
 
         with Session(self.engine) as sess:
+            self._apply_csv_export_statement_timeout(sess)
             query = (
                 sess.query(NoteRecord, PostRecord, RowNoteStatusRecord)
                 .join(PostRecord, NoteRecord.post_id == PostRecord.post_id)
@@ -2354,4 +2381,7 @@ def gen_storage(settings: GlobalSettings, statement_timeout_ms: Optional[int] = 
         settings.storage_settings.sqlalchemy_database_url,
         connect_args={"options": f"-c statement_timeout={timeout_ms}"},
     )
-    return Storage(engine=engine)
+    return Storage(
+        engine=engine,
+        csv_export_statement_timeout_ms=settings.storage_settings.csv_export_statement_timeout_ms,
+    )

--- a/common/tests/test_storage_csv_export.py
+++ b/common/tests/test_storage_csv_export.py
@@ -3,13 +3,15 @@
 See specs/002-csv-export-api/ for the design.
 """
 
-from typing import Generator, List
+from typing import Any, Generator, List
 
 from pytest import fixture
-from sqlalchemy.engine import Engine
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session
 
 from birdxplorer_common.models import NoteId, TextSearchMode, TwitterTimestamp
+from birdxplorer_common.settings import GlobalSettings
 from birdxplorer_common.storage import (
     NoteRecord,
     PostRecord,
@@ -472,3 +474,155 @@ def test_and_search_single_keyword_matches_same_as_or(
         search_mode=TextSearchMode.AND,
     )
     assert {r.note.note_id for r in rows_or} == {r.note.note_id for r in rows_and}
+
+
+# --- statement_timeout の差し替え --------------------------------------------
+#
+# CSV エクスポートは前方ワイルドカードの LIKE + JOIN でインデックスが効かず、
+# 接続全体の既定 statement_timeout を超えうる。そこでこの経路のトランザクション
+# でだけ上限を差し替えている。確かめたいのは次の 2 点:
+#   1. 差し替えが本当に PostgreSQL 側へ効いた状態で本体の SELECT が走ること
+#   2. その値がトランザクションの外（＝プールへ返したコネクション）へ漏れないこと
+
+
+@fixture
+def engine_with_connection_timeout(
+    settings_for_test: GlobalSettings, engine_for_test: Engine
+) -> Generator[Engine, None, None]:
+    """接続側に見分けのつく statement_timeout（7 秒）を持たせた engine。
+
+    テスト DB の既定は 0 なので、接続側が 0 のままだと「0（無制限）へ差し替えた」と
+    「そもそも触っていない」を区別できない。本番の gen_storage も接続側に有限値
+    （既定 30 秒）を入れるので、この方が実際の構成にも近い。
+    """
+    engine = create_engine(
+        settings_for_test.storage_settings.sqlalchemy_database_url,
+        connect_args={"options": "-c statement_timeout=7000"},
+    )
+    yield engine
+    engine.dispose()
+
+
+def _current_statement_timeout(engine: Engine) -> str:
+    """新しいセッションから見える statement_timeout を返す。"""
+    with Session(engine) as sess:
+        value = sess.execute(text("SHOW statement_timeout")).scalar()
+    return "" if value is None else str(value)
+
+
+def _statement_timeout_during_csv_query(engine: Engine, storage: Storage) -> List[str]:
+    """CSV エクスポートが撃つ各クエリの直前に見えている statement_timeout を集めて返す。
+
+    この経路は本体の SELECT だけでなく、リレーションの eager load（note_topic /
+    post_link / x_users）も同じトランザクションで撃つ。差し替えはそれら全部に
+    効いていなければ意味がないので、set_config 自身を除いた全クエリを見る。
+
+    before_cursor_execute の中で、同じ DBAPI コネクションから生カーソルを開いて
+    SHOW を撃つ。SQLAlchemy を経由しないのでイベントが再入せず、かつ同一
+    トランザクション内なので SET LOCAL 相当の値がそのまま見える。
+    """
+    observed: List[str] = []
+
+    def _on_before_cursor_execute(
+        conn: Connection,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        # 差し替え自身は対象外。残り（本体 SELECT と eager load）を全部見る。
+        if "set_config" in statement:
+            return
+        raw_cursor = conn.connection.cursor()
+        try:
+            raw_cursor.execute("SHOW statement_timeout")
+            row = raw_cursor.fetchone()
+            observed.append("" if row is None else str(row[0]))
+        finally:
+            raw_cursor.close()
+
+    event.listen(engine, "before_cursor_execute", _on_before_cursor_execute)
+    try:
+        storage.search_notes_with_posts_for_csv(
+            keywords=["医療"],
+            note_created_at_from=_ts(1700000000000),
+            note_created_at_to=_ts(1700001000000),
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", _on_before_cursor_execute)
+    return observed
+
+
+def test_csv_export_applies_its_own_statement_timeout(
+    engine_with_connection_timeout: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    # 接続側は 7 秒。CSV の経路だけ 45 秒へ差し替わる。
+    engine = engine_with_connection_timeout
+    assert _current_statement_timeout(engine) == "7s"
+    storage = Storage(engine=engine, csv_export_statement_timeout_ms=45000)
+    observed = _statement_timeout_during_csv_query(engine, storage)
+    assert observed and set(observed) == {"45s"}
+
+
+def test_csv_export_statement_timeout_is_transaction_local(
+    engine_with_connection_timeout: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    # プールへ返したコネクションを次に掴んだ処理へ 45 秒が漏れないこと。
+    # （SET LOCAL 相当かどうかの判定は
+    #  test_csv_export_statement_timeout_does_not_survive_commit の担当）
+    engine = engine_with_connection_timeout
+    before = _current_statement_timeout(engine)
+    storage = Storage(engine=engine, csv_export_statement_timeout_ms=45000)
+    storage.search_notes_with_posts_for_csv(
+        keywords=["医療"],
+        note_created_at_from=_ts(1700000000000),
+        note_created_at_to=_ts(1700001000000),
+    )
+    assert _current_statement_timeout(engine) == before == "7s"
+
+
+def test_csv_export_leaves_statement_timeout_alone_when_unset(
+    engine_with_connection_timeout: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    # 未指定なら接続の値（7 秒）をそのまま使う＝差し替えの SQL を撃たない。
+    engine = engine_with_connection_timeout
+    storage = Storage(engine=engine)
+    observed = _statement_timeout_during_csv_query(engine, storage)
+    assert observed and set(observed) == {"7s"}
+
+
+def test_csv_export_statement_timeout_can_be_disabled(
+    engine_with_connection_timeout: Engine,
+    csv_notes: List[NoteRecord],
+    csv_row_note_status: List[RowNoteStatusRecord],
+) -> None:
+    # 0 は「無制限へ差し替える」。未指定（None = 接続の 7 秒のまま）とは意味が違う。
+    engine = engine_with_connection_timeout
+    storage = Storage(engine=engine, csv_export_statement_timeout_ms=0)
+    observed = _statement_timeout_during_csv_query(engine, storage)
+    assert observed and set(observed) == {"0"}
+
+
+def test_csv_export_statement_timeout_does_not_survive_commit(
+    engine_with_connection_timeout: Engine,
+) -> None:
+    # トランザクション単位かどうかは「コミット境界」でしか判定できない。
+    # PostgreSQL では素の SET もトランザクション内ならロールバックで巻き戻るため、
+    # ロールバックしかしない経路を見ても SET LOCAL 相当かは区別できない。
+    # SET LOCAL はコミットでも失効し、素の SET はコミット後セッションに残る。
+    # 差し替えは Storage 内部の一手なので、ここだけ内部メソッドを直接呼んでいる。
+    engine = engine_with_connection_timeout
+    baseline = _current_statement_timeout(engine)
+    storage = Storage(engine=engine, csv_export_statement_timeout_ms=45000)
+    with Session(engine) as sess:
+        storage._apply_csv_export_statement_timeout(sess)
+        assert sess.execute(text("SHOW statement_timeout")).scalar() == "45s"
+        sess.commit()
+        assert sess.execute(text("SHOW statement_timeout")).scalar() == baseline

--- a/common/tests/test_storage_engine.py
+++ b/common/tests/test_storage_engine.py
@@ -60,3 +60,29 @@ def test_gen_storage_keeps_database_url(mocker: MockerFixture) -> None:
     gen_storage(settings)
 
     assert create_engine.call_args.args[0] == settings.storage_settings.sqlalchemy_database_url
+
+
+def test_gen_storage_passes_csv_export_statement_timeout(mocker: MockerFixture) -> None:
+    # CSV エクスポート用の上限はトランザクション単位で使うので、接続ではなく
+    # Storage 側へ渡る。
+    env = dict(BASE_ENV, BX_STORAGE_SETTINGS__CSV_EXPORT_STATEMENT_TIMEOUT_MS="45000")
+    mocker.patch.dict(os.environ, env, clear=True)
+    mocker.patch("birdxplorer_common.storage.create_engine")
+
+    storage = gen_storage(GlobalSettings())
+
+    assert storage.csv_export_statement_timeout_ms == 45000
+
+
+def test_gen_storage_csv_export_timeout_does_not_change_connection_default(mocker: MockerFixture) -> None:
+    # CSV 用の値を上げても、接続全体（＝他の全クエリ）は既定 30 秒のまま。
+    env = dict(BASE_ENV, BX_STORAGE_SETTINGS__CSV_EXPORT_STATEMENT_TIMEOUT_MS="45000")
+    assert _connect_args(mocker, env) == {"options": "-c statement_timeout=30000"}
+
+
+def test_settings_rejects_negative_csv_export_statement_timeout(mocker: MockerFixture) -> None:
+    env = dict(BASE_ENV, BX_STORAGE_SETTINGS__CSV_EXPORT_STATEMENT_TIMEOUT_MS="-1")
+    mocker.patch.dict(os.environ, env, clear=True)
+
+    with pytest.raises(ValidationError):
+        GlobalSettings()

--- a/common/tests/test_storage_engine.py
+++ b/common/tests/test_storage_engine.py
@@ -1,0 +1,62 @@
+import os
+from typing import Any, Dict
+
+import pytest
+from pydantic import ValidationError
+from pytest_mock import MockerFixture
+
+from birdxplorer_common.settings import GlobalSettings
+from birdxplorer_common.storage import gen_storage
+
+BASE_ENV = {"BX_STORAGE_SETTINGS__PASSWORD": "s0m6S+ron9P@55w0rd"}
+
+
+def _connect_args(mocker: MockerFixture, env: Dict[str, str], **kwargs: Any) -> Dict[str, str]:
+    mocker.patch.dict(os.environ, env, clear=True)
+    create_engine = mocker.patch("birdxplorer_common.storage.create_engine")
+    gen_storage(GlobalSettings(), **kwargs)
+    connect_args: Dict[str, str] = create_engine.call_args.kwargs["connect_args"]
+    return connect_args
+
+
+def test_gen_storage_sets_statement_timeout_by_default(mocker: MockerFixture) -> None:
+    # 504 を返したあとも PostgreSQL 側でクエリが走り続け、CPU とコネクションを
+    # 占有するのを防ぐ。既定値は 30 秒。
+    assert _connect_args(mocker, BASE_ENV) == {"options": "-c statement_timeout=30000"}
+
+
+def test_gen_storage_uses_configured_statement_timeout(mocker: MockerFixture) -> None:
+    env = dict(BASE_ENV, BX_STORAGE_SETTINGS__STATEMENT_TIMEOUT_MS="5000")
+    assert _connect_args(mocker, env) == {"options": "-c statement_timeout=5000"}
+
+
+def test_gen_storage_can_disable_statement_timeout_per_call(mocker: MockerFixture) -> None:
+    # マイグレーションのように時間のかかる処理は、呼び出し側で無効化できる
+    # （PostgreSQL は statement_timeout=0 を無制限として扱う）。
+    assert _connect_args(mocker, BASE_ENV, statement_timeout_ms=0) == {"options": "-c statement_timeout=0"}
+
+
+def test_gen_storage_rejects_negative_statement_timeout(mocker: MockerFixture) -> None:
+    # 負の値は PostgreSQL が接続時に弾くので、渡される前に落とす
+    mocker.patch.dict(os.environ, BASE_ENV, clear=True)
+    mocker.patch("birdxplorer_common.storage.create_engine")
+
+    with pytest.raises(ValueError):
+        gen_storage(GlobalSettings(), statement_timeout_ms=-1)
+
+
+def test_settings_rejects_negative_statement_timeout(mocker: MockerFixture) -> None:
+    mocker.patch.dict(os.environ, dict(BASE_ENV, BX_STORAGE_SETTINGS__STATEMENT_TIMEOUT_MS="-1"), clear=True)
+
+    with pytest.raises(ValidationError):
+        GlobalSettings()
+
+
+def test_gen_storage_keeps_database_url(mocker: MockerFixture) -> None:
+    mocker.patch.dict(os.environ, BASE_ENV, clear=True)
+    create_engine = mocker.patch("birdxplorer_common.storage.create_engine")
+    settings = GlobalSettings()
+
+    gen_storage(settings)
+
+    assert create_engine.call_args.args[0] == settings.storage_settings.sqlalchemy_database_url

--- a/migrate/migration/env.py
+++ b/migrate/migration/env.py
@@ -64,7 +64,8 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    storage = gen_storage(settings=bx_settings)
+    # マイグレーションは 1 文が長くなりうるので、クエリの打ち切りを無効にする
+    storage = gen_storage(settings=bx_settings, statement_timeout_ms=0)
     connectable = storage.engine
 
     with connectable.connect() as connection:


### PR DESCRIPTION
## 概要

#278 の「3. DB `statement_timeout` の付与」だけを対応しました。

`gen_storage` が作るエンジンに `connect_args={"options": "-c statement_timeout=..."}` を渡し、1 クエリの上限時間で PostgreSQL 側から打ち切るようにしています。504 を返したあともクエリが走り続けて CPU とコネクションを占有する、という Issue の指摘に対応するものです。

- 既定は 30 秒（Issue の提案どおり）
- `BX_STORAGE_SETTINGS__STATEMENT_TIMEOUT_MS` で変更可能。`0` を指定すると無制限（PostgreSQL の既定の扱い）

### マイグレーションは無効化しています

`gen_storage` は `migrate/migration/env.py` の Alembic online migration からも呼ばれます。無条件に 30 秒を入れると、時間のかかるマイグレーションが途中で中断してしまいます。

そのため呼び出し側で上書きできる引数を用意し、マイグレーションでは `statement_timeout_ms=0` を渡しています。ここは Issue に書かれていない追加分なので、不要であれば外します。

なお ETL は SQLite・PostgreSQL とも `etl/src/birdxplorer_etl/lib/sqlite/init.py`（`init_sqlite` / `init_postgresql`）で独自に `create_engine` しており、`gen_storage` を経由しないため影響を受けません。

### 30 秒に当たりうる経路について

現行コードで既定 30 秒に正当に当たりうるのは `Storage.search_notes_with_posts_for_csv`（`common/birdxplorer_common/storage.py`）だと考えています。`NoteRecord.summary` への前方ワイルドカード `LIKE '%kw%'` に post の INNER JOIN とステータスの LEFT JOIN が乗り、`limit` の既定が 5000 件のためです。

打ち切られると CSV エクスポートが失敗するので、実運用で当たるようなら `BX_STORAGE_SETTINGS__STATEMENT_TIMEOUT_MS` を延ばすか、この経路だけ `gen_storage(..., statement_timeout_ms=0)` 相当の扱いにする形が考えられます。既定値の妥当性についてご意見をいただければ調整します。

### 負の値は接続前に落としています

実際の PostgreSQL に `-c statement_timeout=-1` で接続すると、接続そのものが落ちます。

```
FATAL:  -1 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)
```

接続エラーだと原因が分かりにくいので、設定経由は `Field(ge=0)`、呼び出し側経由は `gen_storage` の `ValueError` で、いずれも接続前に落とすようにしました。

### 項目 1・2 について

- **項目 2（ALB `idleTimeout`）と項目 1 の Fargate 設定**は `BirdXplorer-cdk` 側なので、このリポジトリからは触れていません
- **項目 1 の gunicorn `-w`** は `api/Dockerfile.prd` にありますが、Issue にあるとおり vCPU に合わせる必要があり、0.5 vCPU のまま増やすと競合するだけになります。CDK 側の vCPU 変更とセットで判断すべきと考えて、この PR では触っていません

## 動作確認方法

`common/tests/test_storage_engine.py` を追加しました。`create_engine` を差し替えて、渡される `connect_args` を確認しています。

| テスト | 内容 |
|---|---|
| `test_gen_storage_sets_statement_timeout_by_default` | 既定で `-c statement_timeout=30000` |
| `test_gen_storage_uses_configured_statement_timeout` | 環境変数で 5000 に変更できる |
| `test_gen_storage_can_disable_statement_timeout_per_call` | 呼び出し側から 0 で無効化できる |
| `test_gen_storage_rejects_negative_statement_timeout` | 呼び出し側の負値は `ValueError` |
| `test_settings_rejects_negative_statement_timeout` | 環境変数の負値は `ValidationError` |
| `test_gen_storage_keeps_database_url` | 接続 URL は従来どおり |

実装前にテストを書いて落ちることを確認してから実装しています（`test_gen_storage_keeps_database_url` は変更前から通ります）。

手元の結果です。

- `common` → `tox` **congratulations :)**（154 passed / pflake8 / `mypy --strict` は本体・tests とも Success）
- `api` → `tox` **congratulations :)**（174 passed / pflake8 / `mypy --strict` は本体・tests とも Success）

実行環境の注記として、手元に Python 3.10 が無かったため `tox -e py`（3.12.1）で実行しています。また `common` のテストは PostgreSQL を起動し、`DATA_DIR` は空（`test_data_model.py` が実データを要求しない状態）で回しました。
