### PR TITLE
fix: DB書き込み前に NUL(0x00) バイトを除去し db-write/note-transform DLQ 滞留を解消

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/db_writer_lambda.py
@@ -23,6 +23,23 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+def strip_nul_bytes(value: Any) -> Any:
+    """文字列中の NUL(0x00) 文字を再帰的に除去する。
+
+    PostgreSQL のテキスト型は NUL バイトを保存できず、psycopg2 が
+    ``ValueError: A string literal cannot contain NUL (0x00) characters.``
+    を送出する。X の Community Notes summary や投稿本文にまれに NUL が
+    混入するため、DB 書き込み前に全テキストフィールドから除去する。
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {key: strip_nul_bytes(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [strip_nul_bytes(item) for item in value]
+    return value
+
+
 def process_insert_note(postgresql: Any, note_id: str, data: dict) -> None:
     """ノートの挿入処理（UPSERT使用）"""
     note_data = data
@@ -255,7 +272,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 operation = message_body.get("operation")
                 note_id = message_body.get("note_id")
                 post_id = message_body.get("post_id")
-                data = message_body.get("data", {})
+                # PostgreSQL が保存できない NUL(0x00) を全テキストフィールドから除去
+                data = strip_nul_bytes(message_body.get("data", {}))
 
                 if not operation:
                     logger.error(f"[ERROR] Missing operation in message {message_id}")

--- a/etl/tests/test_db_writer_lambda.py
+++ b/etl/tests/test_db_writer_lambda.py
@@ -6,6 +6,7 @@ import pytest
 from birdxplorer_etl.lib.lambda_handler.db_writer_lambda import (
     lambda_handler,
     process_update_post_language,
+    strip_nul_bytes,
 )
 
 
@@ -174,6 +175,63 @@ class TestProcessUpdatePostLanguage:
 
         with pytest.raises(ValueError):
             process_update_post_language(mock_session, "1234567890", {})
+
+
+class TestStripNulBytes:
+    """strip_nul_bytes が NUL(0x00) 文字を再帰的に除去することを検証"""
+
+    def test_removes_nul_from_string(self) -> None:
+        assert strip_nul_bytes("a\x00b\x00c") == "abc"
+
+    def test_string_without_nul_unchanged(self) -> None:
+        assert strip_nul_bytes("hello") == "hello"
+
+    def test_removes_nul_in_nested_dict(self) -> None:
+        result = strip_nul_bytes({"summary": "pay\x00out", "tweet_id": "123"})
+        assert result == {"summary": "payout", "tweet_id": "123"}
+
+    def test_removes_nul_in_nested_list_and_dict(self) -> None:
+        result = strip_nul_bytes({"post_data": {"text": "a\x00b", "media": [{"url": "u\x00rl"}]}})
+        assert result == {"post_data": {"text": "ab", "media": [{"url": "url"}]}}
+
+    def test_non_string_values_preserved(self) -> None:
+        result = strip_nul_bytes({"count": 5, "flag": True, "none": None, "text": "x\x00y"})
+        assert result == {"count": 5, "flag": True, "none": None, "text": "xy"}
+
+
+class TestInsertNoteStripsNul:
+    """insert_note 経由で summary の NUL バイトが除去されて書き込まれることを検証"""
+
+    @patch("birdxplorer_etl.lib.lambda_handler.db_writer_lambda.init_postgresql")
+    def test_summary_with_nul_is_sanitized_before_insert(self, mock_init_pg: MagicMock) -> None:
+        mock_session = MagicMock()
+        mock_init_pg.return_value = mock_session
+
+        event = {
+            "Records": [
+                {
+                    "messageId": "msg-nul",
+                    "body": json.dumps(
+                        {
+                            "operation": "insert_note",
+                            "note_id": "n1",
+                            "data": {
+                                "note_id": "n1",
+                                "summary": "pay\x00out screenshot",
+                                "tweet_id": "t1",
+                                "created_at_millis": 1786552607612,
+                            },
+                        }
+                    ),
+                }
+            ]
+        }
+
+        result = lambda_handler(event, {})
+
+        assert result["batchItemFailures"] == []
+        stmt = mock_session.execute.call_args_list[0][0][0]
+        assert stmt.compile().params["summary"] == "payout screenshot"
 
 
 class TestUpdatePostLanguageDispatch:


### PR DESCRIPTION
## 概要

db-write DLQ / note-transform DLQ の CloudWatch アラーム（2026-08-12 16:57 UTC 発火）の恒久対応。

## 原因

X の Community Notes summary に NUL(0x00) バイトが混入したノート（`note_id: 2087579058775187609`）が発端。PostgreSQL のテキスト型は NUL を保存できず、`row_notes` への upsert 時に psycopg2 が例外を送出する:

```
[ERROR] Validation error in message ...: A string literal cannot contain NUL (0x00) characters.
```

これが**二重障害**を引き起こしていた:

1. **db-write DLQ**: `insert_note` が NUL で失敗 → 5 回リトライ後 DLQ 行き
2. **note-transform DLQ**: db-write が失敗して `row_notes` に行が作られないため、後段の note-transform が同じノートを見つけられず `Note not found in row_notes` で DLQ 行き

## 修正

`db_writer_lambda.lambda_handler` の `data` 読み取り箇所という**単一チョークポイント**で、再帰的に NUL バイトを除去する `strip_nul_bytes` を適用。

- `insert_note` の `summary`
- `save_post_data` のネストした各テキストフィールド（post text / user name・description / URL 等）

の両方を 1 箇所でカバーする。NUL 以外の制御文字は PostgreSQL が受理するため除去対象外とし、正当なコンテンツを変更しない。

## テスト

- `strip_nul_bytes` の純関数テスト（文字列 / ネスト dict / list / 非文字列保持）
- `insert_note` 経由で summary の NUL が除去され、コンパイル済み SQL パラメータに NUL が残らないことを検証
- `cd etl && tox` → 260 passed, 4 skipped / black・isort・pflake8 すべて OK

## デプロイ後の残作業

このデプロイ後、両 DLQ に滞留中の該当メッセージ（各約 2 件、実体は同一ノート）を redrive すれば解消する見込み。
