### PR TITLE
fix(api): anyio の別名 deprecation で api-test-check が落ちるのを止める

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -76,6 +76,22 @@ testpaths = ["tests", "birdxplorer_api"]
 filterwarnings = [
     "error",
     "ignore:The \\'app\\' shortcut is now deprecated. Use the explicit style \\'transport=WSGITransport\\(app=\\.\\.\\.\\)\\' instead\\.",
+    # starlette の testclient が anyio.abc.* の旧別名を参照しており、新しい anyio が
+    # その別名に DeprecationWarning を付けたため、依存を更新するだけで "error" に
+    # 引っかかって conftest の import 時点で collection error になる。
+    # 実際に警告を出すのは testclient.py:53 のみ(379/422 は from __future__ import
+    # annotations 下の注釈なので評価されない)。こちらのコードでは制御できない。
+    #
+    # 別名を1つに絞らず anyio.abc.* をまとめて対象にしているのは、starlette が別の別名を
+    # 触ったときに同じ失敗を繰り返さないため。メッセージは anyio の
+    # _lazyimport.emit_deprecation_warning だけが生成するので、範囲は限定的。
+    #
+    # 契機: anyio 4.15.0 (2026-09-02) の遅延 import 化 (agronholm/anyio#1169)
+    # 上流 issue: https://github.com/Kludex/starlette/issues/3497
+    # starlette 側が新しい参照に移行したらこの行は削除する。上限指定は不要 -- 別名が
+    # 削除された場合は AttributeError になり、filterwarnings では抑止できないので
+    # CI が初回実行で落ちる。
+    "ignore:The anyio\\.abc\\.\\w+ alias is deprecated:DeprecationWarning",
 ]
 
 [tool.black]


### PR DESCRIPTION
## これは既存の破損です（このPRのコード変更に起因しません）

`Main` ワークフローの **`test / api-test-check` が全ブランチで失敗**しています。

```
DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated,
use anyio.from_thread.BlockingPortal instead.
```

**依存を更新するだけで落ちる状態**になっていました。

- `starlette` の testclient が `anyio.abc.*` の旧別名を参照している（実際に警告を出すのは `testclient.py:53` のみ。379/422 は `from __future__ import annotations` 下の注釈なので評価されません）
- **anyio 4.15.0**（2026-09-02 21:46 UTC 公開）が遅延 import 化（`agronholm/anyio#1169`）に伴い、その別名に `DeprecationWarning` を付けた
- `api/pyproject.toml` の `filterwarnings = ["error", ...]` が全警告をエラー扱いにするため、**conftest の import 時点で collection error** になる
- ロックファイルも上限指定も無いので、CI は毎回最新の anyio を入れる

`main.yaml` は `on: push` で、`main` への最後の push は **2026-08-13**。それ以降テストが走っていないため気づかれていませんでした。**今 `main` を再実行すれば同じように落ちます。**

**現在 #286 と #287 の両方がこれでブロックされています。**

## 対処

既存の慣習に合わせて `filterwarnings` に ignore を1行追加しました（同じ配列に httpx の deprecation を ignore している前例があります）。

```toml
"ignore:The anyio\\.abc\\.\\w+ alias is deprecated:DeprecationWarning",
```

別名を1つに絞らず `anyio.abc.*` をまとめて対象にしているのは、starlette が別の別名を触ったときに同じ失敗を繰り返さないためです。メッセージは anyio の `_lazyimport.emit_deprecation_warning` だけが生成するので範囲は限定的で、**他の `DeprecationWarning` は引き続きエラーになります**（非推奨の別名は7つで、いずれもこのパターンで一致します）。

## 検討して却下した対処

**anyio に上限を付ける** → **不要**と判断しました。別名が将来削除された場合は警告ではなく `AttributeError` になり（モジュールの `__getattr__` 経由）、`filterwarnings` では抑止できないので **CI が初回実行で確実に落ちます**。予兆を失わないため、上限を切って判断を強制する必要がありません。また `anyio` は `birdxplorer_api` の宣言済み依存ではないので、推移的依存を縛るためだけに直接依存を増やすことになります。

**starlette を上げる** → **選択肢として存在しません**。`1.6.0` が最新で、それがこの失敗を出しているバージョンです。`master` にも旧別名の参照が残っており修正は入っていません（上流 issue: [Kludex/starlette#3497](https://github.com/Kludex/starlette/issues/3497)、コメントゼロ）。pydantic-ai も同じ `filterwarnings=error` で踏んで、同様に自分側で filter する対処を選んでいます。

## 検証

**CI と同じ解決結果になる捨て venv** で確認しました（`anyio 4.15.0` / `starlette 1.6.0` / `fastapi 0.141.1` / `pytest 9.1.1` / `httpx2 2.12.0`）。

- CI のトレースバックを再現し、**この1行を追加すると通る**ことを確認
- 失敗は conftest の import 時点で起きるため、そのフェーズで検証しています
- `api` tox の全コマンド（`black` / `isort` / `pytest` / `pflake8` / `mypy --strict` × 2）が緑になることを確認 — **後ろに控えている別の失敗はありません**
- 無関係な `DeprecationWarning`、別モジュールの同形メッセージ、先頭が一致しない変種は**いずれも引き続きエラーになる**ことを確認（scope が広すぎないこと）
- `api` **179 passed**（90% cover）、`mypy --strict` は最新の mypy / pydantic / fastapi に対して clean

## 本質的な修正

**starlette 側が新しい参照に移行することです。** そうなればこの行は削除できます。コメントに上流 issue と契機を書いてあるので、条件を確認できます。

## 別件（このPRの対象外）

`api` の tox は `black` / `isort` を **fix モード**で走らせるため CI では常に exit 0 になりますが、`isort 9.0.1` は `birdxplorer_api/routers/data.py` を**毎回書き換えます**。コミット済みの整形が浮動するツールチェーンと合っていない状態です。無害ですが、別issueに切り出す価値があります。

依存のピン留めが無いこと自体も同じ根っこの問題です。今回は止血に留めています。

## ⚠️ このPRを開くと dev の ApiStack がデプロイされます

`deploy-api.yml` が `api/**` で発火します。**#286 も `api/` を触るので、両方の CI が同時に走ると CloudFormation の ChangeSet で衝突します。** 作成時点で進行中の実行が無いことは確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
