### PR TITLE
perf(etl): notes/noteStatus の TSV をストリーミングで読み、フェーズ隔離を広げる

### DIFF
--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -58,9 +58,9 @@ def postgres_storage_settings_factory(
         __model__ = PostgresStorageSettings
         __check_model__ = False
 
-        host = "localhost"
+        host = os.environ.get("BX_STORAGE_SETTINGS__HOST", "localhost")
         username = "postgres"
-        port = 5432
+        port = int(os.environ.get("BX_STORAGE_SETTINGS__PORT", "5432"))
         database = "postgres"
         password = os.environ["BX_STORAGE_SETTINGS__PASSWORD"]
 

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -189,75 +189,25 @@ def extract_data(postgresql: Session):
         date = datetime.now() - timedelta(days=days_ago)
         dateString = date.strftime("%Y/%m/%d")
 
-        # notes-00000.zip から順に404が返るまでダウンロード
-        file_index = 0
-        date_has_notes = False  # この日のnotesデータが存在するか
+        # notes / noteStatus も _run_phase で包む。ストリーミング化で zip の CRC 検証と
+        # UTF-8 デコードが逐次になったため「ファイル途中で落ちる」が到達可能になり、
+        # 裸で呼ぶとその日の Ratings / Status / Backfill / NoteRequests が全滅する。
+        notes_state = {"date_has_notes": False}
+        notes_ok = _run_phase(
+            "Notes",
+            postgresql,
+            lambda: _extract_notes_files(postgresql, dateString, existing_row_note_ids, notes_state),
+        )
 
-        phase_start = time.time()
-
-        while True:
-            if settings.USE_DUMMY_DATA:
-                note_url = (
-                    "https://raw.githubusercontent.com/codeforjapan/BirdXplorer"
-                    "/refs/heads/main/etl/data/notes_sample.tsv"
-                )
-            else:
-                note_url = f"https://ton.twimg.com/birdwatch-public-data/{dateString}/notes/notes-{file_index:05d}.zip"
-
-            logging.info(f"Fetching notes from: {note_url}")
-            res = requests.get(note_url)
-
-            if res.status_code == 404:
-                if file_index == 0:
-                    logging.info(f"No notes data available for {dateString}, trying previous day")
-                else:
-                    logging.info(
-                        f"Notes file {file_index:05d} not found (404), stopping notes download for {dateString}"
-                    )
-                break
-
-            if res.status_code != 200:
-                logging.warning(f"Unexpected status code {res.status_code} for notes file {file_index:05d}, skipping")
-                file_index += 1
+        if not notes_state["date_has_notes"]:
+            if notes_ok:
+                # 404 = この日のデータがまだ公開されていない。前の日を試す。
                 continue
-
-            # TSVを読み込む
-            date_has_notes = True  # この日のデータが存在する
-            if settings.USE_DUMMY_DATA:
-                # ダミーデータの場合はTSVファイルを直接処理
-                tsv_data = res.content.decode("utf-8").splitlines()
-                reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
-                reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                _process_note_rows(reader, postgresql, existing_row_note_ids)
-            else:
-                with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
-                    tsv_filename = f"notes-{file_index:05d}.tsv"
-                    if tsv_filename not in zip_file.namelist():
-                        logging.error(f"TSV file {tsv_filename} not found in the zip file.")
-                        break
-
-                    # 展開後の TSV は 1.8GB 規模。read().decode().splitlines() は
-                    # bytes / str / str のリストで3重にメモリへ載せ、8GB を超えて OOM した。
-                    # ratings と同じくストリームのまま渡し、消費もこの with の内側で行う。
-                    with zip_file.open(tsv_filename) as tsv_file:
-                        text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
-                        reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
-                        reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                        _process_note_rows(reader, postgresql, existing_row_note_ids)
-
-            logging.info(f"Successfully processed notes file {file_index:05d} for {dateString}")
-
-            # ダミーデータの場合は1ファイルのみなのでループを抜ける
-            if settings.USE_DUMMY_DATA:
-                break
-
-            file_index += 1
-
-        logging.info(f"[PHASE_COMPLETE] Notes: {time.time() - phase_start:.1f}s")
-
-        # この日のnotesデータがなければ前の日を試す
-        if not date_has_notes:
-            continue
+            # 取得そのものが失敗（接続断など）。ここで前日にフォールバックすると、
+            # ratings のフルスワップまで含めて前日分を丸ごと再処理して1時間規模を浪費し、
+            # しかも当日分はこの実行では取り込まれない。ソースは累積スナップショットなので
+            # 次回の定期実行で追いつく。この日で打ち切り、後段フェーズだけ走らせる。
+            break
 
         # 評価データを取得して保存（noteStatus処理より先に実行することで集計タイミングを保証）
         _run_phase("Ratings", postgresql, lambda: extract_ratings(postgresql, dateString, existing_row_note_ids))
@@ -265,66 +215,11 @@ def extract_data(postgresql: Session):
         # notesテーブルの評価集計カラムを再計算
         _run_phase("Rating recalculation", postgresql, lambda: recalculate_rating_counts(postgresql))
 
-        # noteStatusHistory-00000.zip から順に404が返るまでダウンロード
-        phase_start = time.time()
-        file_index = 0
-        while True:
-            if settings.USE_DUMMY_DATA:
-                status_url = (
-                    "https://raw.githubusercontent.com/codeforjapan/BirdXplorer/"
-                    "refs/heads/main/etl/data/noteStatus_sample.tsv"
-                )
-            else:
-                status_url = (
-                    f"https://ton.twimg.com/birdwatch-public-data/{dateString}/"
-                    f"noteStatusHistory/noteStatusHistory-{file_index:05d}.zip"
-                )
-
-            logging.info(f"Fetching note status from: {status_url}")
-            res = requests.get(status_url)
-
-            if res.status_code == 404:
-                logging.info(
-                    f"Note status file {file_index:05d} not found (404), stopping status download for {dateString}"
-                )
-                break
-
-            if res.status_code != 200:
-                logging.warning(f"Unexpected status code {res.status_code} for status file {file_index:05d}, skipping")
-                file_index += 1
-                continue
-
-            # TSVを読み込む
-            if settings.USE_DUMMY_DATA:
-                # Handle dummy data as TSV
-                tsv_data = res.content.decode("utf-8").splitlines()
-                reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
-                reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                _process_note_status_rows(reader, postgresql, existing_row_note_ids)
-            else:
-                # Handle real data as zip file
-                with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
-                    tsv_filename = f"noteStatusHistory-{file_index:05d}.tsv"
-                    if tsv_filename not in zip_file.namelist():
-                        logging.error(f"TSV file {tsv_filename} not found in the zip file.")
-                        break
-
-                    # notes と同じ理由でストリームのまま渡す(172MB の zip = 展開後 700MB 規模)
-                    with zip_file.open(tsv_filename) as tsv_file:
-                        text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
-                        reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
-                        reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-                        _process_note_status_rows(reader, postgresql, existing_row_note_ids)
-
-            logging.info(f"Successfully processed note status file {file_index:05d} for {dateString}")
-
-            # ダミーデータの場合は1ファイルのみなのでループを抜ける
-            if settings.USE_DUMMY_DATA:
-                break
-
-            file_index += 1
-
-        logging.info(f"[PHASE_COMPLETE] Status: {time.time() - phase_start:.1f}s")
+        _run_phase(
+            "Status",
+            postgresql,
+            lambda: _extract_note_status_files(postgresql, dateString, existing_row_note_ids),
+        )
 
         break  # データを処理したので終了
 
@@ -337,6 +232,134 @@ def extract_data(postgresql: Session):
     _run_phase("NoteRequests", postgresql, lambda: run_note_requests_phase(postgresql))
 
     return
+
+
+def _extract_notes_files(postgresql: Session, dateString: str, existing_row_note_ids: set, state: dict) -> None:
+    """notes-XXXXX.zip を 404 まで順に取得して取り込む。
+
+    この日の notes が1ファイルでも存在したかは戻り値ではなく `state["date_has_notes"]`
+    で返す。_run_phase の契約が Callable[[], None] であることに加え、途中で例外になっても
+    「200 を受けた」事実は呼び出し元に残す必要があるため（残さないと前日へフォールバックし、
+    別の日を丸ごと処理してしまう）。
+    """
+    file_index = 0
+
+    while True:
+        if settings.USE_DUMMY_DATA:
+            note_url = (
+                "https://raw.githubusercontent.com/codeforjapan/BirdXplorer"
+                "/refs/heads/main/etl/data/notes_sample.tsv"
+            )
+        else:
+            note_url = f"https://ton.twimg.com/birdwatch-public-data/{dateString}/notes/notes-{file_index:05d}.zip"
+
+        logging.info(f"Fetching notes from: {note_url}")
+        res = requests.get(note_url)
+
+        if res.status_code == 404:
+            if file_index == 0:
+                logging.info(f"No notes data available for {dateString}, trying previous day")
+            else:
+                logging.info(f"Notes file {file_index:05d} not found (404), stopping notes download for {dateString}")
+            break
+
+        if res.status_code != 200:
+            logging.warning(f"Unexpected status code {res.status_code} for notes file {file_index:05d}, skipping")
+            file_index += 1
+            continue
+
+        # TSVを読み込む
+        state["date_has_notes"] = True  # この日のデータが存在する
+        if settings.USE_DUMMY_DATA:
+            # ダミーデータの場合はTSVファイルを直接処理
+            tsv_data = res.content.decode("utf-8").splitlines()
+            reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
+            reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+            _process_note_rows(reader, postgresql, existing_row_note_ids)
+        else:
+            with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
+                tsv_filename = f"notes-{file_index:05d}.tsv"
+                if tsv_filename not in zip_file.namelist():
+                    logging.error(f"TSV file {tsv_filename} not found in the zip file.")
+                    break
+
+                # 展開後の TSV は 1.8GB 規模。read().decode().splitlines() は
+                # bytes / str / str のリストで3重にメモリへ載せ、8GB を超えて OOM した。
+                # ratings と同じくストリームのまま渡し、消費もこの with の内側で行う。
+                with zip_file.open(tsv_filename) as tsv_file:
+                    text_file = io.TextIOWrapper(tsv_file, encoding="utf-8", newline="")
+                    reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
+                    reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                    _process_note_rows(reader, postgresql, existing_row_note_ids)
+
+        logging.info(f"Successfully processed notes file {file_index:05d} for {dateString}")
+
+        # ダミーデータの場合は1ファイルのみなのでループを抜ける
+        if settings.USE_DUMMY_DATA:
+            break
+
+        file_index += 1
+
+
+def _extract_note_status_files(postgresql: Session, dateString: str, existing_row_note_ids: set) -> None:
+    """noteStatusHistory-XXXXX.zip を 404 まで順に取得して取り込む。"""
+    file_index = 0
+
+    while True:
+        if settings.USE_DUMMY_DATA:
+            status_url = (
+                "https://raw.githubusercontent.com/codeforjapan/BirdXplorer/"
+                "refs/heads/main/etl/data/noteStatus_sample.tsv"
+            )
+        else:
+            status_url = (
+                f"https://ton.twimg.com/birdwatch-public-data/{dateString}/"
+                f"noteStatusHistory/noteStatusHistory-{file_index:05d}.zip"
+            )
+
+        logging.info(f"Fetching note status from: {status_url}")
+        res = requests.get(status_url)
+
+        if res.status_code == 404:
+            logging.info(
+                f"Note status file {file_index:05d} not found (404), stopping status download for {dateString}"
+            )
+            break
+
+        if res.status_code != 200:
+            logging.warning(f"Unexpected status code {res.status_code} for status file {file_index:05d}, skipping")
+            file_index += 1
+            continue
+
+        # TSVを読み込む
+        if settings.USE_DUMMY_DATA:
+            # Handle dummy data as TSV
+            tsv_data = res.content.decode("utf-8").splitlines()
+            reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
+            reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+            _process_note_status_rows(reader, postgresql, existing_row_note_ids)
+        else:
+            # Handle real data as zip file
+            with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
+                tsv_filename = f"noteStatusHistory-{file_index:05d}.tsv"
+                if tsv_filename not in zip_file.namelist():
+                    logging.error(f"TSV file {tsv_filename} not found in the zip file.")
+                    break
+
+                # notes と同じ理由でストリームのまま渡す(172MB の zip = 展開後 700MB 規模)
+                with zip_file.open(tsv_filename) as tsv_file:
+                    text_file = io.TextIOWrapper(tsv_file, encoding="utf-8", newline="")
+                    reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
+                    reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                    _process_note_status_rows(reader, postgresql, existing_row_note_ids)
+
+        logging.info(f"Successfully processed note status file {file_index:05d} for {dateString}")
+
+        # ダミーデータの場合は1ファイルのみなのでループを抜ける
+        if settings.USE_DUMMY_DATA:
+            break
+
+        file_index += 1
 
 
 def _process_note_status_rows(reader, postgresql: Session, existing_row_note_ids: set) -> None:
@@ -390,7 +413,7 @@ def _process_note_rows(reader, postgresql: Session, existing_row_note_ids: set) 
     """
     rows_to_add = {}  # note_idをキーにして重複を防ぐ
     pending_rows = {}  # 既存ノートの更新候補（バッチ取得用）
-    for index, row in enumerate(reader):
+    for row in reader:
         note_id = row["note_id"]
         # 既にrows_to_addまたはpending_rowsに追加済みの場合はスキップ
         if note_id in rows_to_add or note_id in pending_rows:
@@ -487,7 +510,9 @@ def _process_note_rows(reader, postgresql: Session, existing_row_note_ids: set) 
             note_record = RowNoteRecord(**row)
             rows_to_add[note_id] = note_record
 
-        if (index + 1) % 1000 == 0:
+        # 境界は「溜まった件数」で判定する。enumerate の index で判定すると、
+        # 重複 note_id の continue が 1000 の倍数を飛ばし、次の境界まで溜め込み続ける。
+        if len(rows_to_add) + len(pending_rows) >= 1000:
             _flush_notes_batch(postgresql, rows_to_add, pending_rows, existing_row_note_ids)
             rows_to_add = {}
             pending_rows = {}
@@ -767,7 +792,7 @@ def extract_ratings(postgresql: Session, dateString: str, existing_row_note_ids:
                             continue
 
                         with zip_file.open(tsv_filename) as tsv_file:
-                            text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
+                            text_file = io.TextIOWrapper(tsv_file, encoding="utf-8", newline="")
                             reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
                             reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
                             total_loaded += _process_rating_rows(reader, postgresql, existing_row_note_ids, file_index)

--- a/etl/src/birdxplorer_etl/extract_ecs.py
+++ b/etl/src/birdxplorer_etl/extract_ecs.py
@@ -226,8 +226,9 @@ def extract_data(postgresql: Session):
             if settings.USE_DUMMY_DATA:
                 # ダミーデータの場合はTSVファイルを直接処理
                 tsv_data = res.content.decode("utf-8").splitlines()
-                reader = csv.DictReader(tsv_data, delimiter="\t")
+                reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
                 reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                _process_note_rows(reader, postgresql, existing_row_note_ids)
             else:
                 with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
                     tsv_filename = f"notes-{file_index:05d}.tsv"
@@ -235,120 +236,14 @@ def extract_data(postgresql: Session):
                         logging.error(f"TSV file {tsv_filename} not found in the zip file.")
                         break
 
+                    # 展開後の TSV は 1.8GB 規模。read().decode().splitlines() は
+                    # bytes / str / str のリストで3重にメモリへ載せ、8GB を超えて OOM した。
+                    # ratings と同じくストリームのまま渡し、消費もこの with の内側で行う。
                     with zip_file.open(tsv_filename) as tsv_file:
-                        tsv_data = tsv_file.read().decode("utf-8").splitlines()
-                        reader = csv.DictReader(tsv_data, delimiter="\t")
+                        text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
+                        reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
                         reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-
-            rows_to_add = {}  # note_idをキーにして重複を防ぐ
-            pending_rows = {}  # 既存ノートの更新候補（バッチ取得用）
-            for index, row in enumerate(reader):
-                note_id = row["note_id"]
-                # 既にrows_to_addまたはpending_rowsに追加済みの場合はスキップ
-                if note_id in rows_to_add or note_id in pending_rows:
-                    continue
-
-                # BinaryBoolフィールドの値を正規化
-                binary_bool_fields = [
-                    "believable",
-                    "misleading_other",
-                    "misleading_factual_error",
-                    "misleading_manipulated_media",
-                    "misleading_outdated_information",
-                    "misleading_missing_important_context",
-                    "misleading_unverified_claim_as_fact",
-                    "misleading_satire",
-                    "not_misleading_other",
-                    "not_misleading_factually_correct",
-                    "not_misleading_outdated_but_not_when_written",
-                    "not_misleading_clearly_satire",
-                    "not_misleading_personal_opinion",
-                    "trustworthy_sources",
-                    "is_media_note",
-                    "is_collaborative_note",
-                ]
-
-                for field in binary_bool_fields:
-                    if field in row:
-                        value = row[field]
-                        if field == "believable":
-                            # believableフィールドの特別な処理
-                            if value == "BELIEVABLE_BY_MANY":
-                                row[field] = "1"
-                            elif value == "BELIEVABLE_BY_FEW":
-                                row[field] = "0"
-                            elif value == "" or value is None or value == "empty":
-                                row[field] = "0"
-                            elif value not in ["0", "1"]:
-                                note_id = row.get("note_id", "unknown")
-                                logging.warning(
-                                    f"Unexpected value '{value}' for believable field in note {note_id}. "
-                                    f"Setting to '0'."
-                                )
-                                row[field] = "0"
-                        else:
-                            # 他のBinaryBoolフィールドの処理
-                            if value == "" or value is None or value == "empty":
-                                row[field] = "0"
-                            elif value not in ["0", "1"]:
-                                # 予期しない値の場合はログに記録して0に設定
-                                note_id = row.get("note_id", "unknown")
-                                logging.warning(
-                                    f"Unexpected value '{value}' for field '{field}' in note {note_id}. "
-                                    f"Setting to '0'."
-                                )
-                                row[field] = "0"
-
-                # harmfulフィールドの処理
-                if "harmful" in row:
-                    value = row["harmful"]
-                    if value == "" or value is None or value == "empty":
-                        row["harmful"] = "LITTLE_HARM"  # デフォルト値
-                    elif value not in ["LITTLE_HARM", "CONSIDERABLE_HARM"]:
-                        note_id = row.get("note_id", "unknown")
-                        logging.warning(
-                            f"Unexpected value '{value}' for harmful field in note {note_id}. "
-                            f"Setting to 'LITTLE_HARM'."
-                        )
-                        row["harmful"] = "LITTLE_HARM"
-
-                # classificationフィールドの処理
-                if "classification" in row:
-                    value = row["classification"]
-                    if value == "" or value is None or value == "empty":
-                        row["classification"] = "NOT_MISLEADING"  # デフォルト値
-                    elif value not in ["NOT_MISLEADING", "MISINFORMED_OR_POTENTIALLY_MISLEADING"]:
-                        note_id = row.get("note_id", "unknown")
-                        logging.warning(
-                            f"Unexpected value '{value}' for classification field in note {note_id}. "
-                            f"Setting to 'NOT_MISLEADING'."
-                        )
-                        row["classification"] = "NOT_MISLEADING"
-
-                # validation_difficultyフィールドの処理（データベースではSummaryString型）
-                if "validation_difficulty" in row:
-                    value = row["validation_difficulty"]
-                    if value == "" or value is None or value == "empty":
-                        row["validation_difficulty"] = ""  # 空文字列として保存
-
-                # その他の空文字列フィールドの処理（harmful と validation_difficulty 以外）
-                for key, value in row.items():
-                    if value == "" and key not in ["harmful", "validation_difficulty"]:
-                        row[key] = None
-
-                if note_id in existing_row_note_ids:
-                    pending_rows[note_id] = dict(row)  # バッチ取得用に蓄積
-                else:
-                    note_record = RowNoteRecord(**row)
-                    rows_to_add[note_id] = note_record
-
-                if (index + 1) % 1000 == 0:
-                    _flush_notes_batch(postgresql, rows_to_add, pending_rows, existing_row_note_ids)
-                    rows_to_add = {}
-                    pending_rows = {}
-
-            # 最後のバッチを処理
-            _flush_notes_batch(postgresql, rows_to_add, pending_rows, existing_row_note_ids)
+                        _process_note_rows(reader, postgresql, existing_row_note_ids)
 
             logging.info(f"Successfully processed notes file {file_index:05d} for {dateString}")
 
@@ -403,8 +298,9 @@ def extract_data(postgresql: Session):
             if settings.USE_DUMMY_DATA:
                 # Handle dummy data as TSV
                 tsv_data = res.content.decode("utf-8").splitlines()
-                reader = csv.DictReader(tsv_data, delimiter="\t")
+                reader = csv.DictReader(_iter_lines_without_nul(tsv_data), delimiter="\t")
                 reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+                _process_note_status_rows(reader, postgresql, existing_row_note_ids)
             else:
                 # Handle real data as zip file
                 with zipfile.ZipFile(io.BytesIO(res.content)) as zip_file:
@@ -413,47 +309,12 @@ def extract_data(postgresql: Session):
                         logging.error(f"TSV file {tsv_filename} not found in the zip file.")
                         break
 
-                    # TSVファイルを読み込み
+                    # notes と同じ理由でストリームのまま渡す(172MB の zip = 展開後 700MB 規模)
                     with zip_file.open(tsv_filename) as tsv_file:
-                        tsv_data = tsv_file.read().decode("utf-8").splitlines()
-                        reader = csv.DictReader(tsv_data, delimiter="\t")
+                        text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
+                        reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
                         reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
-
-            # notesテーブルのnote_idセットを取得（ステータス更新キュー送信判定用）
-            existing_note_record_ids = set(r[0] for r in postgresql.query(NoteRecord.note_id).all())
-            logging.info(f"Loaded {len(existing_note_record_ids)} existing note IDs from notes table")
-
-            rows_to_process = []
-            for index, row in enumerate(reader):
-                for key, value in list(row.items()):
-                    if value == "":
-                        row[key] = None
-
-                # 対応するnote_idがrow_notesテーブルに存在するかをセットで確認
-                if row["note_id"] not in existing_row_note_ids:
-                    continue
-
-                rows_to_process.append(row)
-
-                if len(rows_to_process) >= 1000:
-                    # 差分検出 → UPSERT → 変更分のみ enqueue
-                    changed_note_ids = _detect_status_changes(postgresql, rows_to_process)
-                    _upsert_note_status_batch(postgresql, [dict(r) for r in rows_to_process])
-                    postgresql.commit()
-
-                    notes_to_update_status = [nid for nid in changed_note_ids if nid in existing_note_record_ids]
-                    enqueue_note_status_batch(notes_to_update_status)
-
-                    rows_to_process = []
-
-            # 最後のバッチを処理
-            if rows_to_process:
-                changed_note_ids = _detect_status_changes(postgresql, rows_to_process)
-                _upsert_note_status_batch(postgresql, [dict(r) for r in rows_to_process])
-                postgresql.commit()
-
-                notes_to_update_status = [nid for nid in changed_note_ids if nid in existing_note_record_ids]
-                enqueue_note_status_batch(notes_to_update_status)
+                        _process_note_status_rows(reader, postgresql, existing_row_note_ids)
 
             logging.info(f"Successfully processed note status file {file_index:05d} for {dateString}")
 
@@ -476,6 +337,163 @@ def extract_data(postgresql: Session):
     _run_phase("NoteRequests", postgresql, lambda: run_note_requests_phase(postgresql))
 
     return
+
+
+def _process_note_status_rows(reader, postgresql: Session, existing_row_note_ids: set) -> None:
+    """noteStatusHistory の TSV 行を1行ずつ処理し、1000件ごとに差分検出・UPSERT・enqueue する。
+
+    notes 側と同じ理由で `with zip_file.open(...)` の内側から呼ぶ。
+    """
+    existing_note_record_ids = set(r[0] for r in postgresql.query(NoteRecord.note_id).all())
+    logging.info(f"Loaded {len(existing_note_record_ids)} existing note IDs from notes table")
+
+    rows_to_process = []
+    for index, row in enumerate(reader):
+        for key, value in list(row.items()):
+            if value == "":
+                row[key] = None
+
+        # 対応するnote_idがrow_notesテーブルに存在するかをセットで確認
+        if row["note_id"] not in existing_row_note_ids:
+            continue
+
+        rows_to_process.append(row)
+
+        if len(rows_to_process) >= 1000:
+            # 差分検出 → UPSERT → 変更分のみ enqueue
+            changed_note_ids = _detect_status_changes(postgresql, rows_to_process)
+            _upsert_note_status_batch(postgresql, [dict(r) for r in rows_to_process])
+            postgresql.commit()
+
+            notes_to_update_status = [nid for nid in changed_note_ids if nid in existing_note_record_ids]
+            enqueue_note_status_batch(notes_to_update_status)
+
+            rows_to_process = []
+
+    # 最後のバッチを処理
+    if rows_to_process:
+        changed_note_ids = _detect_status_changes(postgresql, rows_to_process)
+        _upsert_note_status_batch(postgresql, [dict(r) for r in rows_to_process])
+        postgresql.commit()
+
+        notes_to_update_status = [nid for nid in changed_note_ids if nid in existing_note_record_ids]
+        enqueue_note_status_batch(notes_to_update_status)
+
+
+def _process_note_rows(reader, postgresql: Session, existing_row_note_ids: set) -> None:
+    """notes の TSV 行を1行ずつ処理し、1000件ごとに DB へフラッシュする。
+
+    reader は zip 内ファイルを直接ラップしたストリームなので、呼び出しは
+    `with zip_file.open(...)` の内側で行う必要がある。以前はここが while ループ側に
+    あったため reader を作る時点で全件をメモリに載せるしかなく、それが
+    2026-09-08 の OOM(exit 137) の原因になっていた。
+    """
+    rows_to_add = {}  # note_idをキーにして重複を防ぐ
+    pending_rows = {}  # 既存ノートの更新候補（バッチ取得用）
+    for index, row in enumerate(reader):
+        note_id = row["note_id"]
+        # 既にrows_to_addまたはpending_rowsに追加済みの場合はスキップ
+        if note_id in rows_to_add or note_id in pending_rows:
+            continue
+
+        # BinaryBoolフィールドの値を正規化
+        binary_bool_fields = [
+            "believable",
+            "misleading_other",
+            "misleading_factual_error",
+            "misleading_manipulated_media",
+            "misleading_outdated_information",
+            "misleading_missing_important_context",
+            "misleading_unverified_claim_as_fact",
+            "misleading_satire",
+            "not_misleading_other",
+            "not_misleading_factually_correct",
+            "not_misleading_outdated_but_not_when_written",
+            "not_misleading_clearly_satire",
+            "not_misleading_personal_opinion",
+            "trustworthy_sources",
+            "is_media_note",
+            "is_collaborative_note",
+        ]
+
+        for field in binary_bool_fields:
+            if field in row:
+                value = row[field]
+                if field == "believable":
+                    # believableフィールドの特別な処理
+                    if value == "BELIEVABLE_BY_MANY":
+                        row[field] = "1"
+                    elif value == "BELIEVABLE_BY_FEW":
+                        row[field] = "0"
+                    elif value == "" or value is None or value == "empty":
+                        row[field] = "0"
+                    elif value not in ["0", "1"]:
+                        note_id = row.get("note_id", "unknown")
+                        logging.warning(
+                            f"Unexpected value '{value}' for believable field in note {note_id}. " f"Setting to '0'."
+                        )
+                        row[field] = "0"
+                else:
+                    # 他のBinaryBoolフィールドの処理
+                    if value == "" or value is None or value == "empty":
+                        row[field] = "0"
+                    elif value not in ["0", "1"]:
+                        # 予期しない値の場合はログに記録して0に設定
+                        note_id = row.get("note_id", "unknown")
+                        logging.warning(
+                            f"Unexpected value '{value}' for field '{field}' in note {note_id}. " f"Setting to '0'."
+                        )
+                        row[field] = "0"
+
+        # harmfulフィールドの処理
+        if "harmful" in row:
+            value = row["harmful"]
+            if value == "" or value is None or value == "empty":
+                row["harmful"] = "LITTLE_HARM"  # デフォルト値
+            elif value not in ["LITTLE_HARM", "CONSIDERABLE_HARM"]:
+                note_id = row.get("note_id", "unknown")
+                logging.warning(
+                    f"Unexpected value '{value}' for harmful field in note {note_id}. " f"Setting to 'LITTLE_HARM'."
+                )
+                row["harmful"] = "LITTLE_HARM"
+
+        # classificationフィールドの処理
+        if "classification" in row:
+            value = row["classification"]
+            if value == "" or value is None or value == "empty":
+                row["classification"] = "NOT_MISLEADING"  # デフォルト値
+            elif value not in ["NOT_MISLEADING", "MISINFORMED_OR_POTENTIALLY_MISLEADING"]:
+                note_id = row.get("note_id", "unknown")
+                logging.warning(
+                    f"Unexpected value '{value}' for classification field in note {note_id}. "
+                    f"Setting to 'NOT_MISLEADING'."
+                )
+                row["classification"] = "NOT_MISLEADING"
+
+        # validation_difficultyフィールドの処理（データベースではSummaryString型）
+        if "validation_difficulty" in row:
+            value = row["validation_difficulty"]
+            if value == "" or value is None or value == "empty":
+                row["validation_difficulty"] = ""  # 空文字列として保存
+
+        # その他の空文字列フィールドの処理（harmful と validation_difficulty 以外）
+        for key, value in row.items():
+            if value == "" and key not in ["harmful", "validation_difficulty"]:
+                row[key] = None
+
+        if note_id in existing_row_note_ids:
+            pending_rows[note_id] = dict(row)  # バッチ取得用に蓄積
+        else:
+            note_record = RowNoteRecord(**row)
+            rows_to_add[note_id] = note_record
+
+        if (index + 1) % 1000 == 0:
+            _flush_notes_batch(postgresql, rows_to_add, pending_rows, existing_row_note_ids)
+            rows_to_add = {}
+            pending_rows = {}
+
+    # 最後のバッチを処理
+    _flush_notes_batch(postgresql, rows_to_add, pending_rows, existing_row_note_ids)
 
 
 def _flush_notes_batch(postgresql: Session, rows_to_add: dict, pending_rows: dict, existing_row_note_ids: set):

--- a/etl/tests/test_extract_ratings_swap.py
+++ b/etl/tests/test_extract_ratings_swap.py
@@ -641,19 +641,188 @@ class TestExtractDataPhaseIsolation:
         """
         import settings
 
+        original = settings.USE_DUMMY_DATA
         settings.USE_DUMMY_DATA = True
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.content = b"noteId\tsummary\n"
-        mock_requests.get.return_value = mock_response
+        try:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b"noteId\tsummary\n"
+            mock_requests.get.return_value = mock_response
 
-        mock_extract_ratings.side_effect = RuntimeError("end-of-copy marker corrupt")
+            mock_extract_ratings.side_effect = RuntimeError("end-of-copy marker corrupt")
 
-        mock_session = MagicMock()
-        mock_session.query.return_value.all.return_value = []
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
 
-        extract_data(mock_session)
+            extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
 
         mock_extract_ratings.assert_called_once()
         mock_note_requests.assert_called_once()
         mock_backfill.assert_called_once()
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.recalculate_rating_counts")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs._process_note_status_rows")
+    @patch("birdxplorer_etl.extract_ecs._process_note_rows")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_notes_failure_does_not_starve_later_phases(
+        self,
+        mock_requests: MagicMock,
+        mock_process_note_rows: MagicMock,
+        mock_process_note_status_rows: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_recalculate: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """notes の取り込みが途中で落ちても後段フェーズは走り、アラームトークンが出ること。
+
+        ストリーミング化で zip の CRC 検証と UTF-8 デコードが逐次になったため、
+        「ファイル途中で落ちる」が新たに到達可能になった。裸で呼んでいると
+        その日の Ratings / Status / Backfill / NoteRequests が全滅する。
+        """
+        import settings
+
+        original = settings.USE_DUMMY_DATA
+        settings.USE_DUMMY_DATA = True
+        try:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b"noteId\tsummary\n"
+            mock_requests.get.return_value = mock_response
+
+            mock_process_note_rows.side_effect = RuntimeError("Bad CRC-32 for file 'notes-00002.tsv'")
+
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
+
+            with caplog.at_level(logging.ERROR):
+                extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
+
+        assert "EXTRACT_PHASE_FAILED" in caplog.text
+        assert "phase=Notes" in caplog.text
+        mock_extract_ratings.assert_called_once()
+        mock_recalculate.assert_called_once()
+        mock_process_note_status_rows.assert_called_once()
+        mock_backfill.assert_called_once()
+        mock_note_requests.assert_called_once()
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.recalculate_rating_counts")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs._process_note_status_rows")
+    @patch("birdxplorer_etl.extract_ecs._process_note_rows")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_note_status_failure_does_not_starve_backfill_and_note_requests(
+        self,
+        mock_requests: MagicMock,
+        mock_process_note_rows: MagicMock,
+        mock_process_note_status_rows: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_recalculate: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """noteStatus の取り込みが落ちても Backfill / NoteRequests は走ること。"""
+        import settings
+
+        original = settings.USE_DUMMY_DATA
+        settings.USE_DUMMY_DATA = True
+        try:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b"noteId\tcurrentStatus\n"
+            mock_requests.get.return_value = mock_response
+
+            mock_process_note_status_rows.side_effect = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
+
+            with caplog.at_level(logging.ERROR):
+                extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
+
+        assert "EXTRACT_PHASE_FAILED" in caplog.text
+        assert "phase=Status" in caplog.text
+        mock_backfill.assert_called_once()
+        mock_note_requests.assert_called_once()
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_fetch_failure_does_not_fall_back_to_the_previous_day(
+        self,
+        mock_requests: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+    ) -> None:
+        """取得そのものが失敗した日は、前日へフォールバックせず打ち切ること。
+
+        前日フォールバックは「404 = まだ公開されていない」ための仕組み。接続断で
+        前日に流れると ratings のフルスワップ込みで前日分を丸ごと再処理して
+        1時間規模を浪費し、しかも当日分はこの実行では取り込まれない。
+        後段フェーズ(Backfill / NoteRequests)は走らせる必要がある。
+        """
+        import settings
+
+        original = settings.USE_DUMMY_DATA
+        settings.USE_DUMMY_DATA = True
+        try:
+            mock_requests.get.side_effect = OSError("Connection reset by peer")
+
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
+
+            extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
+
+        assert mock_requests.get.call_count == 1, "前日にフォールバックして再取得している"
+        mock_extract_ratings.assert_not_called()
+        mock_backfill.assert_called_once()
+        mock_note_requests.assert_called_once()
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_404_still_falls_back_to_the_previous_day(
+        self,
+        mock_requests: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+    ) -> None:
+        """404 のときは従来どおり3日分まで遡ること（打ち切り条件を広げていない）。"""
+        import settings
+
+        original = settings.USE_DUMMY_DATA
+        settings.USE_DUMMY_DATA = False
+        try:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_requests.get.return_value = mock_response
+
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
+
+            extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
+
+        assert mock_requests.get.call_count == 3, "今日・昨日・一昨日の3日分を試していない"
+        mock_extract_ratings.assert_not_called()
+        mock_note_requests.assert_called_once()

--- a/etl/tests/test_extract_streaming.py
+++ b/etl/tests/test_extract_streaming.py
@@ -1,0 +1,126 @@
+"""notes / noteStatus の TSV をストリーミングで読むことのテスト。
+
+2026-09-08 の OOM は、展開後 1.8GB の TSV を read().decode().splitlines() で
+3段階(bytes / str / str のリスト)にわたってメモリへ載せていたことが原因。
+ratings だけは以前からストリーミングしており、1.26GB の TSV でも落ちていなかった。
+"""
+
+import csv
+import io
+import sys
+import zipfile
+from unittest.mock import MagicMock, patch
+
+# extract_ecs.py は psycopg2 と settings をランタイム前提で import する
+_mock_psycopg2 = MagicMock()
+_mock_psycopg2.extensions = MagicMock()
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+sys.modules.setdefault("psycopg2.extensions", _mock_psycopg2.extensions)
+sys.modules.setdefault("settings", MagicMock())
+
+import stringcase  # noqa: E402
+
+from birdxplorer_etl.extract_ecs import (  # noqa: E402
+    _iter_lines_without_nul,
+    _process_note_rows,
+    _process_note_status_rows,
+)
+
+
+def _reader_over_zip(tsv_text: str, member: str = "notes-00000.tsv") -> csv.DictReader:
+    """production と同じ経路(zip -> TextIOWrapper -> NUL 除去 -> DictReader)で reader を作る。"""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(member, tsv_text)
+    buf.seek(0)
+    zip_file = zipfile.ZipFile(buf)
+    tsv_file = zip_file.open(member)
+    text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
+    reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
+    reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
+    return reader
+
+
+class TestProcessNoteRows:
+    def test_accepts_a_one_shot_iterator(self) -> None:
+        """リストではなくイテレータで処理できること。
+
+        len() や添字を使っていると全件をメモリに載せる実装に戻ってしまう。
+        """
+        reader = _reader_over_zip("noteId\tsummary\nn1\thello\n")
+        session = MagicMock()
+
+        with patch("birdxplorer_etl.extract_ecs._flush_notes_batch") as flush:
+            _process_note_rows(reader, session, {"n1"})
+
+        pending = flush.call_args_list[-1].args[2]
+        assert list(pending) == ["n1"]
+
+    def test_a_quoted_newline_stays_one_row(self) -> None:
+        """splitlines() はクォート内の改行でも行を割ってしまう。
+
+        ストリーミング + csv なら1行として扱われる。取り込み行数が変わる挙動変化。
+        """
+        tsv = 'noteId\tsummary\nn1\t"line one\nline two"\n'
+        reader = _reader_over_zip(tsv)
+        session = MagicMock()
+
+        with patch("birdxplorer_etl.extract_ecs._flush_notes_batch") as flush:
+            _process_note_rows(reader, session, {"n1"})
+
+        pending = flush.call_args_list[-1].args[2]
+        assert list(pending) == ["n1"]
+        assert pending["n1"]["summary"] == "line one\nline two"
+
+    def test_nul_byte_does_not_crash(self) -> None:
+        """csv は NUL を含む行で _csv.Error を投げる。読み取り前に落とす。"""
+        reader = _reader_over_zip("noteId\tsummary\nn1\tbad\x00value\n")
+        session = MagicMock()
+
+        with patch("birdxplorer_etl.extract_ecs._flush_notes_batch") as flush:
+            _process_note_rows(reader, session, {"n1"})
+
+        pending = flush.call_args_list[-1].args[2]
+        assert pending["n1"]["summary"] == "badvalue"
+
+    def test_flushes_every_1000_rows(self) -> None:
+        """バッチ境界を保つ。1回にまとめると結局メモリに全件溜まる。"""
+        rows = "".join(f"n{i}\ts{i}\n" for i in range(2500))
+        reader = _reader_over_zip("noteId\tsummary\n" + rows)
+        session = MagicMock()
+        existing = {f"n{i}" for i in range(2500)}
+
+        with patch("birdxplorer_etl.extract_ecs._flush_notes_batch") as flush:
+            _process_note_rows(reader, session, existing)
+
+        # 1000, 2000 の2回 + 末尾の1回
+        assert flush.call_count == 3
+
+
+class TestProcessNoteStatusRows:
+    def test_accepts_a_one_shot_iterator(self) -> None:
+        reader = _reader_over_zip("noteId\tcurrentStatus\nn1\tHELPFUL\n", member="noteStatusHistory-00000.tsv")
+        session = MagicMock()
+        session.query.return_value.all.return_value = []
+
+        with patch("birdxplorer_etl.extract_ecs._detect_status_changes", return_value=["n1"]):
+            with patch("birdxplorer_etl.extract_ecs._upsert_note_status_batch") as upsert:
+                with patch("birdxplorer_etl.extract_ecs.enqueue_note_status_batch"):
+                    _process_note_status_rows(reader, session, {"n1"})
+
+        assert upsert.call_args.args[1][0]["note_id"] == "n1"
+
+    def test_skips_notes_absent_from_row_notes(self) -> None:
+        reader = _reader_over_zip(
+            "noteId\tcurrentStatus\nn1\tHELPFUL\nother\tHELPFUL\n",
+            member="noteStatusHistory-00000.tsv",
+        )
+        session = MagicMock()
+        session.query.return_value.all.return_value = []
+
+        with patch("birdxplorer_etl.extract_ecs._detect_status_changes", return_value=[]):
+            with patch("birdxplorer_etl.extract_ecs._upsert_note_status_batch") as upsert:
+                with patch("birdxplorer_etl.extract_ecs.enqueue_note_status_batch"):
+                    _process_note_status_rows(reader, session, {"n1"})
+
+        assert [r["note_id"] for r in upsert.call_args.args[1]] == ["n1"]

--- a/etl/tests/test_extract_streaming.py
+++ b/etl/tests/test_extract_streaming.py
@@ -35,7 +35,7 @@ def _reader_over_zip(tsv_text: str, member: str = "notes-00000.tsv") -> csv.Dict
     buf.seek(0)
     zip_file = zipfile.ZipFile(buf)
     tsv_file = zip_file.open(member)
-    text_file = io.TextIOWrapper(tsv_file, encoding="utf-8")
+    text_file = io.TextIOWrapper(tsv_file, encoding="utf-8", newline="")
     reader = csv.DictReader(_iter_lines_without_nul(text_file), delimiter="\t")
     reader.fieldnames = [stringcase.snakecase(field) for field in reader.fieldnames]
     return reader
@@ -56,10 +56,14 @@ class TestProcessNoteRows:
         pending = flush.call_args_list[-1].args[2]
         assert list(pending) == ["n1"]
 
-    def test_a_quoted_newline_stays_one_row(self) -> None:
-        """splitlines() はクォート内の改行でも行を割ってしまう。
+    def test_a_quoted_newline_is_preserved(self) -> None:
+        """クォート内の改行が値として保たれること。
 
-        ストリーミング + csv なら1行として扱われる。取り込み行数が変わる挙動変化。
+        旧実装(splitlines())でも行数は変わらない。splitlines() がクォート内で割った断片を
+        csv.reader が再結合するため。ただし改行そのものは落ちるので値は "line oneline two"
+        になっていた。ストリーミングでは "line one\nline two" のまま保たれる。
+        つまり行数ではなく summary の値が変わる挙動変化であり、次のフル再取り込みで
+        改行を含む summary は全件値が更新される。
         """
         tsv = 'noteId\tsummary\nn1\t"line one\nline two"\n'
         reader = _reader_over_zip(tsv)
@@ -124,3 +128,86 @@ class TestProcessNoteStatusRows:
                     _process_note_status_rows(reader, session, {"n1"})
 
         assert [r["note_id"] for r in upsert.call_args.args[1]] == ["n1"]
+
+
+class TestFlushBoundary:
+    def test_a_duplicate_row_does_not_skip_the_flush_boundary(self) -> None:
+        """重複行で境界を踏み外してバッチが膨らまないこと。
+
+        フラッシュ判定を enumerate の index に依存させると、重複 note_id の
+        `continue` が 1000 の倍数を飛ばし、次の境界まで溜め込み続ける。
+        毎1000行目が重複する入力ではファイル全体がメモリに載る＝潰したはずの OOM 形状。
+        """
+        note_ids = [f"n{i}" for i in range(1999)]
+        lines = [f"{note_id}\ts\n" for note_id in note_ids]
+        lines.insert(999, "n0\ts\n")  # 1000行目を重複させ、境界の判定を踏み外させる
+        reader = _reader_over_zip("noteId\tsummary\n" + "".join(lines))
+        session = MagicMock()
+
+        with patch("birdxplorer_etl.extract_ecs._flush_notes_batch") as flush:
+            _process_note_rows(reader, session, set(note_ids))
+
+        batch_sizes = [len(call.args[1]) + len(call.args[2]) for call in flush.call_args_list]
+        assert max(batch_sizes) <= 1000, f"バッチが 1000 件を超えた: {batch_sizes}"
+        # 境界を直した副作用で行を取りこぼしていないこと（重複1件を除いた全件）
+        assert sum(batch_sizes) == 1999, f"フラッシュされた件数が合わない: {batch_sizes}"
+
+
+class TestProductionReaderWiring:
+    """extract_data から実際の zip を通し、production の配線そのものを検証する。"""
+
+    @patch("birdxplorer_etl.extract_ecs.run_note_requests_phase")
+    @patch("birdxplorer_etl.extract_ecs.backfill_missing_notes")
+    @patch("birdxplorer_etl.extract_ecs.recalculate_rating_counts")
+    @patch("birdxplorer_etl.extract_ecs.extract_ratings")
+    @patch("birdxplorer_etl.extract_ecs._process_note_status_rows")
+    @patch("birdxplorer_etl.extract_ecs._process_note_rows")
+    @patch("birdxplorer_etl.extract_ecs.requests")
+    def test_crlf_inside_a_quoted_field_is_not_rewritten(
+        self,
+        mock_requests: MagicMock,
+        mock_process_note_rows: MagicMock,
+        mock_process_note_status_rows: MagicMock,
+        mock_extract_ratings: MagicMock,
+        mock_recalculate: MagicMock,
+        mock_backfill: MagicMock,
+        mock_note_requests: MagicMock,
+    ) -> None:
+        """TextIOWrapper に newline="" を渡さないと、csv より前に CRLF が LF へ書き換わる。
+
+        行ズレは起きないが、summary の値が黙って変わる。csv のドキュメントが
+        newline="" を要求しているのはこのため。
+        """
+        import settings
+
+        from birdxplorer_etl.extract_ecs import extract_data
+
+        tsv = 'noteId\tsummary\nn1\t"line one\r\nline two"\r\n'
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("notes-00000.tsv", tsv)
+        zip_bytes = buf.getvalue()
+
+        def fake_get(url: str) -> MagicMock:
+            res = MagicMock()
+            if "notes-00000.zip" in url:
+                res.status_code = 200
+                res.content = zip_bytes
+            else:
+                res.status_code = 404
+            return res
+
+        captured: list = []
+        mock_process_note_rows.side_effect = lambda reader, _session, _ids: captured.extend(reader)
+        mock_requests.get.side_effect = fake_get
+
+        original = settings.USE_DUMMY_DATA
+        settings.USE_DUMMY_DATA = False
+        try:
+            mock_session = MagicMock()
+            mock_session.query.return_value.all.return_value = []
+            extract_data(mock_session)
+        finally:
+            settings.USE_DUMMY_DATA = original
+
+        assert [row["summary"] for row in captured] == ["line one\r\nline two"]

--- a/etl/tests/test_realtime_notes_extraction_lambda.py
+++ b/etl/tests/test_realtime_notes_extraction_lambda.py
@@ -19,7 +19,9 @@ from birdxplorer_etl.lib.x.community_notes_client import (
 )
 
 
-def _make_note(note_id: str = "note_001", post_id: str = "post_001", created_at: int | None = 1700000000000) -> CommunityNote:
+def _make_note(
+    note_id: str = "note_001", post_id: str = "post_001", created_at: int | None = 1700000000000
+) -> CommunityNote:
     return CommunityNote(note_id=note_id, summary="test summary", post_id=post_id, created_at=created_at)
 
 


### PR DESCRIPTION
## 背景

2026-09-08 の Extract タスクの OOM(exit 137) は、展開後 1.8GB の notes TSV を
`read().decode("utf-8").splitlines()` で読んでいたことが原因。bytes 1.8GB ＋ str 1.8GB ＋
リスト 2.1GB が同時に載り、**一過性ピークが約 7.5GB** に達して 8GB を超えた。
ratings だけは以前からストリーミングしていたため、1.26GB の TSV でも落ちていなかった。

対症療法として cdk #34 でタスクを 8GB → 16GB に上げてある。本 PR はその恒久対応。

## 変更内容

### 1. notes / noteStatus をストリーミングで読む (a52177b)

`zip_file.open()` のストリームを `TextIOWrapper` でラップして `csv.DictReader` に直接渡し、
消費ループを `_process_note_rows` / `_process_note_status_rows` に切り出して `with` の内側で回す。

`note_requests`(batSignals) は意図的に対象外。zip 36MB で効果が薄い一方、PR #282 の毒行隔離が
生の行文字列を前提にしており、ストリーミング化すると `UnicodeDecodeError` のファイル単位 skip が壊れる。

**ローカル実測（179MB の TSV）: ピーク 804MB → 15MB。**

### 2. notes / noteStatus を `_run_phase` で包む (f523501)

この2フェーズだけ `_run_phase` の外に裸で置かれていた。ストリーミング化で zip の CRC 検証と
UTF-8 デコードが**逐次**になったため、「ファイルの途中で落ちる」が新たに到達可能になる。
裸のままだと、途中失敗がその日の Ratings / Rating recalculation / Status / Backfill /
NoteRequests を全滅させ、しかも `EXTRACT_PHASE_FAILED` トークンが出ないため CloudWatch でも見えない
（#289 で `_run_phase` を入れた動機そのものの失敗クラス）。

`[PHASE_COMPLETE]` のログ文字列は従来と同一なのでメトリクスフィルタは非破壊。

あわせて**前日フォールバックを 404 のときだけに限定**した。`_run_phase` の戻り値で
「404 = まだ公開されていない」と「取得そのものの失敗」を区別する。後者で前日に流れると、
ratings のフルスワップ込みで前日分を丸ごと再処理して1時間規模を浪費し、しかも当日分はその実行では
取り込まれない。ソースは累積スナップショットなので次回の定期実行で追いつく。

### 3. フラッシュ境界を件数ベースに (f523501)

`(index + 1) % 1000 == 0` は重複 `note_id` の `continue` より後ろにあり、1000 の倍数の行が重複だと
その境界を飛ばして次の境界まで溜め込み続ける。毎 1000 行目が重複する入力では**ファイル全体が
メモリに載る**＝この PR が潰そうとしている OOM 形状そのもの。`len(rows_to_add) + len(pending_rows) >= 1000`
に変更（`_process_note_status_rows` は元から正しい形だった）。

### 4. `TextIOWrapper` に `newline=""` (f523501)

csv の要件。無いと universal-newline 変換が csv パーサより**先に** CRLF を LF へ書き換える。
notes / noteStatus / ratings の3箇所に付けた。

**⚠️ 挙動変化**: 行数・行分割は変わらないが、**クォート内に改行を含む `summary` の値が変わる**。
旧実装では `splitlines()` が割った断片を `csv.reader` が再結合する際に改行が落ち、
`"line one\nline two"` が `"line oneline two"` になっていた。新実装では改行が保たれる。
次のフル再取り込みで該当行が更新される。下流は確認済みで安全（`SummaryString` は両端 strip のみ、
CSV export は `QUOTE_MINIMAL`、SQS/OpenSearch は `json.dumps` 経由）。

### 5. テスト接続先の環境変数化 (092d03d)

`common/tests/conftest.py` の host/port が直書きでローカルの検証用 Postgres(5436) に向けられなかった。
CI は該当変数を設定していないので既定値(localhost:5432)のまま。

## テスト

`etl`: **295 passed / 4 skipped**、black・isort・pflake8 クリーン。新規テストはすべて先に RED を確認:

| テスト | RED の内容 |
|---|---|
| `test_a_quoted_newline_is_preserved` | 旧実装だと `"line oneline two"` |
| `test_a_duplicate_row_does_not_skip_the_flush_boundary` | 旧ロジックでバッチが 1999 件に膨張 |
| `test_crlf_inside_a_quoted_field_is_not_rewritten` | `newline=""` を外すと `\r\n` → `\n` |
| `test_notes_failure_does_not_starve_later_phases` | `_run_phase` を外すと例外が貫通 |
| `test_fetch_failure_does_not_fall_back_to_the_previous_day` | 接続失敗で前日に流れる |

リファクタの忠実性は、切り出した2ループを親コミットとインデント正規化して行単位で機械比較し、
**意図した変更以外の差分がゼロ**であることを確認済み（ガード・`break`/`continue` の到達性・
`file_index` の増分・例外の伝播すべて一致）。

## デプロイ後の検証

1. 翌日の日次 Extract が完走(exit 0)すること
2. **常駐量が 2,844 MiB → 数百 MiB に落ちること**
3. それを見てから 16GB → 8GB に戻すか判断する

⚠️ **メモリのピークは Container Insights では測れない。** サンプリングが1分間隔で、OOM は起動
80〜110 秒で起きるため山の頂上が測定の隙間に落ちる。実際 `notes-00002`(469MB) 処理中の観測値は
2,844 MiB のまま29分間平坦だった（これは `splitlines()` 完了後の**常駐量**）。
8GB に戻す判断は常駐量とローカル実測で行い、CloudWatch のピーク値は根拠にしない。

## この PR で直していないもの

- `run_note_requests_phase`(batSignals) は非ストリーミングのまま（上記の理由）
- day ループ直後の裸の `postgresql.commit()`。`_run_phase` 内の rollback も失敗した場合にここが raise して後段を飢餓させ得る（親コミット以前からの既存問題）
- `_run_phase` の戻り値を捨てているため、フェーズが失敗してもタスクは exit 0
- 使い捨てタスク定義でのバックフィルは OOM ルールにもメモリアラームにも掛からない(family が違う)
- `conftest.py` の HOST 上書きは、開発者の `.env` に本物の DB が入っていると common のテスト(テーブル drop/create)がそこへ向く残余リスクがある

🤖 Generated with [Claude Code](https://claude.com/claude-code)