### PR TITLE
fix(etl): ratings の COPY エスケープ漏れを直し、6日間止まっていた日次 Extract を復旧する

### DIFF
--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -155,13 +155,22 @@ def _run_phase(name: str, postgresql: Session, phase: Callable[[], None]) -> boo
     ただし握りつぶしを無音にすると劣化に気付けないので、CloudWatch メトリクスフィルタ用に
     EXTRACT_PHASE_FAILED トークンを必ず出す（NOTE_REQUEST_ROW_SKIPPED と同じ方式）。
     例外後のセッションは InFailedSqlTransaction のままなので rollback して後段に渡す。
+
+    トークンの出力は rollback より必ず先に行う。RDS のフェイルオーバーや接続断で
+    フェーズが落ちた場合は rollback 自体も例外を投げるため、順序を逆にすると
+    トークンを取りこぼしたうえでプロセスが死ぬ。アラームが最も必要な場面で無音になる。
     """
     phase_start = time.time()
     try:
         phase()
     except Exception as e:
-        postgresql.rollback()
         logging.exception(f"EXTRACT_PHASE_FAILED phase={name} elapsed={time.time() - phase_start:.1f}s reason={e}")
+        try:
+            postgresql.rollback()
+        except Exception:
+            # 接続が死んでいると rollback もできない。後段フェーズはそれぞれ失敗して
+            # 個別にトークンを出すので、ここで打ち切らず契約（例外を投げない）を守る。
+            logging.exception(f"EXTRACT_PHASE_FAILED phase={name} rollback also failed")
         return False
     logging.info(f"[PHASE_COMPLETE] {name}: {time.time() - phase_start:.1f}s")
     return True

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -7,7 +7,7 @@ import sys
 import time
 import zipfile
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Callable, Iterable, Iterator, Optional
 
 import boto3
 import requests
@@ -143,6 +143,28 @@ def _detect_status_changes(postgresql: Session, rows: list[dict]) -> list[str]:
             if old != new:
                 changed.append(nid)
     return changed
+
+
+def _run_phase(name: str, postgresql: Session, phase: Callable[[], None]) -> bool:
+    """1フェーズを実行し、失敗しても後続フェーズを止めない。成功なら True。
+
+    フェーズを直列に裸で呼ぶと、前段の例外が extract_data を貫通してプロセスごと落ち、
+    後段のフェーズが一度も走らない。2026-09-02 からの6日間、ratings の COPY 失敗が
+    run_note_requests_phase を巻き添えにして tweet-lookup への enqueue を止めていた。
+
+    ただし握りつぶしを無音にすると劣化に気付けないので、CloudWatch メトリクスフィルタ用に
+    EXTRACT_PHASE_FAILED トークンを必ず出す（NOTE_REQUEST_ROW_SKIPPED と同じ方式）。
+    例外後のセッションは InFailedSqlTransaction のままなので rollback して後段に渡す。
+    """
+    phase_start = time.time()
+    try:
+        phase()
+    except Exception as e:
+        postgresql.rollback()
+        logging.exception(f"EXTRACT_PHASE_FAILED phase={name} elapsed={time.time() - phase_start:.1f}s reason={e}")
+        return False
+    logging.info(f"[PHASE_COMPLETE] {name}: {time.time() - phase_start:.1f}s")
+    return True
 
 
 def extract_data(postgresql: Session):
@@ -334,18 +356,10 @@ def extract_data(postgresql: Session):
             continue
 
         # 評価データを取得して保存（noteStatus処理より先に実行することで集計タイミングを保証）
-        phase_start = time.time()
-        extract_ratings(postgresql, dateString, existing_row_note_ids)
-        logging.info(f"[PHASE_COMPLETE] Ratings: {time.time() - phase_start:.1f}s")
+        _run_phase("Ratings", postgresql, lambda: extract_ratings(postgresql, dateString, existing_row_note_ids))
 
         # notesテーブルの評価集計カラムを再計算
-        phase_start = time.time()
-        try:
-            recalculate_rating_counts(postgresql)
-            logging.info(f"[PHASE_COMPLETE] Rating recalculation: {time.time() - phase_start:.1f}s")
-        except Exception as e:
-            logging.error(f"Rating recalculation failed: {e}")
-            postgresql.rollback()
+        _run_phase("Rating recalculation", postgresql, lambda: recalculate_rating_counts(postgresql))
 
         # noteStatusHistory-00000.zip から順に404が返るまでダウンロード
         phase_start = time.time()
@@ -447,12 +461,10 @@ def extract_data(postgresql: Session):
     postgresql.commit()
 
     # row_notesにあるがnotesにないレコードをバックフィル
-    phase_start = time.time()
-    backfill_missing_notes(postgresql)
-    logging.info(f"[PHASE_COMPLETE] Backfill: {time.time() - phase_start:.1f}s")
+    _run_phase("Backfill", postgresql, lambda: backfill_missing_notes(postgresql))
 
     # Note Requests (batSignals) の取り込みと投稿 lookup の enqueue
-    run_note_requests_phase(postgresql)
+    _run_phase("NoteRequests", postgresql, lambda: run_note_requests_phase(postgresql))
 
     return
 
@@ -599,8 +611,19 @@ _COPY_TEXT_ESCAPES = str.maketrans({"\\": "\\\\", "\n": "\\n", "\r": "\\r", "\t"
 
 
 def _escape_copy_text(value: str) -> str:
-    """COPY TEXT 形式に合わせてバックスラッシュ・タブ・改行をエスケープする。"""
+    """COPY TEXT 形式に合わせてバックスラッシュ・改行・復帰・タブをエスケープする。"""
     return value.translate(_COPY_TEXT_ESCAPES)
+
+
+def _iter_lines_without_nul(lines: Iterable[str]) -> Iterator[str]:
+    """NUL(0x00) を除去しながら行を流す。
+
+    PostgreSQL のテキスト型は NUL を保存できず、COPY TEXT にも表現が無いので除去しかない。
+    さらに csv は NUL を含む行で ``_csv.Error: line contains NUL`` を投げるため、
+    パーサに渡す手前で落とす必要がある。X のフリーテキストにはまれに混入する。
+    """
+    for line in lines:
+        yield line.replace("\x00", "") if "\x00" in line else line
 
 
 def _process_rating_rows(reader, postgresql: Session, existing_row_note_ids: set, file_index: int) -> int:
@@ -705,7 +728,7 @@ def extract_ratings(postgresql: Session, dateString: str, existing_row_note_ids:
             try:
                 if settings.USE_DUMMY_DATA:
                     tsv_data = res.content.decode("utf-8").splitlines()
-                    reader = csv.DictReader(tsv_data, delimiter="\t")
+                    reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
                     reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
                     total_loaded += _process_rating_rows(reader, postgresql, existing_row_note_ids, file_index)
                 else:
@@ -718,7 +741,7 @@ def extract_ratings(postgresql: Session, dateString: str, existing_row_note_ids:
 
                         with zip_file.open(tsv_filename) as tsv_file:
                             text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
-                            reader = csv.DictReader(text_file, delimiter="\t")
+                            reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
                             reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
                             total_loaded += _process_rating_rows(reader, postgresql, existing_row_note_ids, file_index)
 
@@ -820,7 +843,7 @@ def recalculate_rating_counts(postgresql: Session) -> int:
 _STAGING_TABLE = "row_note_ratings_new"
 _OLD_TABLE = "row_note_ratings_old"
 
-# _process_rating_rows_to_staging で COPY に使うカラム順
+# _process_rating_rows で COPY に使うカラム順
 _RATING_COLUMNS = [
     "note_id",
     "rater_participant_id",
@@ -1231,9 +1254,10 @@ def enqueue_note_request_lookups(postgresql: Session, batch_limit: int = 10000):
 
 
 def run_note_requests_phase(postgresql: Session):
-    """Note Requests の取り込みと lookup enqueue。失敗しても extract 全体は落とさない。"""
-    try:
-        extract_note_requests(postgresql)
-        enqueue_note_request_lookups(postgresql)
-    except Exception:
-        logging.exception("Note requests phase failed, continuing")
+    """Note Requests の取り込みと lookup enqueue。
+
+    失敗の握りつぶしは _run_phase に集約している。ここで独自に握りつぶすと
+    EXTRACT_PHASE_FAILED トークンが出ずアラームに乗らないので、例外はそのまま送出する。
+    """
+    extract_note_requests(postgresql)
+    enqueue_note_request_lookups(postgresql)

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -591,6 +591,18 @@ def _validate_rating_row(row: dict, existing_row_note_ids: set) -> bool:
     return True
 
 
+# COPY TEXT 形式の特殊文字。素通しすると値が壊れるだけでなく COPY 自体が失敗する。
+# 特に行頭の `\.` は終端マーカーとみなされ、psycopg2 が
+# BadCopyFileFormat: end-of-copy marker corrupt を送出してファイル全体の取り込みが落ちる。
+# ratings の suggestion はユーザ入力のフリーテキストなので、これらは実際に混入する。
+_COPY_TEXT_ESCAPES = str.maketrans({"\\": "\\\\", "\n": "\\n", "\r": "\\r", "\t": "\\t"})
+
+
+def _escape_copy_text(value: str) -> str:
+    """COPY TEXT 形式に合わせてバックスラッシュ・タブ・改行をエスケープする。"""
+    return value.translate(_COPY_TEXT_ESCAPES)
+
+
 def _process_rating_rows(reader, postgresql: Session, existing_row_note_ids: set, file_index: int) -> int:
     """ratingsのTSV行をバリデーションし、COPYでstaging tableにバルクロードする。"""
     BATCH_SIZE = 50000
@@ -613,7 +625,7 @@ def _process_rating_rows(reader, postgresql: Session, existing_row_note_ids: set
             if val is None:
                 values.append("\\N")
             else:
-                values.append(str(val))
+                values.append(_escape_copy_text(str(val)))
         buffer.write("\t".join(values) + "\n")
         row_count += 1
 

--- a/etl/tests/test_extract_note_requests.py
+++ b/etl/tests/test_extract_note_requests.py
@@ -5,6 +5,8 @@ import sys
 import zipfile
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # extract_ecs.py は psycopg2 と settings を transitively import する（ECS/Lambda ランタイム専用）
 _mock_psycopg2 = MagicMock()
 _mock_psycopg2.extensions = MagicMock()
@@ -283,13 +285,19 @@ class TestEnqueueNoteRequestLookups:
 
 
 class TestRunNoteRequestsPhase:
-    def test_swallows_exceptions(self):
+    def test_propagates_exceptions_so_the_failure_reaches_the_alarm(self):
+        """握りつぶしは _run_phase に集約した。
+
+        ここで握りつぶすと EXTRACT_PHASE_FAILED トークンが出ずアラームに乗らないため、
+        例外はそのまま送出する。extract 全体が落ちない保証は _run_phase 側のテストが持つ。
+        """
         session = MagicMock()
         with patch(
             "birdxplorer_etl.extract_ecs.extract_note_requests",
             side_effect=RuntimeError("SQS send failed"),
         ):
-            run_note_requests_phase(session)  # 例外が伝播しなければ成功
+            with pytest.raises(RuntimeError, match="SQS send failed"):
+                run_note_requests_phase(session)
 
     def test_calls_both_functions(self):
         session = MagicMock()

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -597,6 +597,25 @@ class TestRunPhase:
 
         mock_session.rollback.assert_called_once()
 
+    def test_logs_alarm_token_even_when_rollback_fails(self, caplog: pytest.LogCaptureFixture) -> None:
+        """DB コネクションごと死ぬと rollback 自体も失敗する。
+
+        そこでトークンを取りこぼすと、アラームが最も必要な場面で無音になる。
+        トークンの出力は rollback より先でなければならない。
+        """
+        mock_session = MagicMock()
+        mock_session.rollback.side_effect = RuntimeError("connection already closed")
+
+        def boom() -> None:
+            raise RuntimeError("server closed the connection unexpectedly")
+
+        with caplog.at_level(logging.ERROR):
+            result = _run_phase("Ratings", mock_session, boom)
+
+        assert result is False
+        assert "EXTRACT_PHASE_FAILED" in caplog.text
+        assert "phase=Ratings" in caplog.text
+
 
 class TestExtractDataPhaseIsolation:
     """前段フェーズの失敗が後段フェーズを巻き添えにしないことのテスト"""

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import logging
 import sys
 from unittest.mock import MagicMock, patch
@@ -18,9 +20,12 @@ from birdxplorer_etl.extract_ecs import (  # noqa: E402
     _cleanup_staging_table,
     _create_staging_table,
     _deduplicate_staging_table,
+    _iter_lines_without_nul,
     _process_rating_rows,
+    _run_phase,
     _swap_ratings_table,
     _validate_rating_row,
+    extract_data,
     extract_ratings,
 )
 
@@ -326,7 +331,9 @@ class TestProcessRatingRows:
         written = self._captured_buffer(mock_cursor)
         suggestion_idx = _RATING_COLUMNS.index("suggestion")
         field = written.rstrip("\n").split("\t")[suggestion_idx]
-        assert "\\\\." in field, f"バックスラッシュがエスケープされていない: {field!r}"
+        # 完全一致で見る。部分一致だと二重エスケープされていても通ってしまう。
+        expected = r"based on the number of reported cases\\. However, this does not"
+        assert field == expected, f"想定外の出力: {field!r}"
 
     def test_escapes_tab_newline_and_carriage_return(self) -> None:
         """タブ・改行を素通しすると列がずれる。COPY TEXT のエスケープ形式で書くこと。"""
@@ -512,3 +519,122 @@ class TestRatingColumns:
         idx_suggestion = _RATING_COLUMNS.index("suggestion")
         idx_suggestion_id = _RATING_COLUMNS.index("suggestion_id")
         assert idx_rated < idx_source < idx_suggestion < idx_suggestion_id
+
+
+class TestIterLinesWithoutNul:
+    """_iter_lines_without_nul のユニットテスト"""
+
+    def test_csv_cannot_parse_nul_without_the_helper(self) -> None:
+        """前提の確認: NUL を含む行を csv にそのまま渡すと _csv.Error で落ちる。"""
+        raw = io.StringIO("note_id\tsuggestion\nn1\tbad\x00value\n")
+
+        with pytest.raises(csv.Error, match="NUL"):
+            list(csv.DictReader(raw, delimiter="\t"))
+
+    def test_strips_nul_so_csv_can_parse(self) -> None:
+        raw = io.StringIO("note_id\tsuggestion\nn1\tbad\x00value\n")
+
+        rows = list(csv.DictReader(_iter_lines_without_nul(raw), delimiter="\t"))
+
+        assert rows == [{"note_id": "n1", "suggestion": "badvalue"}]
+
+    def test_leaves_clean_lines_untouched(self) -> None:
+        raw = io.StringIO("note_id\tsuggestion\nn1\tokay\n")
+
+        rows = list(csv.DictReader(_iter_lines_without_nul(raw), delimiter="\t"))
+
+        assert rows == [{"note_id": "n1", "suggestion": "okay"}]
+
+
+class TestRunPhase:
+    """_run_phase のユニットテスト"""
+
+    def test_returns_true_and_logs_completion_on_success(self, caplog: pytest.LogCaptureFixture) -> None:
+        mock_session = MagicMock()
+        calls = []
+
+        with caplog.at_level(logging.INFO):
+            result = _run_phase("Ratings", mock_session, lambda: calls.append("ran"))
+
+        assert result is True
+        assert calls == ["ran"]
+        assert "[PHASE_COMPLETE] Ratings" in caplog.text
+        mock_session.rollback.assert_not_called()
+
+    def test_swallows_exception_so_later_phases_still_run(self) -> None:
+        """フェーズが落ちてもプロセスを殺さない。これが後続フェーズの飢餓を防ぐ肝。"""
+        mock_session = MagicMock()
+
+        def boom() -> None:
+            raise RuntimeError("end-of-copy marker corrupt")
+
+        result = _run_phase("Ratings", mock_session, boom)
+
+        assert result is False
+
+    def test_logs_alarm_token_on_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """握りつぶしを無音にしないため、アラーム連携用トークンを必ず出す。"""
+        mock_session = MagicMock()
+
+        def boom() -> None:
+            raise RuntimeError("end-of-copy marker corrupt")
+
+        with caplog.at_level(logging.ERROR):
+            _run_phase("Ratings", mock_session, boom)
+
+        assert "EXTRACT_PHASE_FAILED" in caplog.text
+        assert "phase=Ratings" in caplog.text
+        assert "end-of-copy marker corrupt" in caplog.text
+
+    def test_rolls_back_on_failure(self) -> None:
+        """例外後のセッションは InFailedSqlTransaction になるため後続フェーズが道連れになる。"""
+        mock_session = MagicMock()
+
+        def boom() -> None:
+            raise RuntimeError("boom")
+
+        _run_phase("Ratings", mock_session, boom)
+
+        mock_session.rollback.assert_called_once()
+
+
+class TestExtractDataPhaseIsolation:
+    """前段フェーズの失敗が後段フェーズを巻き添えにしないことのテスト"""
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.recalculate_rating_counts")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_ratings_failure_does_not_starve_note_requests_phase(
+        self,
+        mock_requests: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_recalculate: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+    ) -> None:
+        """2026-09-02〜09-07 の実障害の再現。
+
+        ratings の COPY が落ちると extract_data ごと死に、最終フェーズの
+        run_note_requests_phase が6日間まったく走らず tweet-lookup への
+        enqueue が止まっていた。
+        """
+        import settings
+
+        settings.USE_DUMMY_DATA = True
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"noteId\tsummary\n"
+        mock_requests.get.return_value = mock_response
+
+        mock_extract_ratings.side_effect = RuntimeError("end-of-copy marker corrupt")
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.all.return_value = []
+
+        extract_data(mock_session)
+
+        mock_extract_ratings.assert_called_once()
+        mock_note_requests.assert_called_once()
+        mock_backfill.assert_called_once()

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -304,6 +304,45 @@ class TestProcessRatingRows:
         assert total == 50001
         assert mock_cursor.copy_expert.call_count == 2
 
+    def _captured_buffer(self, mock_cursor: MagicMock) -> str:
+        """copy_expert に渡された COPY バッファの中身を取り出す"""
+        assert mock_cursor.copy_expert.called, "copy_expert が呼ばれていない"
+        buffer = mock_cursor.copy_expert.call_args[0][1]
+        buffer.seek(0)
+        return buffer.read()
+
+    def test_escapes_backslash_so_copy_marker_is_not_produced(self) -> None:
+        """suggestion 内の `\\.` を素通しすると COPY が end-of-copy marker corrupt で落ちる。
+
+        2026-09-07 の ratings-00008.tsv 5736123行目に実在した値を再現している。
+        """
+        mock_session, _, mock_cursor = self._mock_session_with_dbapi()
+
+        row = self._make_rating_row("n1", "r1")
+        row["suggestion"] = r"based on the number of reported cases\. However, this does not"
+
+        _process_rating_rows([row], mock_session, {"n1"}, 0)
+
+        written = self._captured_buffer(mock_cursor)
+        suggestion_idx = _RATING_COLUMNS.index("suggestion")
+        field = written.rstrip("\n").split("\t")[suggestion_idx]
+        assert "\\\\." in field, f"バックスラッシュがエスケープされていない: {field!r}"
+
+    def test_escapes_tab_newline_and_carriage_return(self) -> None:
+        """タブ・改行を素通しすると列がずれる。COPY TEXT のエスケープ形式で書くこと。"""
+        mock_session, _, mock_cursor = self._mock_session_with_dbapi()
+
+        row = self._make_rating_row("n1", "r1")
+        row["suggestion"] = "line1\nline2\tcol\rend"
+
+        _process_rating_rows([row], mock_session, {"n1"}, 0)
+
+        written = self._captured_buffer(mock_cursor)
+        assert written.count("\n") == 1, "改行が素通しされ行が分割されている"
+        fields = written.rstrip("\n").split("\t")
+        assert len(fields) == len(_RATING_COLUMNS), f"列数がずれている: {len(fields)}"
+        assert fields[_RATING_COLUMNS.index("suggestion")] == r"line1\nline2\tcol\rend"
+
 
 class TestExtractRatingsErrorRecovery:
     """extract_ratings のエラーリカバリテスト"""


### PR DESCRIPTION
## 何が起きていたか

2026-09-02 から 09-07 までの**6日間、日次 Extract が毎日 ratings フェーズで落ちていた**。

```
psycopg2.errors.BadCopyFileFormat: end-of-copy marker corrupt
CONTEXT: COPY row_note_ratings_new, line 48621
```

`extract_ratings` の例外が `extract_data` を貫通してプロセスごと落とすため、**最終フェーズの `run_note_requests_phase` が一度も実行されなかった**。このフェーズは note-requests(batSignals) の取り込みと tweet-lookup キューへの enqueue を担っている。

結果、tweet-lookup への投入が日 6,800 件から 500 件台へ落ちていた。

| 実行日 | COPY エラー | `Enqueued N note request tweet lookups` |
|---|---|---|
| 09-07 | あり | 未到達 |
| 09-06 | あり | 未到達 |
| 09-05 | あり | 未到達 |
| 09-04 | あり | 未到達 |
| 09-03 | あり | 未到達 |
| 09-02 | あり | 未到達 |
| 08-31 | なし | 到達 |

**この6日間、誰も気付かなかった。** タスクは exit 1 で落ちていたが、ECS タスク失敗に対するアラームが存在しないため無音だった。

## 原因

`_process_rating_rows` が COPY TEXT 形式のバッファを組み立てる際、値を `str(val)` のまま連結していた。COPY TEXT ではバックスラッシュがエスケープ文字で、行頭の `\.` は終端マーカーとして解釈される。ratings の `suggestion` はユーザ入力のフリーテキストなので、これらは実際に混入する。

2026-09-07 の `ratings-00008.tsv` を648万行**全走査**したところ、3行にバックスラッシュが含まれていた。うち 5736123 行目が `\.` を含む:

```
...based on the number of reported cases\. However, this does not...
```

## 変更内容

### 1. COPY TEXT のエスケープ (798dfc8)

`\` `\n` `\r` `\t` の4種をエスケープする。タブと改行は終端マーカーを壊さないが、素通しすると列がずれて別の壊れ方をするため同時に対処した。

### 2. フェーズ分離 (dc87ebe)

トリガーを消しても爆発半径は残る。ネットワークエラーや壊れた zip でも同じく後続フェーズが飢える。

`_run_phase(name, session, fn)` を追加し、失敗しても後続へ進むようにした。握りつぶしを無音にすると劣化に気付けないので、CloudWatch メトリクスフィルタ用に `EXTRACT_PHASE_FAILED` トークンを必ず出す（既存の `NOTE_REQUEST_ROW_SKIPPED` と同じ方式）。**アラーム定義は BirdXplorer-cdk#33 で main にマージ済み。**

`run_note_requests_phase` が持っていた独自の try/except は削除した。そこで握りつぶすとトークンが出ずアラームに乗らないため、`_run_phase` に一本化する。`recalculate_rating_counts` のアドホックな try/except も同じ仕組みへ寄せた。

### 3. NUL バイト (dc87ebe)

PostgreSQL のテキスト型は NUL を保存できず COPY TEXT にも表現が無い。加えて csv が NUL を含む行で `_csv.Error: line contains NUL` を投げるため、エスケープでは手当てできずパーサに渡す手前で除去する必要がある。ratings の読み込みに `_iter_lines_without_nul` を挟んだ。db_writer の `strip_nul_bytes` と同じ趣旨。

### 4. アラームトークンを rollback より先に出す (da1a32a)

レビュー指摘。RDS のフェイルオーバーや接続断でフェーズが落ちると `rollback()` 自体も例外を投げる。トークン出力が後だと**一度も出力されないままプロセスが死ぬ** — アラームが最も必要な DB 障害時に無音になる。順序を入れ替え、rollback を独自の try/except で囲った。

## 検証

**実データを実際の PostgreSQL 15.4 に COPY して確認した。**

| | 結果 |
|---|---|
| 修正前 | `BadCopyFileFormat: end-of-copy marker corrupt`（本番と同一エラーを再現）|
| 修正後 | COPY 成功、3件とも元の値と**完全一致** |

- `pytest` — **271 passed, 4 skipped**（skip は X 認証情報が必要なテスト）
- `black` / `isort` / `pflake8` — クリーン
- 新規コードは `mypy --strict` も clean

TDD で進めた。各テストは先に書き、失敗を確認してから実装している。回帰ガードとして実障害そのものを再現するテストを追加した:

```python
def test_ratings_failure_does_not_starve_note_requests_phase(...):
    mock_extract_ratings.side_effect = RuntimeError("end-of-copy marker corrupt")
    extract_data(mock_session)
    mock_note_requests.assert_called_once()   # 6日間走らなかったフェーズ
```

## デプロイ後に起きること

DB 側では既に、消失した lookup の再投入準備が済んでいる（`row_note_requests.lookup_enqueued_at` を NULL に戻した 42,125 行が待機中）。この PR が入って Extract が完走すれば、最終フェーズがそれらを tweet-lookup へ投入する。1,800 件/時のレート上限で約23時間かけて消化される見込み。

## フォローアップ（この PR には含めない）

レビューで挙がった、独立して対応すべき項目:

- **notes / noteStatus のループが未ラップ** — そこで落ちると同じ形の事故が起き、`EXTRACT_PHASE_FAILED` も出ない。アラームの死角
- NUL 除去を notes / noteStatus のリーダーにも適用する（notes summary も同じユーザ入力）
- フェーズ失敗時にタスクを exit 1 にする（現状 `_run_phase` の戻り値を捨てている）
- ratings 失敗時に再集計をスキップする（無駄なだけで無害）

## 関連

- BirdXplorer-cdk#33 — `EXTRACT_PHASE_FAILED` アラーム（**先にマージ済み**。本 PR の CI が MonitoringStack をデプロイする際に一緒に入る）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
