### PR TITLE
feat: /note-requests に language フィルタと search_text 検索を追加

### DIFF
--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -791,15 +791,15 @@ v1_data_note_requests_limit: FastAPIEndpointParamDocs = {
 """,
 }
 
-v1_data_note_requests_language = FastAPIEndpointParamDocs(
-    description="紐づく Post の言語 (ISO 639-1 等) で絞り込む。指定すると Post 未取得のリクエストは除外される。",
-    openapi_examples={"ja": {"summary": "日本語", "value": "ja"}},
-)
+v1_data_note_requests_language: FastAPIEndpointParamDocs = {
+    "description": "紐づく Post の言語 (ISO 639-1 等) で絞り込む。指定すると Post 未取得のリクエストは除外される。",
+    "openapi_examples": {"ja": {"summary": "日本語", "value": "ja"}},
+}
 
-v1_data_note_requests_search_text = FastAPIEndpointParamDocs(
-    description="suggestion 本文または Post 本文への部分一致 (大文字小文字無視)。2 文字以上。",
-    openapi_examples={"scam": {"summary": "詐欺を含む", "value": "詐欺"}},
-)
+v1_data_note_requests_search_text: FastAPIEndpointParamDocs = {
+    "description": "suggestion 本文または Post 本文への部分一致 (大文字小文字無視)。2 文字以上。",
+    "openapi_examples": {"scam": {"summary": "詐欺を含む", "value": "詐欺"}},
+}
 
 V1DataNoteRequestsDocs = FastAPIEndpointDocs(
     "コミュニティノートのリクエスト (Note Requests) のデータを取得するエンドポイント",

--- a/api/birdxplorer_api/openapi_doc.py
+++ b/api/birdxplorer_api/openapi_doc.py
@@ -791,6 +791,16 @@ v1_data_note_requests_limit: FastAPIEndpointParamDocs = {
 """,
 }
 
+v1_data_note_requests_language = FastAPIEndpointParamDocs(
+    description="紐づく Post の言語 (ISO 639-1 等) で絞り込む。指定すると Post 未取得のリクエストは除外される。",
+    openapi_examples={"ja": {"summary": "日本語", "value": "ja"}},
+)
+
+v1_data_note_requests_search_text = FastAPIEndpointParamDocs(
+    description="suggestion 本文または Post 本文への部分一致 (大文字小文字無視)。2 文字以上。",
+    openapi_examples={"scam": {"summary": "詐欺を含む", "value": "詐欺"}},
+)
+
 V1DataNoteRequestsDocs = FastAPIEndpointDocs(
     "コミュニティノートのリクエスト (Note Requests) のデータを取得するエンドポイント",
     {
@@ -798,6 +808,8 @@ V1DataNoteRequestsDocs = FastAPIEndpointDocs(
         "tweet_created_at_from": v1_data_note_requests_tweet_created_at_from,
         "tweet_created_at_to": v1_data_note_requests_tweet_created_at_to,
         "has_post": v1_data_note_requests_has_post,
+        "language": v1_data_note_requests_language,
+        "search_text": v1_data_note_requests_search_text,
         "offset": v1_data_note_requests_offset,
         "limit": v1_data_note_requests_limit,
     },
@@ -810,6 +822,8 @@ V1DataNoteRequestsCountDocs = FastAPIEndpointDocs(
         "tweet_created_at_from": v1_data_note_requests_tweet_created_at_from,
         "tweet_created_at_to": v1_data_note_requests_tweet_created_at_to,
         "has_post": v1_data_note_requests_has_post,
+        "language": v1_data_note_requests_language,
+        "search_text": v1_data_note_requests_search_text,
     },
 )
 

--- a/api/birdxplorer_api/routers/data.py
+++ b/api/birdxplorer_api/routers/data.py
@@ -654,6 +654,10 @@ def gen_router(
             default=None, **V1DataNoteRequestsDocs.params["tweet_created_at_to"]
         ),
         has_post: Union[bool, None] = Query(default=None, **V1DataNoteRequestsDocs.params["has_post"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataNoteRequestsDocs.params["language"]),
+        search_text: Union[str, None] = Query(
+            default=None, min_length=2, **V1DataNoteRequestsDocs.params["search_text"]
+        ),
         offset: int = Query(default=0, ge=0, **V1DataNoteRequestsDocs.params["offset"]),
         limit: int = Query(default=100, gt=0, le=1000, **V1DataNoteRequestsDocs.params["limit"]),
     ) -> NoteRequestListResponse:
@@ -664,6 +668,8 @@ def gen_router(
                 tweet_created_at_to = ensure_twitter_timestamp(tweet_created_at_to)
         except OverflowError as e:
             raise HTTPException(status_code=422, detail=str(e))
+        if search_text is not None and search_text.strip() == "":
+            raise HTTPException(status_code=422, detail="search_text must not be blank")
 
         note_requests = list(
             storage.get_note_requests(
@@ -671,6 +677,8 @@ def gen_router(
                 tweet_created_at_from=tweet_created_at_from,
                 tweet_created_at_to=tweet_created_at_to,
                 has_post=has_post,
+                language=language,
+                search_text=search_text,
                 offset=offset,
                 limit=limit,
             )
@@ -680,6 +688,8 @@ def gen_router(
             tweet_created_at_from=tweet_created_at_from,
             tweet_created_at_to=tweet_created_at_to,
             has_post=has_post,
+            language=language,
+            search_text=search_text,
         )
 
         base_url = str(request.url).split("?")[0]
@@ -710,6 +720,10 @@ def gen_router(
             default=None, **V1DataNoteRequestsCountDocs.params["tweet_created_at_to"]
         ),
         has_post: Union[bool, None] = Query(default=None, **V1DataNoteRequestsCountDocs.params["has_post"]),
+        language: Union[LanguageCode, None] = Query(default=None, **V1DataNoteRequestsCountDocs.params["language"]),
+        search_text: Union[str, None] = Query(
+            default=None, min_length=2, **V1DataNoteRequestsCountDocs.params["search_text"]
+        ),
     ) -> SearchCountResponse:
         try:
             if tweet_created_at_from is not None and isinstance(tweet_created_at_from, str):
@@ -718,12 +732,16 @@ def gen_router(
                 tweet_created_at_to = ensure_twitter_timestamp(tweet_created_at_to)
         except OverflowError as e:
             raise HTTPException(status_code=422, detail=str(e))
+        if search_text is not None and search_text.strip() == "":
+            raise HTTPException(status_code=422, detail="search_text must not be blank")
 
         total_count = storage.get_number_of_note_requests(
             tweet_ids=tweet_ids,
             tweet_created_at_from=tweet_created_at_from,
             tweet_created_at_to=tweet_created_at_to,
             has_post=has_post,
+            language=language,
+            search_text=search_text,
         )
         return SearchCountResponse(total=total_count)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -685,8 +685,10 @@ def mock_storage(
             if language is not None and (r.post is None or r.post.language != language):
                 continue
             if search_text:
-                in_suggestion = any(search_text in (s.suggestion or "") for s in r.suggestions)
-                in_post = r.post is not None and search_text in r.post.text
+                # 実 storage は ILIKE（大文字小文字無視）なのでモックも case-insensitive に合わせる
+                needle = search_text.lower()
+                in_suggestion = any(needle in (s.suggestion or "").lower() for s in r.suggestions)
+                in_post = r.post is not None and needle in r.post.text.lower()
                 if not (in_suggestion or in_post):
                     continue
             filtered.append(r)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -661,6 +661,8 @@ def mock_storage(
         tweet_created_at_from: Union[TwitterTimestamp, None] = None,
         tweet_created_at_to: Union[TwitterTimestamp, None] = None,
         has_post: Union[bool, None] = None,
+        language: Union[LanguageCode, None] = None,
+        search_text: Union[str, None] = None,
         offset: Union[int, None] = None,
         limit: int = 100,
     ) -> Generator[NoteRequest, None, None]:
@@ -680,6 +682,13 @@ def mock_storage(
                 continue
             if has_post is False and r.post is not None:
                 continue
+            if language is not None and (r.post is None or r.post.language != language):
+                continue
+            if search_text:
+                in_suggestion = any(search_text in (s.suggestion or "") for s in r.suggestions)
+                in_post = r.post is not None and search_text in r.post.text
+                if not (in_suggestion or in_post):
+                    continue
             filtered.append(r)
         yield from filtered[offset or 0 : (offset or 0) + limit]
 
@@ -690,8 +699,16 @@ def mock_storage(
         tweet_created_at_from: Union[TwitterTimestamp, None] = None,
         tweet_created_at_to: Union[TwitterTimestamp, None] = None,
         has_post: Union[bool, None] = None,
+        language: Union[LanguageCode, None] = None,
+        search_text: Union[str, None] = None,
     ) -> int:
-        return len(list(_get_note_requests(tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post, 0, 10**9)))
+        return len(
+            list(
+                _get_note_requests(
+                    tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post, language, search_text, 0, 10**9
+                )
+            )
+        )
 
     mock.get_number_of_note_requests.side_effect = _get_number_of_note_requests
 

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -320,3 +320,18 @@ def test_note_requests_count_search_text_min_length(
 ) -> None:
     response = client.get("/api/v1/data/note-requests/count?search_text=a")
     assert response.status_code == 422
+
+
+def test_note_requests_get_search_text_blank_is_422(
+    client: TestClient, note_request_samples: List[NoteRequest]
+) -> None:
+    # min_length=2 は通るが空白のみは 422（strip で弾く分岐）
+    response = client.get("/api/v1/data/note-requests", params={"search_text": "  "})
+    assert response.status_code == 422
+
+
+def test_note_requests_count_search_text_blank_is_422(
+    client: TestClient, note_request_samples: List[NoteRequest]
+) -> None:
+    response = client.get("/api/v1/data/note-requests/count", params={"search_text": "  "})
+    assert response.status_code == 422

--- a/api/tests/routers/test_data.py
+++ b/api/tests/routers/test_data.py
@@ -299,3 +299,24 @@ def test_note_requests_count(client: TestClient, note_request_samples: List[Note
     response = client.get("/api/v1/data/note-requests/count")
     assert response.status_code == 200
     assert response.json() == {"total": 2}
+
+
+def test_note_requests_get_language_filter_passthrough(
+    client: TestClient, note_request_samples: List[NoteRequest]
+) -> None:
+    # 存在しない言語コードでは 0 件（フィルタが storage に渡っている）
+    response = client.get("/api/v1/data/note-requests?language=zz")
+    assert response.status_code == 200
+    assert response.json()["data"] == []
+
+
+def test_note_requests_get_search_text_min_length(client: TestClient, note_request_samples: List[NoteRequest]) -> None:
+    response = client.get("/api/v1/data/note-requests?search_text=a")
+    assert response.status_code == 422
+
+
+def test_note_requests_count_search_text_min_length(
+    client: TestClient, note_request_samples: List[NoteRequest]
+) -> None:
+    response = client.get("/api/v1/data/note-requests/count?search_text=a")
+    assert response.status_code == 422

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1598,6 +1598,8 @@ class Storage:
         tweet_created_at_from: Union[TwitterTimestamp, None] = None,
         tweet_created_at_to: Union[TwitterTimestamp, None] = None,
         has_post: Union[bool, None] = None,
+        language: Union[LanguageCode, None] = None,
+        search_text: Union[str, None] = None,
     ) -> Any:
         if tweet_ids is not None:
             query = query.filter(RowNoteRequestRecord.tweet_id.in_(tweet_ids))
@@ -1609,6 +1611,19 @@ class Storage:
             query = query.filter(PostRecord.post_id.isnot(None))
         elif has_post is False:
             query = query.filter(PostRecord.post_id.is_(None))
+        if language is not None:
+            query = query.filter(PostRecord.language == language)
+        if search_text:
+            pattern = f"%{search_text}%"
+            # suggestions(JSONB 配列)の各要素の "suggestion" 値だけを対象にする（key/id/source_link を誤爆しない）
+            elem = func.jsonb_array_elements(RowNoteRequestRecord.suggestions).table_valued("value")
+            suggestion_match = (
+                select(1)
+                .select_from(elem)
+                .where(func.jsonb_extract_path_text(elem.c.value, "suggestion").ilike(pattern))
+                .exists()
+            )
+            query = query.filter(or_(suggestion_match, PostRecord.text.ilike(pattern)))
         return query
 
     def get_note_requests(
@@ -1617,6 +1632,8 @@ class Storage:
         tweet_created_at_from: Union[TwitterTimestamp, None] = None,
         tweet_created_at_to: Union[TwitterTimestamp, None] = None,
         has_post: Union[bool, None] = None,
+        language: Union[LanguageCode, None] = None,
+        search_text: Union[str, None] = None,
         offset: Union[int, None] = None,
         limit: int = 100,
     ) -> Generator[NoteRequestModel, None, None]:
@@ -1625,7 +1642,7 @@ class Storage:
                 PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id
             )
             query = self._apply_note_request_filters(
-                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post
+                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post, language, search_text
             )
             query = query.order_by(RowNoteRequestRecord.tweet_id)
             if offset is not None:
@@ -1640,14 +1657,17 @@ class Storage:
         tweet_created_at_from: Union[TwitterTimestamp, None] = None,
         tweet_created_at_to: Union[TwitterTimestamp, None] = None,
         has_post: Union[bool, None] = None,
+        language: Union[LanguageCode, None] = None,
+        search_text: Union[str, None] = None,
     ) -> int:
         with Session(self.engine) as sess:
             query = sess.query(RowNoteRequestRecord)
-            if has_post is not None:
-                # posts への join は has_post フィルタでのみ必要 (post_id は PK 同士なので行数は変わらない)
+            if has_post is not None or language is not None or search_text:
+                # posts への join は has_post / language / search_text のいずれかで必要
+                # (post_id は PK 同士なので行数は変わらない)
                 query = query.outerjoin(PostRecord, RowNoteRequestRecord.tweet_id == PostRecord.post_id)
             query = self._apply_note_request_filters(
-                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post
+                query, tweet_ids, tweet_created_at_from, tweet_created_at_to, has_post, language, search_text
             )
             return int(query.count())
 

--- a/common/birdxplorer_common/storage.py
+++ b/common/birdxplorer_common/storage.py
@@ -1615,8 +1615,14 @@ class Storage:
             query = query.filter(PostRecord.language == language)
         if search_text:
             pattern = f"%{search_text}%"
-            # suggestions(JSONB 配列)の各要素の "suggestion" 値だけを対象にする（key/id/source_link を誤爆しない）
-            elem = func.jsonb_array_elements(RowNoteRequestRecord.suggestions).table_valued("value")
+            # suggestions は NULL や JSON スカラー(null 等)がありうる（未取得行は JSON null で保存される）。
+            # jsonb_array_elements は非 array 値でエラーになるため、array のときだけ展開し他は空配列に倒す。
+            suggestions_array = case(
+                (func.jsonb_typeof(RowNoteRequestRecord.suggestions) == "array", RowNoteRequestRecord.suggestions),
+                else_=text("'[]'::jsonb"),
+            )
+            # 各要素の "suggestion" 値だけを対象にする（key/id/source_link を誤爆しない）
+            elem = func.jsonb_array_elements(suggestions_array).table_valued("value")
             suggestion_match = (
                 select(1)
                 .select_from(elem)

--- a/common/tests/test_storage_note_requests.py
+++ b/common/tests/test_storage_note_requests.py
@@ -142,3 +142,100 @@ def test_get_note_requests_out_of_range_millis_returns_none(engine_for_test: Eng
     actual = list(storage.get_note_requests(tweet_ids=[PostId.from_str("30")]))
     assert len(actual) == 1
     assert actual[0].note_request_feed_eligible_at is None
+
+
+@pytest.fixture
+def note_request_search_sample(
+    engine_for_test: Engine,
+    post_records_sample: List[PostRecord],  # x_users(1234567890123456781) と既存 posts を DB に投入する
+) -> List[RowNoteRequestRecord]:
+    with Session(engine_for_test) as sess:
+        sess.add(
+            PostRecord(
+                post_id="2234567890123456999",
+                user_id="1234567890123456781",
+                text="至急送金してください、これは詐欺の疑いがあります",
+                language="ja",
+                created_at=1152921600000,
+                like_count=0,
+                repost_count=0,
+                impression_count=0,
+            )
+        )
+        records = [
+            # ja Post あり + suggestion に「送金」
+            RowNoteRequestRecord(
+                tweet_id="2234567890123456999",
+                note_request_feed_eligible_at_millis=None,
+                api_small_feed_eligible_at_millis=None,
+                api_large_feed_eligible_at_millis=None,
+                api_xl_feed_eligible_at_millis=None,
+                source_links=None,
+                suggestions=[{"suggestion_id": 1, "suggestion": "送金を促す投稿です", "source_link": ""}],
+                tweet_created_at=1782870000001,
+                lookup_enqueued_at=None,
+            ),
+            # Post 未取得 + suggestion に「送金」（search_text は Post なしでもヒットする）
+            RowNoteRequestRecord(
+                tweet_id="9990000000000000001",
+                note_request_feed_eligible_at_millis=None,
+                api_small_feed_eligible_at_millis=None,
+                api_large_feed_eligible_at_millis=None,
+                api_xl_feed_eligible_at_millis=None,
+                source_links=None,
+                suggestions=[{"suggestion_id": 2, "suggestion": "これは送金詐欺です", "source_link": ""}],
+                tweet_created_at=1782870000002,
+                lookup_enqueued_at=None,
+            ),
+        ]
+        sess.add_all(records)
+        sess.commit()
+    return records
+
+
+def test_get_note_requests_language_filter(
+    engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    # language=ja は ja Post が紐づく行のみ（Post 未取得行は language NULL で除外）
+    actual = [str(r.tweet_id) for r in storage.get_note_requests(language="ja")]
+    assert actual == ["2234567890123456999"]
+
+
+def test_get_note_requests_search_text_matches_post_text_or_suggestion(
+    engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    # 「詐欺」は 999 の Post 本文 と 9990... の suggestion にヒット
+    got = sorted(str(r.tweet_id) for r in storage.get_note_requests(search_text="詐欺"))
+    assert got == ["2234567890123456999", "9990000000000000001"]
+    # 「送金」は両方の suggestion にヒット（Post 未取得行も含む）
+    got2 = sorted(str(r.tweet_id) for r in storage.get_note_requests(search_text="送金"))
+    assert got2 == ["2234567890123456999", "9990000000000000001"]
+
+
+def test_get_note_requests_search_text_does_not_match_keys_or_ids(
+    engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    # suggestion 値だけを対象にするので JSON の key/id/source_link は誤爆しない
+    assert list(storage.get_note_requests(search_text="suggestion_id")) == []
+    assert list(storage.get_note_requests(search_text="source_link")) == []
+
+
+def test_get_note_requests_language_and_search_text_are_anded(
+    engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    # 送金 に両方ヒットするが language=ja で Post ありの 999 のみ
+    got = [str(r.tweet_id) for r in storage.get_note_requests(language="ja", search_text="送金")]
+    assert got == ["2234567890123456999"]
+
+
+def test_get_number_of_note_requests_language_and_search_text(
+    engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
+) -> None:
+    storage = Storage(engine=engine_for_test)
+    assert storage.get_number_of_note_requests(language="ja") == 1
+    assert storage.get_number_of_note_requests(search_text="送金") == 2
+    assert storage.get_number_of_note_requests(language="ja", search_text="送金") == 1

--- a/common/tests/test_storage_note_requests.py
+++ b/common/tests/test_storage_note_requests.py
@@ -239,3 +239,63 @@ def test_get_number_of_note_requests_language_and_search_text(
     assert storage.get_number_of_note_requests(language="ja") == 1
     assert storage.get_number_of_note_requests(search_text="送金") == 2
     assert storage.get_number_of_note_requests(language="ja", search_text="送金") == 1
+
+
+@pytest.fixture
+def note_request_null_suggestions_sample(
+    engine_for_test: Engine,
+    post_records_sample: List[PostRecord],  # x_users(1234567890123456781) を DB に投入する
+) -> List[RowNoteRequestRecord]:
+    with Session(engine_for_test) as sess:
+        sess.add(
+            PostRecord(
+                post_id="2234567890123456998",
+                user_id="1234567890123456781",
+                text="ここに検査キーワードを含む本文",
+                language="en",
+                created_at=1152921600000,
+                like_count=0,
+                repost_count=0,
+                impression_count=0,
+            )
+        )
+        records = [
+            # suggestions=NULL + Post あり（本番で多数派。search_text は post 本文で評価される）
+            RowNoteRequestRecord(
+                tweet_id="2234567890123456998",
+                note_request_feed_eligible_at_millis=None,
+                api_small_feed_eligible_at_millis=None,
+                api_large_feed_eligible_at_millis=None,
+                api_xl_feed_eligible_at_millis=None,
+                source_links=None,
+                suggestions=None,
+                tweet_created_at=1782870000003,
+                lookup_enqueued_at=None,
+            ),
+            # suggestions=NULL + Post なし（どこにもマッチしない）
+            RowNoteRequestRecord(
+                tweet_id="9990000000000000002",
+                note_request_feed_eligible_at_millis=None,
+                api_small_feed_eligible_at_millis=None,
+                api_large_feed_eligible_at_millis=None,
+                api_xl_feed_eligible_at_millis=None,
+                source_links=None,
+                suggestions=None,
+                tweet_created_at=1782870000004,
+                lookup_enqueued_at=None,
+            ),
+        ]
+        sess.add_all(records)
+        sess.commit()
+    return records
+
+
+def test_search_text_handles_null_suggestions(
+    engine_for_test: Engine, note_request_null_suggestions_sample: List[RowNoteRequestRecord]
+) -> None:
+    # 本番で多数を占める suggestions=NULL の行があっても jsonb_array_elements(NULL) で
+    # クエリが落ちず、Post 本文一致は正しく拾い、Post 無し NULL 行は拾わないこと（回帰ガード）。
+    storage = Storage(engine=engine_for_test)
+    got = [str(r.tweet_id) for r in storage.get_note_requests(search_text="検査キーワード")]
+    assert got == ["2234567890123456998"]
+    assert storage.get_number_of_note_requests(search_text="検査キーワード") == 1

--- a/common/tests/test_storage_note_requests.py
+++ b/common/tests/test_storage_note_requests.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from birdxplorer_common.models import Post, PostId
+from birdxplorer_common.models import LanguageCode, Post, PostId
 from birdxplorer_common.storage import PostRecord, RowNoteRequestRecord, Storage
 
 
@@ -198,7 +198,7 @@ def test_get_note_requests_language_filter(
 ) -> None:
     storage = Storage(engine=engine_for_test)
     # language=ja は ja Post が紐づく行のみ（Post 未取得行は language NULL で除外）
-    actual = [str(r.tweet_id) for r in storage.get_note_requests(language="ja")]
+    actual = [str(r.tweet_id) for r in storage.get_note_requests(language=LanguageCode("ja"))]
     assert actual == ["2234567890123456999"]
 
 
@@ -228,7 +228,7 @@ def test_get_note_requests_language_and_search_text_are_anded(
 ) -> None:
     storage = Storage(engine=engine_for_test)
     # 送金 に両方ヒットするが language=ja で Post ありの 999 のみ
-    got = [str(r.tweet_id) for r in storage.get_note_requests(language="ja", search_text="送金")]
+    got = [str(r.tweet_id) for r in storage.get_note_requests(language=LanguageCode("ja"), search_text="送金")]
     assert got == ["2234567890123456999"]
 
 
@@ -236,9 +236,9 @@ def test_get_number_of_note_requests_language_and_search_text(
     engine_for_test: Engine, note_request_search_sample: List[RowNoteRequestRecord]
 ) -> None:
     storage = Storage(engine=engine_for_test)
-    assert storage.get_number_of_note_requests(language="ja") == 1
+    assert storage.get_number_of_note_requests(language=LanguageCode("ja")) == 1
     assert storage.get_number_of_note_requests(search_text="送金") == 2
-    assert storage.get_number_of_note_requests(language="ja", search_text="送金") == 1
+    assert storage.get_number_of_note_requests(language=LanguageCode("ja"), search_text="送金") == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## 概要

`GET /note-requests` と `GET /note-requests/count` に **`language`（Post 言語）** と **`search_text`（suggestion 本文 OR Post 本文の部分一致）** フィルタを追加する。クライアントが全件取得してローカル絞り込みしていた（48日分・約28万件で約8分）のをサーバ側フィルタに置き換えるのが目的。

## 変更内容

### common（storage）
- `Storage._apply_note_request_filters` / `get_note_requests` / `get_number_of_note_requests` に `language` / `search_text` を追加（既存フィルタと AND、いずれも既定 `None` で後方互換）。
- **language**: `PostRecord.language == language`。posts は LEFT JOIN のため、指定時は Post 未取得のリクエストは自然に除外される。
- **search_text**: 次の OR
  - suggestions(JSONB 配列)の各要素の `suggestion` 値のみを対象にした相関 EXISTS（`jsonb_extract_path_text` 使用）。key/id/source_link は誤爆しない。
  - `PostRecord.text ILIKE '%...%'`（本文）
- `get_number_of_note_requests` の posts JOIN 条件を `has_post / language / search_text` のいずれか指定時に拡張（PK 同士なので行数不変）。

### api
- 両エンドポイントに `language`（`LanguageCode`）と `search_text`（`min_length=2`、空白のみは 422）を追加してパススルー。
- `openapi_doc.py` に `language` / `search_text` のパラメータ定義を追加。

## テスト
- common: storage テスト追加（language / search_text＝post本文・suggestion / 誤爆なし / AND / count 整合）。**153 passed**。
- api: router テスト追加（language パススルー / search_text の min_length 422×2）。**177 passed**。
- black / isort / pflake8 / `mypy --strict` いずれもクリーン。
- suggestion 検索の SQLAlchemy 形は実 PostgreSQL で TDD 検証済み（`jsonb_array_elements(...).table_valued("value")` + `jsonb_extract_path_text`）。

## 非対象（別PR）
- 前方ワイルドカード ILIKE 高速化のための pg_trgm インデックス（まず実測、遅ければ別PR）。
- 多語検索・表記ゆらぎ正規化。

## CI 注意
common と api を1つの PR に含むため、`api/Dockerfile.prd` が `common@main` を取り込む構成上、**"Deploy API (dev)" CI がマージ前は構造的に失敗しうる**（common がまだ main に無いため）。既知挙動でマージ後に解消します。`test`（api/common/etl）と各イメージ build が緑であることを確認してください。反映は merge 後の API イメージ再ビルドで有効化されます。
