### PR TITLE
fix(etl): X API 402 でバッチを停止する（未処理のまま receive を焼き続けるのを止める）

### DIFF
--- a/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
@@ -104,7 +104,10 @@ def connect_to_endpoint(url: str) -> tuple[dict, Optional[int]]:
         # 毎分 receive し続け、ApproximateReceiveCount だけが進んで maxReceiveCount に達し、
         # 未処理のまま DLQ へ送られる。2026-08-14 の枯渇では実際にこれが起きた。
         logger.error("[CREDITS_DEPLETED] X API 402 Payment Required. API credits exhausted. Stopping batch.")
-        return {"status": "credits_depleted"}, 0
+        # rate_remaining は None を返す。402 はレート制限の残量について何も言っていない。
+        # ここで 0 を返すと、仮に should_stop の break が外れたときに
+        # 「rate limit exhausted」の停止条件を誤って踏み、原因を取り違える。
+        return {"status": "credits_depleted"}, None
     elif response.status_code == 401:
         logger.error("[DLQ_CAUSE:AUTH_FAILED] X API 401 Unauthorized. Check X_BEARER_TOKEN.")
         raise Exception("X API authentication failed: 401 Unauthorized. Token may be invalid or expired.")
@@ -129,6 +132,7 @@ def lookup(id: str) -> tuple[dict, Optional[int]]:
         - 非公開時: ({"status": "protected", "title": ..., "detail": ...}, rate_remaining)
         - その他エラー: ({"status": "error", "title": ..., "detail": ...}, rate_remaining)
         - レート制限時: ({"status": "rate_limited"}, 0)
+        - クレジット枯渇時: ({"status": "credits_depleted"}, None)
     """
     url = create_url(id)
     json_response, rate_remaining = connect_to_endpoint(url)
@@ -177,6 +181,26 @@ def _poll_message(sqs_handler: SQSHandler, queue_url: str) -> Optional[dict]:
 
 MAX_MESSAGES_PER_INVOCATION = 35
 TIMEOUT_BUFFER_MS = 10_000  # 10秒のバッファ
+
+
+def _raise_if_lookup_unavailable(result: dict, should_stop: bool, tweet_id: str) -> None:
+    """取得できていないのに成功として返さないようにする。
+
+    バッチ経路以外(SQS Records / 直接呼び出し)は should_stop を捨てて常に 200 を返して
+    いた。そのため 402 や 429 でツイートを1件も取得できていないのに statusCode 200 が
+    返り、手動バックフィルのスクリプトが「全件成功・0行書き込み」を成功と報告する。
+    さらに将来 SqsEventSource を付けると、200 を見た SQS がメッセージを削除してしまい、
+    DLQ にも残らず恒久的に失われる。
+
+    例外を送出して Lambda の呼び出し自体を失敗させる(Errors メトリクスに出る)。
+    402 は本変更以前も connect_to_endpoint が raise していたので、その挙動に戻す形。
+    """
+    if not should_stop:
+        return
+    if result.get("credits_depleted"):
+        raise Exception(f"X API credits depleted; tweet {tweet_id} was not fetched")
+    if result.get("rate_limited"):
+        raise Exception(f"X API rate limited; tweet {tweet_id} was not fetched")
 
 
 def _process_single_tweet(
@@ -237,7 +261,7 @@ def _process_single_tweet(
             # 別ステータスにしているのは、運用上の原因がレート制限とは全く異なるため
             # (課金の問題であり、待っても回復しない)。ログのキーワードも分けている。
             logger.error("[CREDITS_DEPLETED] Message not deleted. Batch stopped until credits are restored.")
-            return {"credits_depleted": True, "tweet_id": tweet_id}, 0, True
+            return {"credits_depleted": True, "tweet_id": tweet_id}, None, True
 
         detail = post.get("detail", "")
         if status == "deleted":
@@ -420,7 +444,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     "body": json.dumps({"error": "No valid tweet_lookup message found in Records"}),
                 }
 
-            result, _rate_remaining, _should_stop = _process_single_tweet(
+            result, _rate_remaining, should_stop = _process_single_tweet(
                 tweet_id=tweet_id,
                 receipt_handle=None,
                 skip_tweet_lookup=skip_tweet_lookup,
@@ -429,12 +453,13 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 post_transform_queue_url=post_transform_queue_url,
                 tweet_lookup_queue_url=tweet_lookup_queue_url,
             )
+            _raise_if_lookup_unavailable(result, should_stop, tweet_id)
             return {"statusCode": 200, "body": json.dumps(result)}
 
         # 2. 直接呼び出しの場合
         if "tweet_id" in event:
             tweet_id = event["tweet_id"]
-            result, _rate_remaining, _should_stop = _process_single_tweet(
+            result, _rate_remaining, should_stop = _process_single_tweet(
                 tweet_id=tweet_id,
                 receipt_handle=None,
                 skip_tweet_lookup=False,
@@ -443,6 +468,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 post_transform_queue_url=post_transform_queue_url,
                 tweet_lookup_queue_url=tweet_lookup_queue_url,
             )
+            _raise_if_lookup_unavailable(result, should_stop, tweet_id)
             return {"statusCode": 200, "body": json.dumps(result)}
 
         # 3. EventBridge起動の場合 — バッチ処理ループ

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
@@ -116,6 +116,11 @@ def connect_to_endpoint(url: str) -> tuple[dict, Optional[int]]:
         logger.warning("[RATE_LIMITED] 429 received. Message will return to queue via visibility timeout.")
         return {"status": "rate_limited"}, 0
     elif response.status_code == 402:
+        # ⚠️ デプロイ順序: BirdXplorer-cdk の tweet-lookup retentionPeriod 14日化を
+        # 必ず先にデプロイすること。この変更を先に入れると receive が毎分35件から1件に
+        # 落ちて DLQ への退避が止まり、保持期間4日のまま滞留が全件消える。現状は receive の
+        # 回転で一部が DLQ に逃げて14日まで残るので、順序を誤ると何もしないより悪くなる。
+        #
         # X API のクレジット枯渇。全リクエストが失敗するのでバッチを止める。
         # ここで止めないと 1 メッセージも処理できないまま MAX_MESSAGES_PER_INVOCATION 件を
         # 毎分 receive し続け、ApproximateReceiveCount だけが進んで maxReceiveCount に達し、
@@ -200,13 +205,19 @@ MAX_MESSAGES_PER_INVOCATION = 35
 TIMEOUT_BUFFER_MS = 10_000  # 10秒のバッファ
 
 
-def _raise_if_lookup_unavailable(result: dict, should_stop: bool, tweet_id: str) -> None:
+def _raise_if_lookup_unavailable(result: dict[str, Any], should_stop: bool, tweet_id: str) -> None:
     """should_stop なら例外を送出する。取得できていない呼び出しを成功として返さないため。
 
     呼び出し側が statusCode や FunctionError だけを見て成否を判断できることを保証する。
     これが無いと 402/429 で1件も取得できていないのに 200 が返り、手動バックフィルが
     「全件成功・0行書き込み」を成功と報告する。将来 SqsEventSource を付けた場合は
     200 を見た SQS がメッセージを削除するため、DLQ にも残らず恒久的に失われる。
+
+    ⚠️ ただし SqsEventSource を付けるなら、この「送出する」だけでは不十分。402 が続く間
+    メッセージ単位で raise すると maxReceiveCount=5 / visibilityTimeout 180秒 の下では
+    約15分でキュー全体が DLQ に落ちる。つまり元の障害をより速く再現する。恒久停止する
+    種類の失敗にはバッチ単位のサーキットブレーカが必要で、raise はあくまで
+    「EventBridge 単独駆動かつ一過性の失敗」に対する正解。
     """
     if not should_stop:
         return

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
@@ -13,6 +13,23 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+class LookupUnavailableError(Exception):
+    """ツイートを取得できず、リトライしても即座には回復しない状態。
+
+    バッチ経路以外(SQS Records / 直接呼び出し)で送出して、呼び出しを失敗させる。
+    文字列ではなく型で判別できるようにしてある(既存の 401/403 判定が
+    エラーメッセージの部分一致に頼っているため、同じ轍を踏まないように)。
+    """
+
+
+class CreditsDepletedError(LookupUnavailableError):
+    """X API のクレジット枯渇 (HTTP 402)。課金しない限り回復しない"""
+
+
+class RateLimitedError(LookupUnavailableError):
+    """X API のレート制限 (HTTP 429)。時間が経てば回復する"""
+
+
 def create_url(id: str) -> str:
     expansions = (
         "expansions=attachments.poll_ids,attachments.media_keys,author_id,"
@@ -184,23 +201,22 @@ TIMEOUT_BUFFER_MS = 10_000  # 10秒のバッファ
 
 
 def _raise_if_lookup_unavailable(result: dict, should_stop: bool, tweet_id: str) -> None:
-    """取得できていないのに成功として返さないようにする。
+    """should_stop なら例外を送出する。取得できていない呼び出しを成功として返さないため。
 
-    バッチ経路以外(SQS Records / 直接呼び出し)は should_stop を捨てて常に 200 を返して
-    いた。そのため 402 や 429 でツイートを1件も取得できていないのに statusCode 200 が
-    返り、手動バックフィルのスクリプトが「全件成功・0行書き込み」を成功と報告する。
-    さらに将来 SqsEventSource を付けると、200 を見た SQS がメッセージを削除してしまい、
-    DLQ にも残らず恒久的に失われる。
-
-    例外を送出して Lambda の呼び出し自体を失敗させる(Errors メトリクスに出る)。
-    402 は本変更以前も connect_to_endpoint が raise していたので、その挙動に戻す形。
+    呼び出し側が statusCode や FunctionError だけを見て成否を判断できることを保証する。
+    これが無いと 402/429 で1件も取得できていないのに 200 が返り、手動バックフィルが
+    「全件成功・0行書き込み」を成功と報告する。将来 SqsEventSource を付けた場合は
+    200 を見た SQS がメッセージを削除するため、DLQ にも残らず恒久的に失われる。
     """
     if not should_stop:
         return
+    # should_stop = 何も取得できていない。既知のキーに当てはまらない停止理由が将来
+    # 増えても 200 を返さないよう、既定で送出する側に倒す
     if result.get("credits_depleted"):
-        raise Exception(f"X API credits depleted; tweet {tweet_id} was not fetched")
+        raise CreditsDepletedError(f"X API credits depleted; tweet {tweet_id} was not fetched")
     if result.get("rate_limited"):
-        raise Exception(f"X API rate limited; tweet {tweet_id} was not fetched")
+        raise RateLimitedError(f"X API rate limited; tweet {tweet_id} was not fetched")
+    raise LookupUnavailableError(f"lookup unavailable ({sorted(result)}); tweet {tweet_id} was not fetched")
 
 
 def _process_single_tweet(
@@ -411,6 +427,11 @@ def lambda_handler(event: dict, context: Any) -> dict:
     1. EventBridge (定期実行): event={} → SQSキューをポーリング（バッチ処理）
     2. 直接呼び出し: {"tweet_id": "1234567890"}
     3. SQS経由 (レガシー): {"Records": [{"body": "..."}]}
+
+    ログで識別可能なキーワード:
+      [RATE_LIMITED]     : X API 429（時間経過で回復する）
+      [CREDITS_DEPLETED] : X API 402 クレジット枯渇（CW Metric Filter の検知対象）
+      [DLQ_CAUSE:*]      : DLQ 行きの原因
     """
     logger.info("=" * 80)
     logger.info("Postlookup Lambda started")

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 
 import requests
 
+from birdxplorer_common.exceptions import BaseError
 from birdxplorer_etl.lib.lambda_handler.common.sqs_handler import SQSHandler
 
 # Lambda用のロガー設定
@@ -13,7 +14,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-class LookupUnavailableError(Exception):
+class LookupUnavailableError(BaseError):
     """ツイートを取得できず、リトライしても即座には回復しない状態。
 
     バッチ経路以外(SQS Records / 直接呼び出し)で送出して、呼び出しを失敗させる。
@@ -116,12 +117,14 @@ def connect_to_endpoint(url: str) -> tuple[dict, Optional[int]]:
         logger.warning("[RATE_LIMITED] 429 received. Message will return to queue via visibility timeout.")
         return {"status": "rate_limited"}, 0
     elif response.status_code == 402:
-        # ⚠️ デプロイ順序: BirdXplorer-cdk の tweet-lookup retentionPeriod 14日化を
-        # 必ず先にデプロイすること。この変更を先に入れると receive が毎分35件から1件に
-        # 落ちて DLQ への退避が止まり、保持期間4日のまま滞留が全件消える。現状は receive の
-        # 回転で一部が DLQ に逃げて14日まで残るので、順序を誤ると何もしないより悪くなる。
-        #
         # X API のクレジット枯渇。全リクエストが失敗するのでバッチを止める。
+        #
+        # 枯渇中はここで止まるので receive が毎分1件になり、maxReceiveCount には事実上
+        # 到達しない。したがって滞留の期限は tweet-lookup キューの retentionPeriod で決まる
+        # (2026-09-03 時点で14日、元 enqueue 起算)。保持期間切れは DLQ に回らず静かに削除
+        # されるので、期限までにクレジットを復旧させるか再 enqueue 経路を用意する必要がある。
+        # postlookup は本体キューしかポーリングしないため、DLQ に落ちた分は手動 redrive が
+        # 必要になる。
         # ここで止めないと 1 メッセージも処理できないまま MAX_MESSAGES_PER_INVOCATION 件を
         # 毎分 receive し続け、ApproximateReceiveCount だけが進んで maxReceiveCount に達し、
         # 未処理のまま DLQ へ送られる。2026-08-14 の枯渇では実際にこれが起きた。
@@ -214,10 +217,12 @@ def _raise_if_lookup_unavailable(result: dict[str, Any], should_stop: bool, twee
     200 を見た SQS がメッセージを削除するため、DLQ にも残らず恒久的に失われる。
 
     ⚠️ ただし SqsEventSource を付けるなら、この「送出する」だけでは不十分。402 が続く間
-    メッセージ単位で raise すると maxReceiveCount=5 / visibilityTimeout 180秒 の下では
-    約15分でキュー全体が DLQ に落ちる。つまり元の障害をより速く再現する。恒久停止する
-    種類の失敗にはバッチ単位のサーキットブレーカが必要で、raise はあくまで
-    「EventBridge 単独駆動かつ一過性の失敗」に対する正解。
+    メッセージ単位で raise すると、そのメッセージは maxReceiveCount=5 /
+    visibilityTimeout 180秒 の下で約12〜15分で DLQ に落ちる。キュー全体がどれだけの
+    速さで流れるかは配信スループット次第だが、いずれにせよ未取得のまま DLQ に溜まる
+    という元の障害を再現する。恒久停止する種類の失敗にはバッチ単位のサーキット
+    ブレーカが必要で、raise はあくまで「EventBridge 単独駆動かつ一過性の失敗」に
+    対する正解。
     """
     if not should_stop:
         return

--- a/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
+++ b/etl/src/birdxplorer_etl/lib/lambda_handler/postlookup_lambda.py
@@ -98,6 +98,13 @@ def connect_to_endpoint(url: str) -> tuple[dict, Optional[int]]:
     if response.status_code == 429:
         logger.warning("[RATE_LIMITED] 429 received. Message will return to queue via visibility timeout.")
         return {"status": "rate_limited"}, 0
+    elif response.status_code == 402:
+        # X API のクレジット枯渇。全リクエストが失敗するのでバッチを止める。
+        # ここで止めないと 1 メッセージも処理できないまま MAX_MESSAGES_PER_INVOCATION 件を
+        # 毎分 receive し続け、ApproximateReceiveCount だけが進んで maxReceiveCount に達し、
+        # 未処理のまま DLQ へ送られる。2026-08-14 の枯渇では実際にこれが起きた。
+        logger.error("[CREDITS_DEPLETED] X API 402 Payment Required. API credits exhausted. Stopping batch.")
+        return {"status": "credits_depleted"}, 0
     elif response.status_code == 401:
         logger.error("[DLQ_CAUSE:AUTH_FAILED] X API 401 Unauthorized. Check X_BEARER_TOKEN.")
         raise Exception("X API authentication failed: 401 Unauthorized. Token may be invalid or expired.")
@@ -224,6 +231,13 @@ def _process_single_tweet(
         if status == "rate_limited":
             logger.info("[RATE_LIMITED] Message not deleted. Will return to queue via visibility timeout.")
             return {"rate_limited": True, "tweet_id": tweet_id}, 0, True
+
+        if status == "credits_depleted":
+            # rate_limited と同様にメッセージを削除せず、バッチを止める。
+            # 別ステータスにしているのは、運用上の原因がレート制限とは全く異なるため
+            # (課金の問題であり、待っても回復しない)。ログのキーワードも分けている。
+            logger.error("[CREDITS_DEPLETED] Message not deleted. Batch stopped until credits are restored.")
+            return {"credits_depleted": True, "tweet_id": tweet_id}, 0, True
 
         detail = post.get("detail", "")
         if status == "deleted":
@@ -440,6 +454,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
         skipped = 0
         errors = 0
         rate_limited = False
+        credits_depleted = False
         last_rate_remaining: Optional[int] = None
 
         for i in range(MAX_MESSAGES_PER_INVOCATION):
@@ -484,6 +499,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     skipped += 1
                 elif result.get("rate_limited"):
                     rate_limited = True
+                elif result.get("credits_depleted"):
+                    credits_depleted = True
                 else:
                     processed += 1
 
@@ -510,7 +527,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
         logger.info("=" * 80)
         logger.info(
             f"[BATCH_COMPLETE] Processed={processed}, Skipped={skipped}, "
-            f"Errors={errors}, RateLimited={rate_limited}"
+            f"Errors={errors}, RateLimited={rate_limited}, CreditsDepleted={credits_depleted}"
         )
         logger.info("=" * 80)
 
@@ -523,6 +540,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     "skipped": skipped,
                     "errors": errors,
                     "rate_limited": rate_limited,
+                    "credits_depleted": credits_depleted,
                 }
             ),
         }

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -110,6 +110,22 @@ class TestConnectToEndpoint:
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
+    def test_credits_depleted_returns_status_instead_of_raising(self, _mock_auth, mock_request):
+        """402 は raise せず credits_depleted を返す。
+
+        raise すると呼び出し側で「非致命的エラー」として次のメッセージに進んでしまい、
+        1件も処理できないまま毎分 MAX_MESSAGES_PER_INVOCATION 件を receive し続ける。
+        ApproximateReceiveCount だけが進んで未処理のまま DLQ に落ちる。
+        """
+        mock_request.return_value = _make_mock_response(402)
+
+        result, rate_remaining = connect_to_endpoint("https://api.twitter.com/2/tweets/123")
+
+        assert result == {"status": "credits_depleted"}
+        assert rate_remaining == 0
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
     def test_401_raises(self, _mock_auth, mock_request):
         mock_request.return_value = _make_mock_response(401)
 
@@ -245,6 +261,28 @@ class TestProcessSingleTweet:
         assert remaining == 0
         assert should_stop is True
         # メッセージは削除しない
+        sqs.delete_message.assert_not_called()
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.lookup")
+    def test_credits_depleted_stops_loop(self, mock_lookup):
+        """402 は rate_limited と同様にメッセージを削除せずループを止める"""
+        mock_lookup.return_value = ({"status": "credits_depleted"}, 0)
+        sqs = _make_sqs_handler()
+
+        result, remaining, should_stop = _process_single_tweet(
+            tweet_id="222",
+            receipt_handle="rh-4",
+            skip_tweet_lookup=False,
+            sqs_handler=sqs,
+            db_write_queue_url="https://sqs/db-write",
+            post_transform_queue_url="https://sqs/post-transform",
+            tweet_lookup_queue_url="https://sqs/tweet-lookup",
+        )
+
+        assert result["credits_depleted"] is True
+        assert remaining == 0
+        assert should_stop is True
+        # メッセージを削除しない = クレジット復旧後に再処理できる
         sqs.delete_message.assert_not_called()
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.lookup")

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -122,7 +122,8 @@ class TestConnectToEndpoint:
         result, rate_remaining = connect_to_endpoint("https://api.twitter.com/2/tweets/123")
 
         assert result == {"status": "credits_depleted"}
-        assert rate_remaining == 0
+        # 402 はレート制限の残量について何も言っていないので 0 を偽らない
+        assert rate_remaining is None
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
@@ -280,7 +281,7 @@ class TestProcessSingleTweet:
         )
 
         assert result["credits_depleted"] is True
-        assert remaining == 0
+        assert remaining is None
         assert should_stop is True
         # メッセージを削除しない = クレジット復旧後に再処理できる
         sqs.delete_message.assert_not_called()
@@ -401,6 +402,65 @@ class TestBatchProcessingLoop:
         assert body["batch"] is True
         assert body["processed"] == 0
         assert body["skipped"] == 0
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._poll_message")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_stops_on_credits_depleted(self, mock_sqs_cls, mock_poll, mock_process):
+        """402 で1件目でループが止まり、フラグが応答に載る"""
+        mock_sqs_cls.return_value = _make_sqs_handler()
+        mock_poll.return_value = {"tweet_id": "t1", "receipt_handle": "rh-1", "body": {"tweet_id": "t1"}}
+        mock_process.return_value = ({"credits_depleted": True, "tweet_id": "t1"}, None, True)
+
+        result = lambda_handler({}, _make_context())
+
+        body = json.loads(result["body"])
+        assert body["credits_depleted"] is True
+        assert body["processed"] == 0
+        # ここが本変更の目的。35件ではなく1件で止まる
+        assert mock_process.call_count == 1
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_402_polls_once_and_deletes_nothing(self, mock_sqs_cls, _mock_auth, mock_request):
+        """402 では receive が1回だけ、delete は0回。
+
+        変更前は1件も処理できないのに35件を receive し続け、ApproximateReceiveCount だけが
+        進んで未処理のまま DLQ に落ちていた。
+        """
+        sqs = _make_sqs_handler()
+        # receive_message はメッセージの list を返す
+        sqs.receive_message.return_value = [{"Body": json.dumps({"tweet_id": "t1"}), "ReceiptHandle": "rh-1"}]
+        mock_sqs_cls.return_value = sqs
+        mock_request.return_value = _make_mock_response(402)
+
+        result = lambda_handler({}, _make_context())
+
+        body = json.loads(result["body"])
+        assert body["credits_depleted"] is True
+        assert sqs.receive_message.call_count == 1
+        # 削除しない = クレジット復旧後に再処理できる
+        sqs.delete_message.assert_not_called()
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_direct_invoke_does_not_report_success_when_lookup_unavailable(self, mock_sqs_cls, mock_process):
+        """取得できていないのに 200 を返さない。
+
+        非バッチ経路は should_stop を捨てて常に 200 を返していた。手動バックフィルの
+        スクリプトが「全件成功・0行書き込み」を成功と誤認するため、例外を送出して
+        Lambda の呼び出し自体を失敗させる。
+        """
+        mock_sqs_cls.return_value = _make_sqs_handler()
+
+        for flag in ("credits_depleted", "rate_limited"):
+            mock_process.return_value = ({flag: True, "tweet_id": "t1"}, None, True)
+            with pytest.raises(Exception, match="was not fetched"):
+                lambda_handler({"tweet_id": "t1"}, _make_context())
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._poll_message")

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -726,6 +726,8 @@ class TestNonBatchPathsFailLoudly:
         mock_sqs_cls.return_value = _make_sqs_handler()
         mock_process.return_value = ({flag: True, "tweet_id": "t1"}, None, True)
 
+        # 型で判別できることが要点。umbrella での catch が壊れていないことも固定する
+        assert issubclass(expected, LookupUnavailableError)
         with pytest.raises(expected, match="was not fetched"):
             lambda_handler(event, _make_context())
 
@@ -763,12 +765,13 @@ class TestCreditsDepletedObservability:
         with caplog.at_level(logging.ERROR):
             lambda_handler({}, _make_context())
 
-        # 出力箇所ごとに固定する。どちらか一方が debug に落ちても text 全体には
-        # 残ってしまうため、「少なくとも1箇所」では検知の後退を捕まえられない
-        emitters = {
-            r.funcName for r in caplog.records if "CREDITS_DEPLETED" in r.getMessage() and r.levelno >= logging.ERROR
-        }
-        assert emitters == {"connect_to_endpoint", "_process_single_tweet"}
+        # メトリクスフィルタの契約は「ERROR 以上で1回以上出ること」。どの関数が出すかや
+        # 何回出るかは実装の詳細なので固定しない(現状は2箇所から出るが、重複の整理を
+        # テストで妨げたくない)。全箇所が debug に落ちたりリネームされた場合はここで落ちる
+        credit_errors = [
+            r for r in caplog.records if "CREDITS_DEPLETED" in r.getMessage() and r.levelno >= logging.ERROR
+        ]
+        assert credit_errors, "CREDITS_DEPLETED が ERROR 以上で出力されていない"
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -390,6 +390,9 @@ class TestBatchProcessingLoop:
         body = json.loads(result["body"])
         assert body["batch"] is True
         assert body["processed"] == 3
+        # 負方向も固定する。フラグが常時 True に張り付いても捕まえられなかった
+        assert body["rate_limited"] is False
+        assert body["credits_depleted"] is False
         assert mock_process.call_count == 3
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._poll_message")
@@ -760,7 +763,12 @@ class TestCreditsDepletedObservability:
         with caplog.at_level(logging.ERROR):
             lambda_handler({}, _make_context())
 
-        assert "CREDITS_DEPLETED" in caplog.text
+        # 出力箇所ごとに固定する。どちらか一方が debug に落ちても text 全体には
+        # 残ってしまうため、「少なくとも1箇所」では検知の後退を捕まえられない
+        emitters = {
+            r.funcName for r in caplog.records if "CREDITS_DEPLETED" in r.getMessage() and r.levelno >= logging.ERROR
+        }
+        assert emitters == {"connect_to_endpoint", "_process_single_tweet"}
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")

--- a/etl/tests/test_postlookup_lambda.py
+++ b/etl/tests/test_postlookup_lambda.py
@@ -1,9 +1,13 @@
 import json
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from birdxplorer_etl.lib.lambda_handler.postlookup_lambda import (
+    CreditsDepletedError,
+    LookupUnavailableError,
+    RateLimitedError,
     _poll_message,
     _process_single_tweet,
     connect_to_endpoint,
@@ -446,23 +450,6 @@ class TestBatchProcessingLoop:
         sqs.delete_message.assert_not_called()
 
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
-    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
-    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
-    def test_direct_invoke_does_not_report_success_when_lookup_unavailable(self, mock_sqs_cls, mock_process):
-        """取得できていないのに 200 を返さない。
-
-        非バッチ経路は should_stop を捨てて常に 200 を返していた。手動バックフィルの
-        スクリプトが「全件成功・0行書き込み」を成功と誤認するため、例外を送出して
-        Lambda の呼び出し自体を失敗させる。
-        """
-        mock_sqs_cls.return_value = _make_sqs_handler()
-
-        for flag in ("credits_depleted", "rate_limited"):
-            mock_process.return_value = ({flag: True, "tweet_id": "t1"}, None, True)
-            with pytest.raises(Exception, match="was not fetched"):
-                lambda_handler({"tweet_id": "t1"}, _make_context())
-
-    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._poll_message")
     @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
     @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
@@ -710,3 +697,105 @@ class TestParseApiError:
             {"errors": [{"type": "not-authorized", "title": "Authorization Error", "detail": "Forbidden"}]}
         )
         assert result["status"] == "protected"
+
+
+_NON_BATCH_EVENTS = [
+    pytest.param({"tweet_id": "t1"}, id="direct-invoke"),
+    pytest.param(
+        {"Records": [{"body": json.dumps({"processing_type": "tweet_lookup", "tweet_id": "t1"})}]},
+        id="sqs-records",
+    ),
+]
+
+
+class TestNonBatchPathsFailLoudly:
+    """バッチ経路以外は、取得できていない呼び出しを成功として返さない"""
+
+    @pytest.mark.parametrize("event", _NON_BATCH_EVENTS)
+    @pytest.mark.parametrize(
+        ("flag", "expected"),
+        [("credits_depleted", CreditsDepletedError), ("rate_limited", RateLimitedError)],
+    )
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_raises_instead_of_returning_200(self, mock_sqs_cls, mock_process, flag, expected, event):
+        mock_sqs_cls.return_value = _make_sqs_handler()
+        mock_process.return_value = ({flag: True, "tweet_id": "t1"}, None, True)
+
+        with pytest.raises(expected, match="was not fetched"):
+            lambda_handler(event, _make_context())
+
+    @pytest.mark.parametrize("event", _NON_BATCH_EVENTS)
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda._process_single_tweet")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_unknown_stop_reason_also_raises(self, mock_sqs_cls, mock_process, event):
+        """将来 should_stop の理由が増えても 200 を返さない（既定で送出側に倒す）"""
+        mock_sqs_cls.return_value = _make_sqs_handler()
+        mock_process.return_value = ({"some_future_status": True, "tweet_id": "t1"}, None, True)
+
+        with pytest.raises(LookupUnavailableError, match="lookup unavailable"):
+            lambda_handler(event, _make_context())
+
+
+class TestCreditsDepletedObservability:
+    """CW Metric Filter が拾うリテラルと、部分的な進捗の保持"""
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict("os.environ", {"TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup"})
+    def test_logs_credits_depleted_keyword(self, mock_sqs_cls, _mock_auth, mock_request, caplog):
+        """このリテラルは CDK の FilterPattern.literal('CREDITS_DEPLETED') との契約。
+
+        402 のときバッチは 200 を返し Errors にも出ないので、このログ行だけが検知手段。
+        リネームやログレベル変更で 2026-08-14 の「20日気づけない」状態に戻る。
+        """
+        sqs = _make_sqs_handler()
+        sqs.receive_message.return_value = [{"Body": json.dumps({"tweet_id": "t1"}), "ReceiptHandle": "rh-1"}]
+        mock_sqs_cls.return_value = sqs
+        mock_request.return_value = _make_mock_response(402)
+
+        with caplog.at_level(logging.ERROR):
+            lambda_handler({}, _make_context())
+
+        assert "CREDITS_DEPLETED" in caplog.text
+
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.requests.request")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.bearer_oauth")
+    @patch("birdxplorer_etl.lib.lambda_handler.postlookup_lambda.SQSHandler")
+    @patch.dict(
+        "os.environ",
+        {
+            "TWEET_LOOKUP_QUEUE_URL": "https://sqs/tweet-lookup",
+            "DB_WRITE_QUEUE_URL": "https://sqs/db-write",
+            "POST_TRANSFORM_QUEUE_URL": "https://sqs/post-transform",
+        },
+    )
+    def test_preserves_progress_made_before_the_402(self, mock_sqs_cls, _mock_auth, mock_request):
+        """402 の手前で成功した分は processed に残り、そのメッセージは削除される。
+
+        4万件の滞留を捌く途中で枯渇に当たるので、ここが潰れると復旧のたびに
+        取り込み済みの分を数え直すことになる。
+        """
+        sqs = _make_sqs_handler()
+        sqs.receive_message.side_effect = [
+            [{"Body": json.dumps({"tweet_id": "t1"}), "ReceiptHandle": "rh-1"}],
+            [{"Body": json.dumps({"tweet_id": "t2"}), "ReceiptHandle": "rh-2"}],
+        ]
+        mock_sqs_cls.return_value = sqs
+        mock_request.side_effect = [
+            _make_mock_response(200, json_data=_make_tweet_response("t1")),
+            _make_mock_response(402),
+        ]
+
+        result = lambda_handler({}, _make_context())
+
+        body = json.loads(result["body"])
+        assert body["processed"] == 1
+        assert body["credits_depleted"] is True
+        assert sqs.receive_message.call_count == 2
+        # 成功した1件目だけが削除される
+        sqs.delete_message.assert_called_once()
+        assert "rh-1" in sqs.delete_message.call_args[0]


### PR DESCRIPTION
## 背景（進行中の障害）

**2026-08-14 19:11 UTC から X API が全リクエストに 402 (`credits depleted`) を返しており、投稿の取り込みが完全に停止しています。** 課金はまだ復旧していません。

問題は、この状態で postlookup が**1件も処理できないのに毎分35件を receive し続けていた**ことです。

```
SQS NumberOfMessagesDeleted    08-25〜09-02 の9日間すべて 0
SQS NumberOfMessagesReceived   3〜4.3万件/日
```

原因は 402 が `connect_to_endpoint` の汎用分岐（`status_code != 200`）で raise され、バッチループ側で「非致命的エラー」として `continue` されていたことです。**429 は `should_stop` を立てて止まり、401/403 は再 raise して止まるのに、402 だけが止まりません。** 結果として `ApproximateReceiveCount` だけが進み、未処理のまま DLQ へ送られます。

## 変更

402 を専用ステータス `credits_depleted` として扱い、`rate_limited` と同様に**メッセージを削除せず `should_stop` を立てます**。

```
receive ペース:  35件/分  →  1件/分
```

`rate_limited` と別ステータスにしたのは運用上の原因がまったく違うためです。**レート制限は待てば回復しますが、クレジット枯渇は課金しない限り回復しません。** ログも `[CREDITS_DEPLETED]` と分け、`BATCH_COMPLETE` に `CreditsDepleted` を追加しました。

あわせて以下を修正しています。

- **非バッチ経路（SQS Records / 直接呼び出し）が取得失敗を HTTP 200 で返す穴を塞ぎました。** これらは `should_stop` を捨てて常に 200 を返していたため、手動バックフィルが「全件成功・0行書き込み」を成功と誤認します。`LookupUnavailableError`（`BaseError` 継承）とその派生を送出し、呼び出し自体を失敗させます
- 402 の `rate_remaining` を `0` ではなく `None` に。402 はレート残量について何も言っていません
- ログキーワードの宣言ブロックを追加（`realtime_notes_extraction_lambda` の慣習に倣う）

## ⚠️ この修正はデータを保全しません。時間を買うだけです

**救うのは「期限までにクレジットを復旧させること」か「再 enqueue 経路を作ること」で、この PR ではありません。**

**期限は 2026-09-15 です。** 最古メッセージの `SentTimestamp` が 09-01 12:28 UTC で、保持期間14日はそこから数えます（実測）。

そして**保持期間切れは DLQ に回らず静かに削除されます**。消えたメッセージは自動では戻りません。`row_note_requests.lookup_enqueued_at` は enqueue 時点で押され、notes 経路も `notes` テーブルへの存在チェックで塞がれているため、どちらの producer も再投入しません。復旧には手書きの SQL が2本必要で、**専用スクリプトは存在しません**。

## 復旧の見込み（検証済み）

課金が戻れば滞留は捌けます。

| | |
|---|---|
| PostLookup の処理能力 | 35件 × 1440回/日 = 50,400件/日 |
| **X API の上限** | **450/15分 = 43,200件/日** ← ボトルネック |
| **全件消化** | **41,404 ÷ 43,200 ≒ 23時間** |

下流にボトルネックはありません（db-write 60倍、post-transform 12倍、lang-detect 50倍の余裕）。postlookup 自体が API で 30件/分に抑えられるため、下流はバーストを受けません。

## 🚨 この PR を開くと dev にデプロイされます

`deploy-etl-lambda.yml` は **PR を開いた時点で** `_deploy.yaml` を呼び、`--exclusively` **無し**で `cdk deploy devbird-xplorerStack devbird-xplorerMonitoringStack` を実行します。依存が引き込まれるため、実際に触るのは8スタックです。

- **Alembic マイグレーションが再実行されます**（`migration-stack.ts:291` が `new Date().toISOString()` を埋めているため、MigrationStack は毎回差分が出ます）
- **ETL Lambda 12個のイメージがこの PR のビルドしたタグに差し替わります**
- **`CreditsDepleted` アラームが新規作成され、5〜8分で発報します**（402 が毎分続いているため）。これは望ましい動作ですが、ETL の PR の副作用として入ります
- `X_COOKIES` の環境変数が Secret から再解決されます。Secret には正しい値が入っているので実害はなく、CFn ドリフトが解消します

**他の `etl/**` `common/**` `migrate/**` PR と同時に開かないでください。** 同時デプロイは CloudFormation の ChangeSet で衝突します。作成時点で進行中の実行が無いことは確認済みです。

## 前提: キュー保持期間の14日化（済）

`BirdXplorer-cdk#32` が **2026-09-03 07:47 UTC に dev へデプロイ済み**です。

この修正だけを先に入れると receive が止まって DLQ への退避も起きなくなり、保持期間4日のままだと滞留が全件消えます。**その前提は既に満たされているので、この PR は単独でマージして問題ありません。**

## 検証

- `etl` **272 passed / 4 skipped**（新規テスト多数）
- 変異テストで以下がいずれも検出されることを確認
  - 402 分岐の削除 / `should_stop` を `False` に / バッチのカウント分岐削除
  - 非バッチ2経路それぞれのガード削除 / ガードの既定送出を `return` に
  - `CREDITS_DEPLETED` を全箇所リネーム・全箇所 debug 化
  - 例外の継承関係を外す / `processed` を 0 に潰す / フラグを常時 True に
  - 402 でメッセージを削除する
- black（120）/ isort / pflake8 クリーン
- 実際の 402 を通して `receive_message` が1回・`delete_message` が0回であることを確認（受信ペース削減が目的なのでここが本体）
- 402 の手前で成功した分が `processed` に残り、そのメッセージだけが削除されることを確認

## スコープ外

**1. すでに消滅した分の復旧。** 09-05 より前に期限切れになった分は上記の SQL が必要です。

**2. DLQ の約6万件。** 保持期間は既に上限の14日で、元 enqueue が 08-24 以前のため 09-07 までに失われます。設定では救えません。

**3. 再 enqueue 経路。** これが無い限り、同じ障害が起きるたびに手作業が必要です。恒久対策として別途検討すべきです。

**4. 本体キューの滞留・経過時間のアラーム。** この修正により receive が落ちて DLQ に到達しなくなるため、DLQ アラームは事実上鳴りません。`ApproximateAgeOfOldestMessage` のアラームがあれば、キーワードに依存せず滞留そのものを検知できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
