### PR TITLE
fix(etl): note-requests取り込みのCSVフィールド上限超過クラッシュを修正

### DIFF
--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import sys
 import time
 import zipfile
 from datetime import datetime, timedelta
@@ -23,6 +24,11 @@ from birdxplorer_common.storage import (
     RowNoteRequestRecord,
     RowNoteStatusRecord,
 )
+
+# batSignals の suggestions フィールドは JSON がノートリクエスト提案の蓄積で肥大化し、
+# csv デフォルト上限 (131072 バイト) を超える行がある。上限を上げないと
+# `_csv.Error: field larger than field limit` で読み取りが途中で落ちる（毎日発生していた）。
+csv.field_size_limit(sys.maxsize)
 
 # モジュールレベル SQS クライアント（再生成コスト排除）
 _sqs_client = None
@@ -1055,39 +1061,69 @@ def extract_note_requests(postgresql: Session):
     for days_ago in range(3):  # 今日、昨日、一昨日
         date = datetime.now() - timedelta(days=days_ago)
         dateString = date.strftime("%Y/%m/%d")
-        url = f"https://ton.twimg.com/birdwatch-public-data/{dateString}/batSignals/batSignals-00000.zip"
-        logging.info(f"Fetching note requests from: {url}")
-        res = requests.get(url)
-        if res.status_code == 404:
-            logging.info(f"No note requests data available for {dateString}, trying previous day")
-            continue
-        if res.status_code != 200:
-            logging.warning(f"Unexpected status code {res.status_code} for note requests, skipping day")
-            continue
-        with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
-            tsv_filename = "batSignals-00000.tsv"
-            if tsv_filename not in zip_file.namelist():
-                logging.error(f"TSV file {tsv_filename} not found in the zip file.")
-                return
-            with zip_file.open(tsv_filename) as tsv_file:
-                tsv_data = tsv_file.read().decode("utf-8").splitlines()
-                reader = csv.DictReader(tsv_data, delimiter="\t")
-                reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                rows_by_id = {}
-                total = 0
-                for row in reader:
-                    parsed = parse_note_request_row(row)
-                    if parsed is None:
-                        continue
-                    rows_by_id[parsed["tweet_id"]] = parsed
-                    if len(rows_by_id) >= 10000:
-                        _flush_note_request_batch(postgresql, list(rows_by_id.values()))
-                        total += len(rows_by_id)
-                        rows_by_id = {}
-                _flush_note_request_batch(postgresql, list(rows_by_id.values()))
-                total += len(rows_by_id)
-        logging.info(f"[PHASE_COMPLETE] NoteRequests: {total} rows in {time.time() - phase_start:.1f}s")
-        return
+
+        # batSignals-00000.zip から順に404が返るまでダウンロード（notes/ratings と同じ連番方式）
+        file_index = 0
+        date_has_data = False
+        rows_by_id = {}
+        total = 0
+
+        while True:
+            url = (
+                f"https://ton.twimg.com/birdwatch-public-data/{dateString}/"
+                f"batSignals/batSignals-{file_index:05d}.zip"
+            )
+            logging.info(f"Fetching note requests from: {url}")
+            res = requests.get(url)
+
+            if res.status_code == 404:
+                if file_index == 0:
+                    logging.info(f"No note requests data available for {dateString}, trying previous day")
+                else:
+                    logging.info(
+                        f"Note requests file {file_index:05d} not found (404), "
+                        f"stopping note requests download for {dateString}"
+                    )
+                break
+
+            if res.status_code != 200:
+                logging.warning(
+                    f"Unexpected status code {res.status_code} for note requests file {file_index:05d}, skipping"
+                )
+                file_index += 1
+                continue
+
+            with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
+                tsv_filename = f"batSignals-{file_index:05d}.tsv"
+                if tsv_filename not in zip_file.namelist():
+                    logging.error(f"TSV file {tsv_filename} not found in the zip file.")
+                    file_index += 1
+                    continue
+
+                date_has_data = True
+                with zip_file.open(tsv_filename) as tsv_file:
+                    tsv_data = tsv_file.read().decode("utf-8").splitlines()
+                    reader = csv.DictReader(tsv_data, delimiter="\t")
+                    reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                    for row in reader:
+                        parsed = parse_note_request_row(row)
+                        if parsed is None:
+                            continue
+                        rows_by_id[parsed["tweet_id"]] = parsed
+                        if len(rows_by_id) >= 10000:
+                            _flush_note_request_batch(postgresql, list(rows_by_id.values()))
+                            total += len(rows_by_id)
+                            rows_by_id = {}
+
+            file_index += 1
+
+        if date_has_data:
+            # 全ファイル処理後、残りをフラッシュ
+            _flush_note_request_batch(postgresql, list(rows_by_id.values()))
+            total += len(rows_by_id)
+            logging.info(f"[PHASE_COMPLETE] NoteRequests: {total} rows in {time.time() - phase_start:.1f}s")
+            return
+
     logging.warning("No note requests data found in the last 3 days")
 
 

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -1055,8 +1055,29 @@ def _flush_note_request_batch(postgresql: Session, batch: list):
     postgresql.commit()
 
 
+def _log_skipped_note_request_row(file_index: int, line_no: int, line: str, header: list[str], exc: Exception) -> None:
+    """毒行を skip する際、根本調査用の識別情報を WARN 出力する。
+
+    `NOTE_REQUEST_ROW_SKIPPED` トークンで CloudWatch メトリクスフィルタ/アラームに接続し、
+    tweet_id・例外種別・最長フィールド（肥大の疑いが濃い箇所）を残して原因追跡を可能にする。
+    """
+    fields = line.split("\t")
+    tweet_id = fields[0][:32] if fields else ""
+    max_idx = max(range(len(fields)), key=lambda i: len(fields[i])) if fields else -1
+    max_len = len(fields[max_idx]) if max_idx >= 0 else 0
+    field_name = header[max_idx] if 0 <= max_idx < len(header) else f"col{max_idx}"
+    logging.warning(
+        f"NOTE_REQUEST_ROW_SKIPPED file={file_index:05d} line={line_no} tweet_id={tweet_id} "
+        f"reason={type(exc).__name__}: {str(exc)[:200]} field={field_name} field_len={max_len}"
+    )
+
+
 def extract_note_requests(postgresql: Session):
-    """batSignals (Note Requests) の日次スナップショットを row_note_requests に UPSERT する。"""
+    """batSignals (Note Requests) の日次スナップショットを row_note_requests に UPSERT する。
+
+    1行/1ファイルの異常はそれぞれ skip して継続し、フェーズ全体を中断させない
+    （毒行1件で以降のツイートが取り込まれなくなる silent truncation を構造的に防ぐ）。
+    """
     phase_start = time.time()
     for days_ago in range(3):  # 今日、昨日、一昨日
         date = datetime.now() - timedelta(days=days_ago)
@@ -1067,6 +1088,7 @@ def extract_note_requests(postgresql: Session):
         date_has_data = False
         rows_by_id = {}
         total = 0
+        skipped = 0
 
         while True:
             url = (
@@ -1093,27 +1115,47 @@ def extract_note_requests(postgresql: Session):
                 file_index += 1
                 continue
 
-            with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
-                tsv_filename = f"batSignals-{file_index:05d}.tsv"
-                if tsv_filename not in zip_file.namelist():
-                    logging.error(f"TSV file {tsv_filename} not found in the zip file.")
-                    file_index += 1
-                    continue
+            tsv_filename = f"batSignals-{file_index:05d}.tsv"
+            try:
+                with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
+                    if tsv_filename not in zip_file.namelist():
+                        logging.error(f"TSV file {tsv_filename} not found in the zip file.")
+                        file_index += 1
+                        continue
+                    with zip_file.open(tsv_filename) as tsv_file:
+                        tsv_data = tsv_file.read().decode("utf-8").splitlines()
+            except (zipfile.BadZipFile, UnicodeDecodeError) as exc:
+                # 壊れた zip / 不正 UTF-8 は 1 ファイルに閉じ込めて skip（他ファイル・他日は継続）
+                logging.error(
+                    f"NOTE_REQUEST_FILE_SKIPPED file={file_index:05d} date={dateString} "
+                    f"reason={type(exc).__name__}: {str(exc)[:200]}"
+                )
+                file_index += 1
+                continue
 
-                date_has_data = True
-                with zip_file.open(tsv_filename) as tsv_file:
-                    tsv_data = tsv_file.read().decode("utf-8").splitlines()
-                    reader = csv.DictReader(tsv_data, delimiter="\t")
-                    reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                    for row in reader:
-                        parsed = parse_note_request_row(row)
-                        if parsed is None:
-                            continue
-                        rows_by_id[parsed["tweet_id"]] = parsed
-                        if len(rows_by_id) >= 10000:
-                            _flush_note_request_batch(postgresql, list(rows_by_id.values()))
-                            total += len(rows_by_id)
-                            rows_by_id = {}
+            if not tsv_data:
+                logging.warning(f"Empty note requests file {file_index:05d} for {dateString}, skipping")
+                file_index += 1
+                continue
+
+            date_has_data = True
+            header = [stringcase.snakecase(field) for field in next(csv.reader([tsv_data[0]], delimiter="\t"))]
+            for line_no, line in enumerate(tsv_data[1:], start=2):
+                # 1行のパース失敗（csv.Error/JSON/値異常）は skip して継続。フラッシュ(DBエラー)は隔離しない。
+                try:
+                    values = next(csv.reader([line], delimiter="\t"))
+                    parsed = parse_note_request_row(dict(zip(header, values)))
+                except Exception as exc:
+                    skipped += 1
+                    _log_skipped_note_request_row(file_index, line_no, line, header, exc)
+                    continue
+                if parsed is None:
+                    continue
+                rows_by_id[parsed["tweet_id"]] = parsed
+                if len(rows_by_id) >= 10000:
+                    _flush_note_request_batch(postgresql, list(rows_by_id.values()))
+                    total += len(rows_by_id)
+                    rows_by_id = {}
 
             file_index += 1
 
@@ -1121,7 +1163,10 @@ def extract_note_requests(postgresql: Session):
             # 全ファイル処理後、残りをフラッシュ
             _flush_note_request_batch(postgresql, list(rows_by_id.values()))
             total += len(rows_by_id)
-            logging.info(f"[PHASE_COMPLETE] NoteRequests: {total} rows in {time.time() - phase_start:.1f}s")
+            logging.info(
+                f"[PHASE_COMPLETE] NoteRequests: {total} rows ({skipped} skipped) "
+                f"in {time.time() - phase_start:.1f}s"
+            )
             return
 
     logging.warning("No note requests data found in the last 3 days")

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -1138,8 +1138,18 @@ def extract_note_requests(postgresql: Session):
                 file_index += 1
                 continue
 
+            # ヘッダ行のパースも 1 ファイルに閉じ込める（行の隔離と同じく phase 全体を止めない）
+            try:
+                header = [stringcase.snakecase(field) for field in next(csv.reader([tsv_data[0]], delimiter="\t"))]
+            except csv.Error as exc:
+                logging.error(
+                    f"NOTE_REQUEST_FILE_SKIPPED file={file_index:05d} date={dateString} "
+                    f"reason=header_{type(exc).__name__}: {str(exc)[:200]}"
+                )
+                file_index += 1
+                continue
+
             date_has_data = True
-            header = [stringcase.snakecase(field) for field in next(csv.reader([tsv_data[0]], delimiter="\t"))]
             for line_no, line in enumerate(tsv_data[1:], start=2):
                 # 1行のパース失敗（csv.Error/JSON/値異常）は skip して継続。フラッシュ(DBエラー)は隔離しない。
                 try:

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import sys
 import zipfile
 from unittest.mock import MagicMock, patch
@@ -162,6 +163,48 @@ class TestExtractNoteRequests:
         assert len(batch) == 1
         assert batch[0]["tweet_id"] == "1212092628029698048"
         assert len(batch[0]["suggestions"]) == 1
+
+    def test_skips_poison_row_and_logs_diagnostics(self, caplog):
+        # 1行の異常 (NULバイト -> _csv.Error) が phase 全体を止めず、
+        # 前後の正常行は取り込まれ、毒行は識別情報付きで WARN される
+        good0 = "1212092628029698048\t-1\t-1\t-1\t-1\t\t[]"
+        poison = "1212092628029698099\t-1\t-1\t-1\t-1\t\tbad\x00value"  # NUL で csv.Error
+        good1 = "1212092628029698050\t-1\t-1\t-1\t-1\t\t[]"
+        tsv = TSV_HEADER + "\n" + good0 + "\n" + poison + "\n" + good1 + "\n"
+        res_200 = MagicMock(status_code=200, content=_build_zip(tsv))
+        res_404 = MagicMock(status_code=404)
+        session = MagicMock()
+        with caplog.at_level(logging.WARNING):
+            with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_200, res_404]):
+                with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                    extract_note_requests(session)  # 毒行があっても例外を投げない
+        assert flush.call_count == 1
+        batch = flush.call_args[0][1]
+        tweet_ids = {r["tweet_id"] for r in batch}
+        assert tweet_ids == {"1212092628029698048", "1212092628029698050"}  # 良行は両方入る
+        # メトリクスフィルタ用トークン + 根本調査用の tweet_id が残る
+        assert "NOTE_REQUEST_ROW_SKIPPED" in caplog.text
+        assert "1212092628029698099" in caplog.text
+
+    def test_skips_broken_zip_file_and_falls_back(self, caplog):
+        # zip 破損ファイル (200) は 1 ファイルに閉じ込めて skip し、phase は落ちない
+        good = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
+        broken = MagicMock(status_code=200, content=b"this is not a zip")
+        res_404 = MagicMock(status_code=404)
+        res_good = MagicMock(status_code=200, content=_build_zip(good))
+        session = MagicMock()
+        # 当日: -00000 壊れzip -> skip, -00001 404 -> データ無し -> 前日へ
+        # 前日: -00000 正常, -00001 404
+        with caplog.at_level(logging.ERROR):
+            with patch(
+                "birdxplorer_etl.extract_ecs.requests.get",
+                side_effect=[broken, res_404, res_good, res_404],
+            ) as get:
+                with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                    extract_note_requests(session)
+        assert get.call_count == 4
+        assert flush.call_count == 1  # 前日の正常行のみ
+        assert "NOTE_REQUEST_FILE_SKIPPED" in caplog.text
 
     def test_falls_back_to_previous_day_on_404(self):
         tsv = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -206,6 +206,29 @@ class TestExtractNoteRequests:
         assert flush.call_count == 1  # 前日の正常行のみ
         assert "NOTE_REQUEST_FILE_SKIPPED" in caplog.text
 
+    def test_skips_file_with_poison_header_and_falls_back(self, caplog):
+        # ヘッダ行自体が壊れている (NUL) ファイルも 1 ファイルに閉じ込めて skip し、phase を止めない
+        poison_header = TSV_HEADER.replace("suggestions", "sugg\x00estions")
+        bad = poison_header + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
+        good = TSV_HEADER + "\n1212092628029698050\t-1\t-1\t-1\t-1\t\t[]\n"
+        res_bad = MagicMock(status_code=200, content=_build_zip(bad))
+        res_good = MagicMock(status_code=200, content=_build_zip(good))
+        res_404 = MagicMock(status_code=404)
+        session = MagicMock()
+        # 当日: -00000 毒ヘッダ -> skip, -00001 404 -> データ無し -> 前日へ / 前日: 正常
+        with caplog.at_level(logging.ERROR):
+            with patch(
+                "birdxplorer_etl.extract_ecs.requests.get",
+                side_effect=[res_bad, res_404, res_good, res_404],
+            ) as get:
+                with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                    extract_note_requests(session)  # 毒ヘッダでも例外を投げない
+        assert get.call_count == 4
+        assert flush.call_count == 1
+        batch = flush.call_args[0][1]
+        assert {r["tweet_id"] for r in batch} == {"1212092628029698050"}
+        assert "NOTE_REQUEST_FILE_SKIPPED" in caplog.text
+
     def test_falls_back_to_previous_day_on_404(self):
         tsv = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
         res_404 = MagicMock(status_code=404)

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -92,10 +92,10 @@ TSV_HEADER = (
 )
 
 
-def _build_zip(tsv: str) -> bytes:
+def _build_zip(tsv: str, file_index: int = 0) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("batSignals-00000.tsv", tsv)
+        zf.writestr(f"batSignals-{file_index:05d}.tsv", tsv)
     return buf.getvalue()
 
 
@@ -108,11 +108,14 @@ class TestExtractNoteRequests:
             + json.dumps([{"suggestion_id": 1, "suggestion": "test", "source_link": ""}])
             + "\n"
         )
-        mock_res = MagicMock(status_code=200, content=_build_zip(tsv))
+        # batSignals-00000 は 200、次のファイル (-00001) は 404 で打ち止め
+        res_200 = MagicMock(status_code=200, content=_build_zip(tsv))
+        res_404 = MagicMock(status_code=404)
         session = MagicMock()
-        with patch("birdxplorer_etl.extract_ecs.requests.get", return_value=mock_res):
+        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_200, res_404]) as get:
             with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
                 extract_note_requests(session)
+        assert get.call_count == 2
         assert flush.call_count == 1
         batch = flush.call_args[0][1]
         assert len(batch) == 1
@@ -123,15 +126,53 @@ class TestExtractNoteRequests:
         assert batch[0]["source_links"] == ["https://x.com/i/status/1", "https://x.com/i/status/2"]
         assert batch[0]["suggestions"] == [{"suggestion_id": 1, "suggestion": "test", "source_link": ""}]
 
+    def test_downloads_multiple_files_until_404(self):
+        # notes/ratings と同様、batSignals-00000, -00001 ... と 404 まで連番でDLする
+        tsv0 = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
+        tsv1 = TSV_HEADER + "\n1212092628029698049\t-1\t-1\t-1\t-1\t\t[]\n"
+        res0 = MagicMock(status_code=200, content=_build_zip(tsv0, file_index=0))
+        res1 = MagicMock(status_code=200, content=_build_zip(tsv1, file_index=1))
+        res_404 = MagicMock(status_code=404)
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res0, res1, res_404]) as get:
+            with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                extract_note_requests(session)
+        # -00000, -00001, -00002(404) の 3 回 GET
+        assert get.call_count == 3
+        # 両ファイルの行が最終フラッシュにまとめて渡る
+        assert flush.call_count == 1
+        batch = flush.call_args[0][1]
+        tweet_ids = {r["tweet_id"] for r in batch}
+        assert tweet_ids == {"1212092628029698048", "1212092628029698049"}
+
+    def test_handles_field_larger_than_default_csv_limit(self):
+        # suggestions が Python の csv デフォルト上限 (131072 バイト) を超えても
+        # _csv.Error を出さずに処理できること（本番で毎日クラッシュしていた回帰の防止）
+        big_suggestions = json.dumps([{"suggestion_id": 1, "suggestion": "x" * 140000, "source_link": ""}])
+        assert len(big_suggestions) > 131072
+        tsv = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t" + big_suggestions + "\n"
+        res_200 = MagicMock(status_code=200, content=_build_zip(tsv))
+        res_404 = MagicMock(status_code=404)
+        session = MagicMock()
+        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_200, res_404]):
+            with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
+                extract_note_requests(session)  # _csv.Error が投げられないこと
+        assert flush.call_count == 1
+        batch = flush.call_args[0][1]
+        assert len(batch) == 1
+        assert batch[0]["tweet_id"] == "1212092628029698048"
+        assert len(batch[0]["suggestions"]) == 1
+
     def test_falls_back_to_previous_day_on_404(self):
         tsv = TSV_HEADER + "\n1212092628029698048\t-1\t-1\t-1\t-1\t\t[]\n"
         res_404 = MagicMock(status_code=404)
         res_200 = MagicMock(status_code=200, content=_build_zip(tsv))
         session = MagicMock()
-        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_404, res_200]) as get:
+        # 当日は -00000 が 404 → 前日にフォールバック → 前日 -00000 は 200、-00001 は 404
+        with patch("birdxplorer_etl.extract_ecs.requests.get", side_effect=[res_404, res_200, res_404]) as get:
             with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
                 extract_note_requests(session)
-        assert get.call_count == 2
+        assert get.call_count == 3
         assert flush.call_count == 1
 
     def test_gives_up_after_3_days_of_404(self):
@@ -140,6 +181,7 @@ class TestExtractNoteRequests:
         with patch("birdxplorer_etl.extract_ecs.requests.get", return_value=res_404) as get:
             with patch("birdxplorer_etl.extract_ecs._flush_note_request_batch") as flush:
                 extract_note_requests(session)
+        # 3 日分それぞれ -00000 が 404 → 各日即打ち止め
         assert get.call_count == 3
         assert flush.call_count == 0
 


### PR DESCRIPTION
## 概要

ノートリクエスト (batSignals) の取り込みが**毎日クラッシュ**しており、`row_note_requests` の新規行が約 2026-07-17 で凍結していた問題を修正する。

## 症状（報告ベース）

- `row_note_requests.tweet_created_at` の最大が 2026-07-17 頃で止まり、それ以降の新しい tweet_id が1件も入らない
- 一方で `api_xl_feed_eligible_at` などの eligibility は 2026-08-02 まで更新されている
- `/note-requests/count` で `tweet_created_at_from=7/18` 以降 → `total=0`

## 根本原因

`tweet_created_at` はファイルの値ではなく tweet_id からの Snowflake 逆算なので、「最大 tweet_created_at = 07-17」は「取り込めた最大 tweet_id が 07-17 相当」を意味する。

dev の ETL ログ (`dev-bird-xplorer-etlExtractLogGroup`) を確認したところ、直近12日で `[PHASE_COMPLETE] NoteRequests` が一度も出ておらず、毎回次のエラーで落ちていた：

```
File ".../extract_ecs.py", line 1078, in extract_note_requests
    for row in reader:
_csv.Error: field larger than field limit (131072)
```

batSignals の `suggestions`（ノートリクエスト提案の JSON）はツイートへの提案が蓄積して肥大化し、Python `csv` のデフォルト上限 **131072 バイト (128KB)** を超える行が存在する。`extract_ecs.py` は `csv.field_size_limit()` を設定していないため、その行で `for row in reader` が例外を送出。

- ファイルは tweet_id 昇順ソート
- `_flush_note_request_batch` は1万行ごとに commit、`run_note_requests_phase` の `try/except` が例外を握りつぶす
- → **壁の手前まで commit**（既存行の eligibility は 08-02 まで進む）、**壁より後の新規ツイートは永久に取り込まれない**

実データ (`2026/08/02/batSignals-00000`, 482,423行) を解析し、128KB 超のフィールドを持つ行がちょうど1件、`suggestions` 160,321 バイト、tweet 生成 2026-07-16 23:14 JST であることを確認。観測された 07-17 凍結と一致する。

## 変更内容

1. **CSV フィールド上限の引き上げ**: モジュール冒頭で `csv.field_size_limit(sys.maxsize)` を設定。全リーダー (notes/ratings/noteStatusHistory/batSignals) を保護する。
2. **batSignals の連番ダウンロード**: `batSignals-00000.zip` 決め打ちをやめ、notes/ratings と同様に 404 まで `-00000, -00001, ...` を順に取得するループに変更。現状 `-00001` は 404 なので挙動は変わらないが、将来 X がファイル分割した場合の取りこぼしを防ぐ潜在バグ対応。

## 検証

- 新規テスト2件を追加（128KB 超フィールドの処理 / 複数ファイル連番DL）＋既存テストをループ方式に更新
- `tests/test_extract_note_requests.py`: 18 passed
- ETL 全テスト: 251 passed, 4 skipped（X API 資格情報）
- black / isort / pflake8 クリーン、新規 mypy 指摘なし
- **実データ E2E**: 本番でクラッシュ中の `2026/08/02` ファイル全 482,423 行をパッチ後コードで読み切り、最大 tweet_created_at = 2026-08-02 04:53 JST に到達することを確認

## 影響環境

dev で失敗を確認。prod も同一イメージ・同一コードパスのため同様に影響しているとみられる。マージ後、次回 ETL 実行で 07-18〜現在のノートリクエストが取り込まれる。
