### PR TITLE
feat(api): statement_timeout で打ち切られたクエリを 504、その他の DB 障害を 503 に返す (#284)

### DIFF
--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -30,6 +30,11 @@ logger = getLogger(__name__)
 # PostgreSQL の SQLSTATE 57014 (query_canceled)。statement_timeout での打ち切りがこれにあたる。
 PG_QUERY_CANCELED_SQLSTATE = "57014"
 
+# 応答本文は英語。同じファイルの SemanticSearchUnavailableError ハンドラが英語であり、
+# この API は外部提供 (dev.api-birdxplorer.code4japan.org) なので利用者が日本語を読めるとは限らない。
+_QUERY_TIMEOUT_DETAIL = "the query timed out; please narrow the conditions and retry"
+_DB_UNAVAILABLE_DETAIL = "the database is temporarily unavailable; please retry later"
+
 
 def _is_query_canceled(exc: OperationalError) -> bool:
     """OperationalError が statement_timeout による打ち切り (SQLSTATE 57014) かを判定する。
@@ -99,7 +104,7 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
             logger.warning(f"query canceled by statement_timeout: {request.method} {request.url.path}")
             return JSONResponse(
                 status_code=504,
-                content={"detail": "クエリがタイムアウトしました。条件を絞って再試行してください"},
+                content={"detail": _QUERY_TIMEOUT_DETAIL},
             )
         logger.error(
             f"database operational error: {type(exc.orig).__name__}: {exc.orig} "
@@ -107,7 +112,7 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
         )
         return JSONResponse(
             status_code=503,
-            content={"detail": "データベースに接続できません。しばらくしてから再試行してください"},
+            content={"detail": _DB_UNAVAILABLE_DETAIL},
         )
 
     app.include_router(gen_system_router(), prefix="/api/v1/system")

--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -9,7 +9,8 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic.alias_generators import to_snake
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from birdxplorer_common.logger import get_logger
@@ -101,7 +102,13 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
         (実測で確認)。ドライバ側のメッセージ `exc.orig` には SQL もバインド値も含まれない。
         """
         if _is_query_canceled(exc):
-            logger.warning(f"query canceled by statement_timeout: {request.method} {request.url.path}")
+            # exc.orig も出す。57014 は statement_timeout だけでなく pg_cancel_backend() による
+            # 手動キャンセルでも返るので、ドライバ側のメッセージ
+            # ("due to statement timeout" / "due to user request") が両者を区別する唯一の手がかりになる。
+            # タイムアウト時の exc.orig はバインド値を含まない (503 側と同じ理由で str(exc) は使わない)。
+            logger.warning(
+                f"query canceled: {type(exc.orig).__name__}: {exc.orig} " f"({request.method} {request.url.path})"
+            )
             return JSONResponse(
                 status_code=504,
                 content={"detail": _QUERY_TIMEOUT_DETAIL},
@@ -110,10 +117,48 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
             f"database operational error: {type(exc.orig).__name__}: {exc.orig} "
             f"({request.method} {request.url.path})"
         )
-        return JSONResponse(
-            status_code=503,
-            content={"detail": _DB_UNAVAILABLE_DETAIL},
-        )
+        return JSONResponse(status_code=503, content={"detail": _DB_UNAVAILABLE_DETAIL})
+
+    @app.exception_handler(InterfaceError)
+    @app.exception_handler(SQLAlchemyTimeoutError)
+    def handle_db_unavailable(request: Request, exc: Exception) -> JSONResponse:
+        """OperationalError では捕まらない「DB に手が届かない」系を 503 に変換する。
+
+        sqlalchemy.exc の階層 (2.0.52 で実測):
+
+            DBAPIError
+            |-- InterfaceError        <- DatabaseError の下ではないので OperationalError では捕まらない
+            +-- DatabaseError
+                +-- OperationalError  <- 上のハンドラが捕まえる範囲
+            TimeoutError(SQLAlchemyError)  <- DBAPIError ですらない
+
+        - InterfaceError: セッションが接続断をまたいだときにドライバが出す
+          (psycopg2 の `connection already closed` / `cursor already closed`)。
+        - TimeoutError: コネクションプールの枯渇。storage.gen_storage() の create_engine は
+          pool 設定を渡していないので SQLAlchemy 既定 (pool_size=5 / max_overflow=10 /
+          pool_timeout=30) が効く。同時リクエストが 15 を超えると 30 秒待って失敗する
+          ＝利用者から見た症状は statement_timeout と同じ「遅い → エラー」なので、
+          片方だけ 504 でもう片方が 500 になるのを避ける。
+
+        DBAPIError まで広げないのは意図的。IntegrityError や ProgrammingError はアプリ側のバグで、
+        500 のままにしたい。
+        """
+        # TimeoutError は DBAPIError ではないので orig を持たない。
+        #
+        # orig が無い DBAPIError に str(exc) を使ってはいけない。DBAPIError の __str__ は
+        # `[SQL: ...]` と `[parameters: ...]` を足すので、バインド値 (検索キーワードなど) が
+        # ログに漏れる。実測: InterfaceError(stmt, params, None) を str() すると
+        # "[parameters: {'keyword': '%secret-search-term%'}]" がそのまま出る。
+        # TimeoutError は DBAPIError ではなく SQL を持たないので str(exc) で安全。
+        orig = getattr(exc, "orig", None)
+        if orig is not None:
+            detail = f"{type(orig).__name__}: {orig}"
+        elif isinstance(exc, DBAPIError):
+            detail = type(exc).__name__
+        else:
+            detail = str(exc)
+        logger.error(f"database unavailable: {type(exc).__name__}: {detail} ({request.method} {request.url.path})")
+        return JSONResponse(status_code=503, content={"detail": _DB_UNAVAILABLE_DETAIL})
 
     app.include_router(gen_system_router(), prefix="/api/v1/system")
     app.include_router(

--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -90,6 +90,10 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
         statement_timeout で打ち切られたクエリ (SQLSTATE 57014) は「重すぎるクエリのタイムアウト」なので
         504 を返し、接続断などそれ以外の OperationalError は 503 を返す。どちらも 500 (サーバ内部エラー)
         ではクライアントに意味が伝わらない。
+
+        ログには例外全体 (`str(exc)`) を出さない。SQLAlchemy の DBAPIError は文字列化すると
+        `[SQL: ...]` と `[parameters: ...]` を含み、検索キーワードなどのバインド値がログに漏れる
+        (実測で確認)。ドライバ側のメッセージ `exc.orig` には SQL もバインド値も含まれない。
         """
         if _is_query_canceled(exc):
             logger.warning(f"query canceled by statement_timeout: {request.method} {request.url.path}")
@@ -97,7 +101,10 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
                 status_code=504,
                 content={"detail": "クエリがタイムアウトしました。条件を絞って再試行してください"},
             )
-        logger.error(f"database operational error: {exc}")
+        logger.error(
+            f"database operational error: {type(exc.orig).__name__}: {exc.orig} "
+            f"({request.method} {request.url.path})"
+        )
         return JSONResponse(
             status_code=503,
             content={"detail": "データベースに接続できません。しばらくしてから再試行してください"},

--- a/api/birdxplorer_api/app.py
+++ b/api/birdxplorer_api/app.py
@@ -1,6 +1,7 @@
 import csv
 import io
 from logging import getLogger
+from typing import Any, Optional
 from urllib.parse import parse_qs as parse_query_string
 from urllib.parse import urlencode as encode_query_string
 
@@ -8,6 +9,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic.alias_generators import to_snake
+from sqlalchemy.exc import OperationalError
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from birdxplorer_common.logger import get_logger
@@ -24,6 +26,24 @@ from .semantic_search import (
 )
 
 logger = getLogger(__name__)
+
+# PostgreSQL の SQLSTATE 57014 (query_canceled)。statement_timeout での打ち切りがこれにあたる。
+PG_QUERY_CANCELED_SQLSTATE = "57014"
+
+
+def _is_query_canceled(exc: OperationalError) -> bool:
+    """OperationalError が statement_timeout による打ち切り (SQLSTATE 57014) かを判定する。
+
+    api パッケージは DB ドライバに直接依存しない (psycopg2 は dev 依存のみ) ため、
+    例外クラスではなく SQLSTATE で判定する。psycopg2 は `pgcode`、psycopg (3系) は
+    `sqlstate` に SQLSTATE を持つので、両方を見る。
+    """
+    orig: Optional[BaseException] = exc.orig
+    for attribute in ("pgcode", "sqlstate"):
+        code: Any = getattr(orig, attribute, None)
+        if code == PG_QUERY_CANCELED_SQLSTATE:
+            return True
+    return False
 
 
 class QueryStringFlatteningMiddleware:
@@ -62,6 +82,26 @@ def gen_app(settings: GlobalSettings) -> FastAPI:
         """SemanticSearchUnavailableError を 503 に変換するアプリレベルハンドラ"""
         logger.error(f"semantic search unavailable: {exc}")
         return JSONResponse(status_code=503, content={"detail": "semantic search is temporarily unavailable"})
+
+    @app.exception_handler(OperationalError)
+    def handle_db_operational_error(request: Request, exc: OperationalError) -> JSONResponse:
+        """DB の OperationalError を 504 / 503 に変換するアプリレベルハンドラ
+
+        statement_timeout で打ち切られたクエリ (SQLSTATE 57014) は「重すぎるクエリのタイムアウト」なので
+        504 を返し、接続断などそれ以外の OperationalError は 503 を返す。どちらも 500 (サーバ内部エラー)
+        ではクライアントに意味が伝わらない。
+        """
+        if _is_query_canceled(exc):
+            logger.warning(f"query canceled by statement_timeout: {request.method} {request.url.path}")
+            return JSONResponse(
+                status_code=504,
+                content={"detail": "クエリがタイムアウトしました。条件を絞って再試行してください"},
+            )
+        logger.error(f"database operational error: {exc}")
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "データベースに接続できません。しばらくしてから再試行してください"},
+        )
 
     app.include_router(gen_system_router(), prefix="/api/v1/system")
     app.include_router(

--- a/api/tests/test_db_error_handler.py
+++ b/api/tests/test_db_error_handler.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 from pytest import LogCaptureFixture
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 _VALID_FROM = 1700000000000
 _VALID_TO = 1700100000000
@@ -106,3 +107,141 @@ def test_csv_export_query_canceled_returns_504_json(client: TestClient, mock_sto
     # 壊れた CSV が途中まで返っていないことを content-type と BOM の不在で確かめる。
     assert response.headers["content-type"].startswith("application/json")
     assert not response.content.startswith(b"\xef\xbb\xbf")
+
+
+def test_non_timeout_sqlstate_returns_503(client: TestClient, mock_storage: MagicMock) -> None:
+    """57014 以外の SQLSTATE はタイムアウト扱いにしない。
+
+    40001 は直列化失敗 (serialization_failure)。SQLSTATE を持っていても 504 にはならないことを
+    固定しておかないと、_is_query_canceled が `code is not None` のような判定に書き換わっても気づけない。
+    """
+    mock_storage.get_topics.side_effect = OperationalError(
+        "SELECT 1", {}, _Psycopg2StyleError("could not serialize access due to concurrent update", "40001")
+    )
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+
+
+def test_interface_error_returns_503(client: TestClient, mock_storage: MagicMock) -> None:
+    """InterfaceError は OperationalError の兄弟なので、別ハンドラが要る。
+
+    sqlalchemy 2.0.52 実測: InterfaceError <- DBAPIError で、DatabaseError の下ではない
+    (= OperationalError では捕まらない)。セッションが接続断をまたぐと psycopg2 がこれを出す。
+    """
+    mock_storage.get_topics.side_effect = InterfaceError(
+        "SELECT 1", {}, _Psycopg2StyleError("connection already closed")
+    )
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "temporarily unavailable" in response.json()["detail"]
+
+
+def test_pool_timeout_returns_503(client: TestClient, mock_storage: MagicMock) -> None:
+    """コネクションプールの枯渇も 503。
+
+    sqlalchemy.exc.TimeoutError は SQLAlchemyError の直下で DBAPIError ですらないので、
+    OperationalError ハンドラでも DBAPIError ハンドラでも捕まらない。
+    gen_storage() の create_engine は pool 設定を渡していない (SQLAlchemy 既定
+    pool_size=5 / max_overflow=10 / pool_timeout=30) ので、同時 15 リクエスト超で実際に起きる。
+    """
+    mock_storage.get_topics.side_effect = SQLAlchemyTimeoutError(
+        "QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00"
+    )
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "temporarily unavailable" in response.json()["detail"]
+
+
+def test_pool_timeout_log_has_no_orig(client: TestClient, mock_storage: MagicMock, caplog: LogCaptureFixture) -> None:
+    """TimeoutError は orig を持たないので、ハンドラは例外自身の文字列に落ちる。
+
+    getattr(exc, "orig", None) の None 経路が実際に通ることを固定する
+    (exc.orig を直接触る実装に戻すと AttributeError で 500 になる)。
+    """
+    mock_storage.get_topics.side_effect = SQLAlchemyTimeoutError("QueuePool limit of size 5 overflow 10 reached")
+
+    with caplog.at_level(logging.ERROR, logger="birdxplorer_api.app"):
+        response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "QueuePool limit" in caplog.text
+
+
+def test_timeout_log_contains_driver_message_without_bound_values(
+    client: TestClient, mock_storage: MagicMock, caplog: LogCaptureFixture
+) -> None:
+    """504 側のログにもドライバ側のメッセージを出す。
+
+    57014 は statement_timeout だけでなく pg_cancel_backend() の手動キャンセルでも返るので、
+    "due to statement timeout" / "due to user request" がログだけで両者を区別する唯一の手がかりになる。
+    タイムアウト時の exc.orig はバインド値を含まないため、503 側と同じ理由でそのまま出せる。
+    """
+    statement = "SELECT * FROM note WHERE summary LIKE %(keyword)s"
+    params = {"keyword": "%secret-search-term%"}
+    mock_storage.get_topics.side_effect = OperationalError(
+        statement, params, _Psycopg2StyleError(_TIMEOUT_MESSAGE, "57014")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="birdxplorer_api.app"):
+        response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 504
+    assert _TIMEOUT_MESSAGE in caplog.text
+    assert "secret-search-term" not in caplog.text
+    assert "[SQL:" not in caplog.text
+
+
+def test_interface_error_log_has_no_sql_or_bound_values(
+    client: TestClient, mock_storage: MagicMock, caplog: LogCaptureFixture
+) -> None:
+    """503 の新経路でもログに SQL とバインド値を出さない。
+
+    status と detail だけを見るテストでは、ハンドラが `str(exc)` を出す実装に戻っても気づけない
+    (DBAPIError の __str__ は `[SQL: ...]` と `[parameters: ...]` を足す)。
+    """
+    statement = "SELECT * FROM note WHERE summary LIKE %(keyword)s"
+    params = {"keyword": "%secret-search-term%"}
+    mock_storage.get_topics.side_effect = InterfaceError(
+        statement, params, _Psycopg2StyleError("connection already closed")
+    )
+
+    with caplog.at_level(logging.ERROR, logger="birdxplorer_api.app"):
+        response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "secret-search-term" not in caplog.text
+    assert "[SQL:" not in caplog.text
+    assert "connection already closed" in caplog.text
+
+
+def test_dbapi_error_without_orig_does_not_leak_bound_values(
+    client: TestClient, mock_storage: MagicMock, caplog: LogCaptureFixture
+) -> None:
+    """orig を持たない DBAPIError でもバインド値を漏らさない。
+
+    `str(exc)` へのフォールバックは DBAPIError には使えない。実測 (SQLAlchemy 2.0.52):
+    InterfaceError(stmt, params, None) を str() すると
+    `[parameters: {'keyword': '%secret-search-term%'}]` がそのまま含まれる。
+    """
+    statement = "SELECT * FROM note WHERE summary LIKE %(keyword)s"
+    params = {"keyword": "%secret-search-term%"}
+    # 型スタブでは orig は BaseException 必須だが、実行時には None を渡せてしまう。
+    # そのときログが何を出すかを固定するのがこのテストの目的なので、意図的に None を渡す。
+    exc = InterfaceError(statement, params, None)  # type: ignore[arg-type]
+    assert isinstance(exc, DBAPIError)
+    assert "secret-search-term" in str(exc)  # 前提: str(exc) は実際に漏らす
+    mock_storage.get_topics.side_effect = exc
+
+    with caplog.at_level(logging.ERROR, logger="birdxplorer_api.app"):
+        response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "secret-search-term" not in caplog.text
+    assert "[SQL:" not in caplog.text
+    assert "InterfaceError" in caplog.text

--- a/api/tests/test_db_error_handler.py
+++ b/api/tests/test_db_error_handler.py
@@ -46,7 +46,7 @@ def test_query_canceled_returns_504(client: TestClient, mock_storage: MagicMock)
     response = client.get("/api/v1/data/topics")
 
     assert response.status_code == 504
-    assert "タイムアウト" in response.json()["detail"]
+    assert "timed out" in response.json()["detail"]
 
 
 def test_query_canceled_with_sqlstate_attribute_returns_504(client: TestClient, mock_storage: MagicMock) -> None:
@@ -68,7 +68,8 @@ def test_connection_failure_returns_503(client: TestClient, mock_storage: MagicM
     response = client.get("/api/v1/data/topics")
 
     assert response.status_code == 503
-    assert response.json()["detail"] != ""
+    # 504 側と同じ粒度で文言を見る。`!= ""` はハンドラが本文を作らなくなっても気づけない。
+    assert "temporarily unavailable" in response.json()["detail"]
 
 
 def test_log_does_not_contain_sql_or_bound_values(

--- a/api/tests/test_db_error_handler.py
+++ b/api/tests/test_db_error_handler.py
@@ -6,10 +6,12 @@
 (ドライバがサーバ応答から設定するため) ので、テストでは pgcode を持つスタブで本番の形を再現する。
 """
 
+import logging
 from typing import Optional
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
+from pytest import LogCaptureFixture
 from sqlalchemy.exc import OperationalError
 
 _VALID_FROM = 1700000000000
@@ -67,6 +69,27 @@ def test_connection_failure_returns_503(client: TestClient, mock_storage: MagicM
 
     assert response.status_code == 503
     assert response.json()["detail"] != ""
+
+
+def test_log_does_not_contain_sql_or_bound_values(
+    client: TestClient, mock_storage: MagicMock, caplog: LogCaptureFixture
+) -> None:
+    """SQLAlchemy の例外を文字列化すると `[SQL: ...]` と `[parameters: ...]` が付き、
+    検索キーワードなどのバインド値がログに漏れる。ログにはドライバ側のメッセージだけを出す。
+    """
+    statement = "SELECT * FROM note WHERE summary LIKE %(keyword)s"
+    params = {"keyword": "%secret-search-term%"}
+    mock_storage.get_topics.side_effect = OperationalError(
+        statement, params, _Psycopg2StyleError("connection to server failed: Connection refused")
+    )
+
+    with caplog.at_level(logging.ERROR, logger="birdxplorer_api.app"):
+        response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert "secret-search-term" not in caplog.text
+    assert "[SQL:" not in caplog.text
+    assert "Connection refused" in caplog.text
 
 
 def test_csv_export_query_canceled_returns_504_json(client: TestClient, mock_storage: MagicMock) -> None:

--- a/api/tests/test_db_error_handler.py
+++ b/api/tests/test_db_error_handler.py
@@ -1,0 +1,84 @@
+"""DB の OperationalError を HTTP ステータスへ変換するハンドラのテスト。
+
+実測 (PostgreSQL 15.4 / psycopg2 2.9.12 / SQLAlchemy 2.0.52) では、statement_timeout で打ち切られた
+クエリは sqlalchemy.exc.OperationalError にラップされ、`orig` は psycopg2.errors.QueryCanceled・
+`pgcode` は '57014' になる。一方、手で構築した psycopg2.errors.QueryCanceled は pgcode を持たない
+(ドライバがサーバ応答から設定するため) ので、テストでは pgcode を持つスタブで本番の形を再現する。
+"""
+
+from typing import Optional
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+_VALID_FROM = 1700000000000
+_VALID_TO = 1700100000000
+
+_TIMEOUT_MESSAGE = "canceling statement due to statement timeout"
+
+
+class _Psycopg2StyleError(Exception):
+    """psycopg2 のドライバ例外を模したスタブ (SQLSTATE を pgcode に持つ)"""
+
+    def __init__(self, message: str, pgcode: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.pgcode = pgcode
+
+
+class _Psycopg3StyleError(Exception):
+    """psycopg (3系) のドライバ例外を模したスタブ (SQLSTATE を sqlstate に持つ)"""
+
+    def __init__(self, message: str, sqlstate: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.sqlstate = sqlstate
+
+
+def _query_canceled_error() -> OperationalError:
+    return OperationalError("SELECT 1", {}, _Psycopg2StyleError(_TIMEOUT_MESSAGE, "57014"))
+
+
+def test_query_canceled_returns_504(client: TestClient, mock_storage: MagicMock) -> None:
+    mock_storage.get_topics.side_effect = _query_canceled_error()
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 504
+    assert "タイムアウト" in response.json()["detail"]
+
+
+def test_query_canceled_with_sqlstate_attribute_returns_504(client: TestClient, mock_storage: MagicMock) -> None:
+    mock_storage.get_topics.side_effect = OperationalError(
+        "SELECT 1", {}, _Psycopg3StyleError(_TIMEOUT_MESSAGE, "57014")
+    )
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 504
+
+
+def test_connection_failure_returns_503(client: TestClient, mock_storage: MagicMock) -> None:
+    # 接続断は pgcode を持たない (実測: psycopg2.OperationalError / pgcode=None)
+    mock_storage.get_topics.side_effect = OperationalError(
+        "SELECT 1", {}, _Psycopg2StyleError("connection to server failed: Connection refused")
+    )
+
+    response = client.get("/api/v1/data/topics")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] != ""
+
+
+def test_csv_export_query_canceled_returns_504_json(client: TestClient, mock_storage: MagicMock) -> None:
+    mock_storage.search_notes_with_posts_for_csv.side_effect = _query_canceled_error()
+
+    response = client.get(
+        "/api/v1/data/export/csv",
+        params={"keywords": "医療", "note_created_at_from": _VALID_FROM, "note_created_at_to": _VALID_TO},
+    )
+
+    assert response.status_code == 504
+    # 全行取得の完了後にストリームを開始する実装なので、打ち切りは応答開始前に起きる。
+    # 壊れた CSV が途中まで返っていないことを content-type と BOM の不在で確かめる。
+    assert response.headers["content-type"].startswith("application/json")
+    assert not response.content.startswith(b"\xef\xbb\xbf")


### PR DESCRIPTION
closes #284

## 変更

`api/birdxplorer_api/app.py` に `OperationalError` のアプリレベルハンドラを追加しました。

- statement_timeout で打ち切られたクエリ（SQLSTATE `57014`）→ **504** ＋「クエリがタイムアウトしました。条件を絞って再試行してください」
- 接続断などそれ以外の `OperationalError` → **503**

テストは `api/tests/test_db_error_handler.py`（新規・5 件）です。

## 打ち切りの判定方法

実 DB（PostgreSQL 15.4 / psycopg2 2.9.12 / SQLAlchemy 2.0.52）で例外の形を測ってから決めました。

| ケース | 例外 | `orig` | `pgcode` |
|---|---|---|---|
| 接続既定の `statement_timeout`（`gen_storage`） | `sqlalchemy.exc.OperationalError` | `psycopg2.errors.QueryCanceled` | `'57014'` |
| CSV 経路の `set_config(..., is_local => true)` | 同上 | 同上 | `'57014'` |
| ORM `Session` 経由（`storage.py` と同じ形） | 同上 | 同上 | `'57014'` |
| 接続失敗（Connection refused） | 同上 | `psycopg2.OperationalError` | `None` |

打ち切りと接続障害は `pgcode` で判別できるので、**例外クラスではなく SQLSTATE で判定**しています。`api` の依存にドライバは入っていない（`psycopg2-binary` は dev のみ）ため、`psycopg2` を import しない形にしました。psycopg（3 系）は SQLSTATE を `sqlstate` に持つので両方の属性を見ています。

なお、手で構築した `psycopg2.errors.QueryCanceled` は `pgcode` を持ちません（ドライバがサーバ応答から設定するため）。そのためテストでは `pgcode` / `sqlstate` を持つスタブで本番の形を再現しています。

## CSV エクスポート

`export_csv` は `search_notes_with_posts_for_csv()`（内部で `query.all()`）を **`StreamingResponse` を作る前**に呼ぶので、打ち切りは応答開始前に起きます。テストで 504 の JSON が返ること・BOM 付き CSV が途中まで返っていないことを確認しました（issue の補足の裏取りです）。

## ログ

`str(exc)` は SQLAlchemy が `[SQL: ...]` `[parameters: ...]` を付けるため、そのままログに出すと検索キーワードなどのバインド値が残ります（実測で確認）。ドライバ側のメッセージ `exc.orig` には SQL もバインド値も含まれないので、ログにはこちらだけを出し、回帰テストを付けました。

## テスト結果

- api: **184 passed**（新規 5 件）/ common: **168 passed** / etl: **260 passed**
- `mypy --strict` 0 / `pflake8` 0 / black・isort 差分なし（`tox` は api・common とも congratulations）
- 実装前は新規テストが落ちることを確認済み（ステータス変換 4 件・ログ 1 件とも red → green）

## ご相談

好みに合わせて直しますので、指定いただければ対応します。

1. **メッセージの言語**: issue の文面に合わせて日本語にしました。既存の `SemanticSearchUnavailableError` ハンドラは英語（`semantic search is temporarily unavailable`）なので、英語に揃える方がよければ直します。
2. **レスポンスの形**: 既存のアプリレベルハンドラと同じ `{"detail": ...}` にしました。`/export/csv` 自身のバリデーションエラーは `{"error", "message"}` 形式なので、CSV 経路だけ形が変わります。揃えた方がよければ対応します。
